### PR TITLE
fix: no mobile autofocus on search, stop profile cards overflowing vi…

### DIFF
--- a/src/app/(main)/komunita/profil/[id]/page.tsx
+++ b/src/app/(main)/komunita/profil/[id]/page.tsx
@@ -181,11 +181,11 @@ export default async function ProfilePage({ params, searchParams }: PageProps) {
                         )}
                       </Link>
                       <div className="flex-1 min-w-0 space-y-1">
-                        <Link href={`/eseje/${essay.id}`}>
-                          <p className="font-semibold text-sm leading-snug line-clamp-1 group-hover:text-primary transition-colors inline-flex items-center gap-1.5">
-                            {essay.pinned_at && <Pin className="size-3 shrink-0 text-primary fill-primary" />}
+                        <Link href={`/eseje/${essay.id}`} className="flex min-w-0 items-center gap-1.5">
+                          {essay.pinned_at && <Pin className="size-3 shrink-0 text-primary fill-primary" />}
+                          <span className="font-semibold text-sm leading-snug truncate group-hover:text-primary transition-colors">
                             {essay.title}
-                          </p>
+                          </span>
                         </Link>
                         <p className="text-xs text-muted-foreground truncate">
                           {essay.book!.title_cs}
@@ -226,11 +226,11 @@ export default async function ProfilePage({ params, searchParams }: PageProps) {
                           <Sparkles className="size-4 text-amber-500/40" />
                         </Link>
                         <div className="flex-1 min-w-0 space-y-1">
-                          <Link href={`/eseje/${essay.id}`}>
-                            <p className="font-semibold text-sm leading-snug line-clamp-1 group-hover:text-amber-700 dark:group-hover:text-amber-300 transition-colors inline-flex items-center gap-1.5">
-                              {essay.pinned_at && <Pin className="size-3 shrink-0 text-primary fill-primary" />}
+                          <Link href={`/eseje/${essay.id}`} className="flex min-w-0 items-center gap-1.5">
+                            {essay.pinned_at && <Pin className="size-3 shrink-0 text-primary fill-primary" />}
+                            <span className="font-semibold text-sm leading-snug truncate group-hover:text-amber-700 dark:group-hover:text-amber-300 transition-colors">
                               {essay.title}
-                            </p>
+                            </span>
                           </Link>
                           <p className="text-xs text-amber-600/70 dark:text-amber-400/70 flex items-center gap-1">
                             <Sparkles className="size-3" />

--- a/src/components/search/search-page-client.tsx
+++ b/src/components/search/search-page-client.tsx
@@ -27,6 +27,7 @@ interface SearchPageClientProps {
 }
 
 const CATEGORIES = Object.entries(BOOK_CATEGORY_LABELS);
+const FINE_POINTER_QUERY = '(pointer: fine)';
 
 export function SearchPageClient({ popularEssays, categoryBestBooks, teamsWithMembers }: SearchPageClientProps) {
   const [query, setQuery] = useState('');
@@ -36,6 +37,13 @@ export function SearchPageClient({ popularEssays, categoryBestBooks, teamsWithMe
   const [categoryBooks, setCategoryBooks] = useState<(BookWithProfiles & { essay_count?: number })[]>([]);
   const [categoryLoading, setCategoryLoading] = useState(false);
   const timer = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  // Focus the search box on pointer devices only — on touch it would pop up the
+  // on-screen keyboard and cover the page the moment it opens.
+  useEffect(() => {
+    if (window.matchMedia(FINE_POINTER_QUERY).matches) inputRef.current?.focus();
+  }, []);
 
   useEffect(() => {
     if (!query.trim()) { setResults(null); return; }
@@ -75,11 +83,11 @@ export function SearchPageClient({ popularEssays, categoryBestBooks, teamsWithMe
       <div className="relative">
         <Search className="absolute left-4 top-1/2 -translate-y-1/2 size-5 text-muted-foreground pointer-events-none" />
         <Input
+          ref={inputRef}
           value={query}
           onChange={(e) => setQuery(e.target.value)}
           placeholder="Hledat eseje, knihy, témata…"
           className="h-12 pl-12 text-base rounded-xl shadow-sm"
-          autoFocus
         />
         {loading && (
           <div className="absolute right-4 top-1/2 -translate-y-1/2 size-4 animate-spin rounded-full border-2 border-primary border-t-transparent" />

--- a/src/components/ui/sidebar.tsx
+++ b/src/components/ui/sidebar.tsx
@@ -309,7 +309,10 @@ function SidebarInset({ className, ...props }: React.ComponentProps<"main">) {
     <main
       data-slot="sidebar-inset"
       className={cn(
-        "bg-background relative flex w-full flex-1 flex-col",
+        // min-w-0: without it the inset's automatic min-width is its content's
+        // min-content size, so a wide child pushes the whole page wider than the
+        // viewport instead of being constrained by it.
+        "bg-background relative flex w-full min-w-0 flex-1 flex-col",
         "md:peer-data-[variant=inset]:m-2 md:peer-data-[variant=inset]:ml-0 md:peer-data-[variant=inset]:rounded-xl md:peer-data-[variant=inset]:shadow-sm md:peer-data-[variant=inset]:peer-data-[state=collapsed]:ml-2",
         className
       )}


### PR DESCRIPTION
…ewport

- /hledat: replace bare autoFocus with a (pointer: fine) gated focus so touch devices don't get the on-screen keyboard on page load
- profile essay cards: the title had both line-clamp-1 and inline-flex on the same element, so the conflicting display values meant it never truncated and spilled out of the card. Link is now the flex min-w-0 container, pin is a shrink-0 sibling, title is a truncate span
- SidebarInset: add min-w-0 so a wide child can't push the inset past the viewport via its content-based automatic minimum