### PR TITLE
pridan support pro rektorat.czu.cz

### DIFF
--- a/components/verify-email-form.tsx
+++ b/components/verify-email-form.tsx
@@ -33,7 +33,7 @@ import { isValidWorkEmailDomain, OTP_LENGTH, DEFAULT_LOGGED_IN_PAGE } from "@/li
 import { hasLinkedProfile } from "@/lib/auth-helpers";
 
 const STORAGE_KEY = "verify-email-form-state";
-const EMAIL_DOMAIN_OPTIONS = ["@studenti.czu.cz", "@pef.czu.cz"] as const;
+const EMAIL_DOMAIN_OPTIONS = ["@studenti.czu.cz", "@pef.czu.cz", "@rektorat.czu.cz"] as const;
 const DEFAULT_EMAIL_DOMAIN = EMAIL_DOMAIN_OPTIONS[0];
 const DEV_MAILPIT_URL = "http://127.0.0.1:54324";
 const OTP_INPUT_SLOTS = Array.from({ length: OTP_LENGTH }, (_, index) => index);

--- a/lib/constants/auth.ts
+++ b/lib/constants/auth.ts
@@ -4,6 +4,7 @@
 export const ALLOWED_WORK_EMAIL_DOMAINS: readonly string[] = [
   'studenti.czu.cz',
   'pef.czu.cz',
+  'rektorat.czu.cz',
 ] as const;
 
 /**
@@ -39,7 +40,7 @@ export const isPublicRoute = (pathname: string): boolean => {
 /**
  * Validates that an email address ends with an allowed CZU domain
  * @param email - The email address to validate
- * @returns True if the email ends with @studenti.czu.cz or @pef.czu.cz, false otherwise
+ * @returns True if the email ends with an allowed CZU domain, false otherwise
  */
 export const isValidWorkEmailDomain = (email: string): boolean => {
   if (!email || !email.includes('@')) {

--- a/progress.md
+++ b/progress.md
@@ -1,6 +1,24 @@
 # Progress
 
 - **Status:** COMPLETED
+- **Timestamp:** 2026-06-21 22:24:00 EET
+- **Task:** Update backend auth email trigger functions and domain checks for `@rektorat.czu.cz`.
+- **Completed work:**
+  - Added migration `supabase/migrations/20260621202500_add_rektorat_domain_to_auth_triggers.sql`.
+  - Updated `public.validate_czu_email_domain_trigger()` to allow `rektorat.czu.cz`, validate old/new direct email changes, and keep `public.profiles.work_email` in sync for linked profiles.
+  - Updated `public.set_verified_work_email_on_change()` to include `rektorat.czu.cz` in verified email updates and backfill query.
+  - Updated `public.profiles` domain check constraint `valid_czu_domain` to include `rektorat.czu.cz`.
+  - Applied migration via Supabase MCP (`apply_migration`) to keep file and database state aligned.
+
+- **Status:** COMPLETED
+- **Timestamp:** 2026-06-21 21:59:00 EET
+- **Task:** Add frontend support for `@rektorat.czu.cz` in work email verification.
+- **Completed work:**
+  - Added `rektorat.czu.cz` to `ALLOWED_WORK_EMAIL_DOMAINS` in `lib/constants/auth.ts`, so frontend domain validation accepts it.
+  - Added `@rektorat.czu.cz` to the domain dropdown options in `components/verify-email-form.tsx`.
+  - Verified no lint errors in touched files.
+
+- **Status:** COMPLETED
 - **Timestamp:** 2026-02-25 19:01:22 EET
 - **Task:** Enable `Cmd + Enter` submit in reservation dialogs when focus is inside text fields.
 - **Completed work:**

--- a/supabase/migrations/20260621202500_add_rektorat_domain_to_auth_triggers.sql
+++ b/supabase/migrations/20260621202500_add_rektorat_domain_to_auth_triggers.sql
@@ -1,0 +1,168 @@
+-- Migration: Add rektorat domain to auth email validation and verification
+-- Purpose: Extend auth email validation, profile sync, and verified email updates to support @rektorat.czu.cz
+-- Affected tables: public.profiles, public.users, auth.users
+-- Special considerations: Replaces trigger functions already attached to auth.users
+
+-- ============================================================================
+-- CONSTRAINTS
+-- ============================================================================
+
+-- Expand the profile work email domain check to include rektorat.czu.cz
+alter table public.profiles
+drop constraint if exists valid_czu_domain;
+
+alter table public.profiles
+add constraint valid_czu_domain check (
+  lower(split_part(work_email, '@', 2)) in ('pef.czu.cz', 'studenti.czu.cz', 'rektorat.czu.cz')
+);
+
+-- ============================================================================
+-- FUNCTIONS
+-- ============================================================================
+
+-- Validate auth email updates, keep linked profile email in sync, and enforce approved domains.
+create or replace function public.validate_czu_email_domain_trigger()
+returns trigger
+language plpgsql
+security definer
+set search_path = ''
+as $$
+declare
+  v_email text;
+  v_email_change text;
+  v_domain text;
+  v_user_id uuid;
+  v_has_linked_profile boolean;
+begin
+  if tg_op != 'UPDATE' then
+    return new;
+  end if;
+
+  -- Find the public.users row linked to this auth.users row.
+  select public.users.id
+  into v_user_id
+  from public.users
+  where public.users.auth_user_id = new.id;
+
+  -- If the user has a linked profile, sync profile work_email on direct email changes.
+  if v_user_id is not null then
+    select exists (
+      select 1
+      from public.profiles
+      where public.profiles.user_id = v_user_id
+    )
+    into v_has_linked_profile;
+
+    if v_has_linked_profile and old.email is distinct from new.email then
+      if old.email is not null then
+        if lower(split_part(old.email, '@', 2)) not in ('pef.czu.cz', 'studenti.czu.cz', 'rektorat.czu.cz') then
+          raise exception 'Current email must belong to an approved domain';
+        end if;
+      end if;
+
+      if new.email is not null then
+        if lower(split_part(new.email, '@', 2)) not in ('pef.czu.cz', 'studenti.czu.cz', 'rektorat.czu.cz') then
+          raise exception 'New email must belong to an approved domain';
+        end if;
+      end if;
+
+      update public.profiles
+      set work_email = new.email
+      where public.profiles.user_id = v_user_id;
+    end if;
+  end if;
+
+  -- Validate pending email_change value.
+  if old.email_change is distinct from new.email_change then
+    v_email_change := new.email_change;
+
+    if v_email_change is not null and v_email_change != '' then
+      v_domain := lower(split_part(v_email_change, '@', 2));
+
+      if v_domain not in ('pef.czu.cz', 'studenti.czu.cz', 'rektorat.czu.cz') then
+        raise exception 'Email must end with @pef.czu.cz, @rektorat.czu.cz or @studenti.czu.cz. Provided domain: %', v_domain;
+      end if;
+    end if;
+  end if;
+
+  -- Validate current auth.users.email value.
+  if old.email is distinct from new.email then
+    v_email := new.email;
+
+    if v_email is not null and v_email != '' then
+      v_domain := lower(split_part(v_email, '@', 2));
+
+      if v_domain not in ('pef.czu.cz', 'studenti.czu.cz', 'rektorat.czu.cz') then
+        raise exception 'Email must end with @pef.czu.cz, @rektorat.czu.cz or @studenti.czu.cz. Provided domain: %', v_domain;
+      end if;
+    end if;
+  end if;
+
+  return new;
+end;
+$$;
+
+comment on function public.validate_czu_email_domain_trigger() is 'Validates auth.users email domains, syncs linked profile work_email on direct email updates, and enforces allowed CZU domains (@pef.czu.cz, @studenti.czu.cz, @rektorat.czu.cz).';
+
+-- Set verified_work_email after successful email verification for allowed CZU domains.
+create or replace function public.set_verified_work_email_on_change()
+returns trigger
+language plpgsql
+security definer
+set search_path = ''
+as $$
+declare
+  v_user_id uuid;
+  v_email text;
+  v_domain text;
+begin
+  -- Determine which email should be treated as verified after this update.
+  if old.email is distinct from new.email then
+    v_email := new.email;
+  elsif old.email_change is distinct from new.email_change and (new.email_change is null or new.email_change = '') then
+    v_email := new.email;
+  else
+    return new;
+  end if;
+
+  if v_email is null or v_email = '' then
+    return new;
+  end if;
+
+  v_domain := lower(split_part(v_email, '@', 2));
+
+  if v_domain not in ('pef.czu.cz', 'studenti.czu.cz', 'rektorat.czu.cz') then
+    return new;
+  end if;
+
+  select public.users.id
+  into v_user_id
+  from public.users
+  where public.users.auth_user_id = new.id;
+
+  if v_user_id is null then
+    return new;
+  end if;
+
+  update public.users
+  set verified_work_email = v_email,
+      verified_work_email_at = now()
+  where public.users.id = v_user_id
+    and (public.users.verified_work_email is null or public.users.verified_work_email != v_email);
+
+  return new;
+end;
+$$;
+
+comment on function public.set_verified_work_email_on_change() is 'Sets public.users.verified_work_email after successful auth email verification for allowed CZU domains (@pef.czu.cz, @studenti.czu.cz, @rektorat.czu.cz).';
+
+-- Backfill verified_work_email for existing users with allowed domains.
+update public.users as u
+set verified_work_email = au.email,
+    verified_work_email_at = au.updated_at
+from auth.users as au
+where u.auth_user_id = au.id
+  and au.email is not null
+  and au.email != ''
+  and lower(split_part(au.email, '@', 2)) in ('pef.czu.cz', 'studenti.czu.cz', 'rektorat.czu.cz')
+  and (u.verified_work_email is null or u.verified_work_email != au.email);

--- a/supabase/migrations/20260621202500_add_rektorat_domain_to_auth_triggers.sql
+++ b/supabase/migrations/20260621202500_add_rektorat_domain_to_auth_triggers.sql
@@ -54,12 +54,6 @@ begin
     into v_has_linked_profile;
 
     if v_has_linked_profile and old.email is distinct from new.email then
-      if old.email is not null then
-        if lower(split_part(old.email, '@', 2)) not in ('pef.czu.cz', 'studenti.czu.cz', 'rektorat.czu.cz') then
-          raise exception 'Current email must belong to an approved domain';
-        end if;
-      end if;
-
       if new.email is not null then
         if lower(split_part(new.email, '@', 2)) not in ('pef.czu.cz', 'studenti.czu.cz', 'rektorat.czu.cz') then
           raise exception 'New email must belong to an approved domain';


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for the `@rektorat.czu.cz` email domain in work email verification. Users can now select this domain from the dropdown when verifying their work email address. The system recognizes and validates this domain as an approved organizational email address alongside other existing approved domains.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->