### PR TITLE
fix: store training session times with correct Prague timezone

### DIFF
--- a/app/(main)/komunita/profil/[id]/page.tsx
+++ b/app/(main)/komunita/profil/[id]/page.tsx
@@ -18,10 +18,14 @@ interface PageProps {
   params: Promise<{
     id: string;
   }>;
+  searchParams: Promise<{
+    from?: string;
+  }>;
 }
 
-export default async function ProfilePage({ params }: PageProps) {
+export default async function ProfilePage({ params, searchParams }: PageProps) {
   const { id } = await params;
+  const { from } = await searchParams;
   const supabase = await createClient();
 
   // Fetch viewed profile and current user profile in parallel
@@ -42,9 +46,9 @@ export default async function ProfilePage({ params }: PageProps) {
     <div className="container mx-auto py-6 max-w-4xl space-y-6">
       {/* Back Button */}
       <Button variant="ghost" size="sm" asChild>
-        <Link href="/komunita/lide">
+        <Link href={from ?? '/komunita/lide'}>
           <ArrowLeft className="size-4 mr-2" />
-          Zpět na komunitu
+          Zpět
         </Link>
       </Button>
 

--- a/app/(main)/komunita/tymy/[id]/page.tsx
+++ b/app/(main)/komunita/tymy/[id]/page.tsx
@@ -31,15 +31,17 @@ export default async function TeamPage({ params }: PageProps) {
   // Group profiles by role
   const coaches = team.profiles.filter((p) => p.role === 'coach');
   const teamLeaders = team.profiles.filter((p) => p.role === 'team_leader');
-  const students = team.profiles.filter((p) => p.role === 'student');
+  const students = team.profiles.filter((p) => p.role === 'student' || p.role === 'admin');
+
+  const backHref = `/komunita/tymy/${team.id}`;
 
   return (
     <div className="container mx-auto py-6 space-y-6">
       {/* Back Button */}
       <Button variant="ghost" size="sm" asChild>
-        <Link href="/komunita/lide">
+        <Link href="/komunita/tymy">
           <ArrowLeft className="size-4 mr-2" />
-          Zpět na komunitu
+          Zpět na týmy
         </Link>
       </Button>
 
@@ -76,6 +78,7 @@ export default async function TeamPage({ params }: PageProps) {
                   key={profile.id}
                   profile={{ ...profile, team }}
                   pictureUrl={pictureUrl}
+                  from={backHref}
                 />
               );
             })}
@@ -95,6 +98,7 @@ export default async function TeamPage({ params }: PageProps) {
                   key={profile.id}
                   profile={{ ...profile, team }}
                   pictureUrl={pictureUrl}
+                  from={backHref}
                 />
               );
             })}
@@ -114,6 +118,7 @@ export default async function TeamPage({ params }: PageProps) {
                   key={profile.id}
                   profile={{ ...profile, team }}
                   pictureUrl={pictureUrl}
+                  from={backHref}
                 />
               );
             })}

--- a/app/api/recurring-schedules/[id]/route.ts
+++ b/app/api/recurring-schedules/[id]/route.ts
@@ -2,6 +2,7 @@ import { createClient } from "@/lib/supabase/server";
 import { NextRequest, NextResponse } from "next/server";
 import { addDays, format, parseISO, getDay } from "date-fns";
 import { getCurrentUserProfile } from "@/lib/auth-helpers";
+import { pragueLocalToUtcISO } from "@/lib/reservations/utils";
 
 interface RouteParams {
   params: Promise<{ id: string }>;
@@ -93,8 +94,6 @@ export async function PATCH(request: NextRequest, { params }: RouteParams) {
     while (currentDate <= endDate) {
       if (getDay(currentDate) === finalSchedule.day_of_week) {
         const dateStr = format(currentDate, "yyyy-MM-dd");
-        const startDateTime = `${dateStr}T${finalSchedule.start_time}`;
-        const endDateTime = `${dateStr}T${finalSchedule.end_time}`;
 
         reservationsToCreate.push({
           room_id: finalSchedule.room_id,
@@ -102,8 +101,8 @@ export async function PATCH(request: NextRequest, { params }: RouteParams) {
           recurring_schedule_id: id,
           reservation_type: "training_session",
           title: "Training Session",
-          start_time: startDateTime,
-          end_time: endDateTime,
+          start_time: pragueLocalToUtcISO(dateStr, finalSchedule.start_time),
+          end_time: pragueLocalToUtcISO(dateStr, finalSchedule.end_time),
         });
       }
       currentDate = addDays(currentDate, 1);

--- a/app/api/recurring-schedules/route.ts
+++ b/app/api/recurring-schedules/route.ts
@@ -1,7 +1,8 @@
 import { createClient } from "@/lib/supabase/server";
 import { NextRequest, NextResponse } from "next/server";
-import { addDays, format, getDay, setHours, setMinutes } from "date-fns";
+import { addDays, format, getDay } from "date-fns";
 import { getCurrentUserProfile } from "@/lib/auth-helpers";
+import { pragueLocalToUtcISO } from "@/lib/reservations/utils";
 
 interface CreateScheduleInput {
   room_id: string;
@@ -111,8 +112,6 @@ export async function POST(request: NextRequest) {
     }));
 
     // Generate individual reservations
-    const [startHour, startMin] = start_time.split(":").map(Number);
-    const [endHour, endMin] = end_time.split(":").map(Number);
     const startDate = new Date(valid_from);
     const endDate = new Date(valid_until);
 
@@ -139,8 +138,9 @@ export async function POST(request: NextRequest) {
       );
 
       if (!isInBreak) {
-        const reservationStart = setMinutes(setHours(new Date(currentDate), startHour), startMin);
-        const reservationEnd = setMinutes(setHours(new Date(currentDate), endHour), endMin);
+        const dateStr = format(currentDate, "yyyy-MM-dd");
+        const reservationStart = pragueLocalToUtcISO(dateStr, start_time);
+        const reservationEnd = pragueLocalToUtcISO(dateStr, end_time);
 
         reservations.push({
           room_id,
@@ -148,8 +148,8 @@ export async function POST(request: NextRequest) {
           recurring_schedule_id: schedule.id,
           reservation_type: "training_session",
           title: `TS - ${team.name}`,
-          start_time: reservationStart.toISOString(),
-          end_time: reservationEnd.toISOString(),
+          start_time: reservationStart,
+          end_time: reservationEnd,
         });
       }
 

--- a/app/api/reservations/route.ts
+++ b/app/api/reservations/route.ts
@@ -55,11 +55,11 @@ export async function GET(request: NextRequest) {
     }
 
     if (startDate) {
-      query = query.gte("end_time", startDate);
+      query = query.gt("end_time", startDate);
     }
 
     if (endDate) {
-      query = query.lte("start_time", endDate);
+      query = query.lt("start_time", endDate);
     }
 
     if (userId) {

--- a/components/komunita/user-card.tsx
+++ b/components/komunita/user-card.tsx
@@ -13,11 +13,15 @@ import { cn } from '@/lib/utils';
 interface UserCardProps {
   profile: ProfileWithTeam;
   pictureUrl: string | null;
+  from?: string;
 }
 
-export function UserCard({ profile, pictureUrl }: UserCardProps) {
+export function UserCard({ profile, pictureUrl, from }: UserCardProps) {
+  const href = from
+    ? `/komunita/profil/${profile.id}?from=${encodeURIComponent(from)}`
+    : `/komunita/profil/${profile.id}`;
   return (
-    <Link href={`/komunita/profil/${profile.id}`}>
+    <Link href={href}>
       <Card className="hover:shadow-md transition-shadow cursor-pointer h-full">
         <CardContent className="p-4 space-y-3">
           {/* Avatar and Name */}

--- a/components/reservations/room-filter.tsx
+++ b/components/reservations/room-filter.tsx
@@ -92,8 +92,10 @@ export function RoomFilter({ rooms, onFilterChange, onFilterStateChange }: RoomF
         const annotatedRooms = rooms.map((room) => {
           const isDayAvailable = isRoomAvailableOnDay(room, startDateTime);
           const conflictingReservation = reservations.find(
-            (r: { room_id: string; start_time: string; end_time: string; title: string }) => 
-              r.room_id === room.id
+            (r: { room_id: string; start_time: string; end_time: string; title: string }) =>
+              r.room_id === room.id &&
+              new Date(r.start_time) < endDateTime &&
+              new Date(r.end_time) > startDateTime
           );
 
           // Room is available if it's open on this day AND no conflicts

--- a/lib/reservations/utils.ts
+++ b/lib/reservations/utils.ts
@@ -21,6 +21,75 @@ export function isRoomAvailableOnDay(room: Room, date: Date): boolean {
 
 const PRAGUE_TZ = "Europe/Prague";
 
+/**
+ * Convert a date string (YYYY-MM-DD) and time string (HH:MM or HH:MM:SS)
+ * from Europe/Prague local time to a UTC ISO string.
+ *
+ * This is needed because training session times are user-entered in Prague
+ * time, but reservations.start_time / end_time are TIMESTAMPTZ columns stored
+ * as UTC in the database.
+ */
+export function pragueLocalToUtcISO(dateStr: string, timeStr: string): string {
+  // Normalise time to HH:MM:SS
+  const timePart = timeStr.length === 5 ? `${timeStr}:00` : timeStr;
+
+  // Build an ISO-8601 string that Intl can resolve in the Prague zone.
+  // We do this by asking the runtime what UTC instant corresponds to
+  // "YYYY-MM-DDTHH:MM:SS" in Europe/Prague.
+  const naiveISO = `${dateStr}T${timePart}`;
+
+  // Use Intl to get the Prague-zone offset at this instant.
+  // Strategy: create a Date from the naive string (JS treats it as LOCAL
+  // time of the runtime, which may be UTC on the server), then correct
+  // for the difference between Prague offset and the runtime offset.
+  const runtimeDate = new Date(naiveISO);
+
+  // Get the UTC offset for Prague at this instant (in minutes, e.g. +60 or +120)
+  const pragueOffsetMin = getPragueOffsetMinutes(runtimeDate);
+  // Get the runtime (server) UTC offset in minutes (0 on production servers)
+  const runtimeOffsetMin = -runtimeDate.getTimezoneOffset();
+
+  // Adjust: if runtime parsed it as UTC (offset 0) but Prague is +60,
+  // we need to subtract 60 minutes from the UTC time.
+  const correctedDate = new Date(
+    runtimeDate.getTime() - (pragueOffsetMin - runtimeOffsetMin) * 60_000
+  );
+
+  return correctedDate.toISOString();
+}
+
+/**
+ * Get the current UTC offset of Europe/Prague for a given instant, in minutes.
+ * Returns e.g. 60 for CET (+01:00) or 120 for CEST (+02:00).
+ */
+function getPragueOffsetMinutes(date: Date): number {
+  // Format the date twice: once in UTC, once in Prague. The difference is the offset.
+  const utcStr = new Intl.DateTimeFormat("en-CA", {
+    timeZone: "UTC",
+    year: "numeric",
+    month: "2-digit",
+    day: "2-digit",
+    hour: "2-digit",
+    minute: "2-digit",
+    hour12: false,
+  }).format(date);
+
+  const pragueStr = new Intl.DateTimeFormat("en-CA", {
+    timeZone: PRAGUE_TZ,
+    year: "numeric",
+    month: "2-digit",
+    day: "2-digit",
+    hour: "2-digit",
+    minute: "2-digit",
+    hour12: false,
+  }).format(date);
+
+  const utcMs = new Date(utcStr.replace(", ", "T")).getTime();
+  const pragueMs = new Date(pragueStr.replace(", ", "T")).getTime();
+
+  return (pragueMs - utcMs) / 60_000;
+}
+
 function getPragueHourAndMinute(date: Date): { hour: number; minute: number } {
   const parts = new Intl.DateTimeFormat("cs-CZ", {
     timeZone: PRAGUE_TZ,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved timezone conversion for recurring training schedules so Prague-local times are accurately stored as UTC.

* **New Features**
  * Profile pages now accept an optional return path so "Back" can return the user to where they came from.
  * User cards can include and propagate that return path to profile links.

* **UI**
  * Back button labels simplified to "Zpět" and team pages now link back to the teams list.
* **Behavior**
  * Team member lists now include admins alongside students.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->