### PR TITLE
Osobnostní testy (issue #59)

### DIFF
--- a/db/schema/personality-tests.ts
+++ b/db/schema/personality-tests.ts
@@ -46,7 +46,7 @@ export const personalityTests = pgTable("personality_tests", {
     name: "personality_tests_updated_by_profile_id_fkey"
   }).onDelete("restrict"),
   check("personality_tests_other_type_required", sql`(test_type <> 'other' OR (test_type_other IS NOT NULL AND length(trim(test_type_other)) > 0))`),
-  pgPolicy("Verified users can view personality tests", { as: "permissive", for: "select", to: ["authenticated"], using: sql`(removed_at IS NULL) AND (EXISTS (SELECT 1 FROM users WHERE (users.auth_user_id = (SELECT auth.uid()) AND users.verified_work_email IS NOT NULL)))` }),
+  pgPolicy("Verified users can view personality tests", { as: "permissive", for: "select", to: ["authenticated"], using: sql`(EXISTS (SELECT 1 FROM users WHERE (users.auth_user_id = (SELECT auth.uid()) AND users.verified_work_email IS NOT NULL)))` }),
   pgPolicy("Users can create their own personality tests", { as: "permissive", for: "insert", to: ["authenticated"], withCheck: sql`(profile_id = current_profile_id())` }),
   pgPolicy("Users can update their own personality tests", { as: "permissive", for: "update", to: ["authenticated"], using: sql`(profile_id = current_profile_id())`, withCheck: sql`(profile_id = current_profile_id())` }),
   pgPolicy("Users can delete their own personality tests", { as: "permissive", for: "delete", to: ["authenticated"], using: sql`(profile_id = current_profile_id())` }),

--- a/db/schema/personality-tests.ts
+++ b/db/schema/personality-tests.ts
@@ -1,0 +1,53 @@
+// Schema source of truth (drizzle-kit only; NOT imported at runtime — app uses supabase-js).
+// Please look at CONTRIBUTING.md for more information on how to change the schema.
+import { pgTable, foreignKey, pgPolicy, uuid, text, timestamp, date, integer, index, check, pgEnum } from "drizzle-orm/pg-core"
+import { sql } from "drizzle-orm"
+import { profiles } from "./profiles"
+
+export const personalityTestType = pgEnum("personality_test_type", [
+  "gallup",
+  "mbti",
+  "disc",
+  "big_five",
+  "enneagram",
+  "belbin",
+  "other",
+])
+
+export const personalityTests = pgTable("personality_tests", {
+  id: uuid().defaultRandom().primaryKey().notNull(),
+  profileId: uuid("profile_id").notNull(),
+  testType: personalityTestType("test_type").notNull(),
+  testTypeOther: text("test_type_other"),
+  testedOn: date("tested_on").notNull(),
+  filePath: text("file_path").notNull(),
+  fileName: text("file_name").notNull(),
+  fileSize: integer("file_size").notNull(),
+  removedAt: timestamp("removed_at", { withTimezone: true, mode: 'string' }),
+  createdAt: timestamp("created_at", { withTimezone: true, mode: 'string' }).defaultNow().notNull(),
+  updatedAt: timestamp("updated_at", { withTimezone: true, mode: 'string' }).defaultNow().notNull(),
+  createdByProfileId: uuid("created_by_profile_id").notNull(),
+  updatedByProfileId: uuid("updated_by_profile_id").notNull(),
+}, (table) => [
+  index("personality_tests_profile_tested_on_idx").using("btree", table.profileId.asc().nullsLast().op("uuid_ops"), table.testedOn.asc().nullsLast().op("date_ops")),
+  foreignKey({
+    columns: [table.profileId],
+    foreignColumns: [profiles.id],
+    name: "personality_tests_profile_id_fkey"
+  }).onDelete("cascade"),
+  foreignKey({
+    columns: [table.createdByProfileId],
+    foreignColumns: [profiles.id],
+    name: "personality_tests_created_by_profile_id_fkey"
+  }).onDelete("restrict"),
+  foreignKey({
+    columns: [table.updatedByProfileId],
+    foreignColumns: [profiles.id],
+    name: "personality_tests_updated_by_profile_id_fkey"
+  }).onDelete("restrict"),
+  check("personality_tests_other_type_required", sql`(test_type <> 'other' OR (test_type_other IS NOT NULL AND length(trim(test_type_other)) > 0))`),
+  pgPolicy("Verified users can view personality tests", { as: "permissive", for: "select", to: ["authenticated"], using: sql`(removed_at IS NULL) AND (EXISTS (SELECT 1 FROM users WHERE (users.auth_user_id = (SELECT auth.uid()) AND users.verified_work_email IS NOT NULL)))` }),
+  pgPolicy("Users can create their own personality tests", { as: "permissive", for: "insert", to: ["authenticated"], withCheck: sql`(profile_id = current_profile_id())` }),
+  pgPolicy("Users can update their own personality tests", { as: "permissive", for: "update", to: ["authenticated"], using: sql`(profile_id = current_profile_id())`, withCheck: sql`(profile_id = current_profile_id())` }),
+  pgPolicy("Users can delete their own personality tests", { as: "permissive", for: "delete", to: ["authenticated"], using: sql`(profile_id = current_profile_id())` }),
+]).enableRLS()

--- a/docs/plans/2026-07-01-navigation-architecture.md
+++ b/docs/plans/2026-07-01-navigation-architecture.md
@@ -55,6 +55,7 @@ Místnosti                 (unchanged)
 
 **Not in the sidebar — profile-page cards (individual):**
 Osobnostní test (T11), Learning Contract (T08), Skill Profile (T06, may also need a team-comparison tab), Birth Giving (T10), Rocket Model personal half (T07).
+> **Override (18. 8. 2026, issue #59):** Osobnostní test (T11) gets a **sidebar shortcut** after all — a beta-gated „Osobnostní testy" item in the Hlavní section linking to the user's own profile tests tab (`/komunita/profil/{id}?tab=osobnostni-testy`). The feature itself still lives on the profile page.
 
 **Not in the sidebar — team-page cards:**
 Team Contract & Leading Thoughts (I03), Finanční směrnice (I11), Týmové role (I04), Semestrální reflexe (I07, confirm cadence), Rocket Model team half (I09), Crossfertilizace (T05, confirm cadence — could be a repeated log instead if sessions are frequent).

--- a/docs/plans/2026-08-18-osobnostni-testy-design.md
+++ b/docs/plans/2026-08-18-osobnostni-testy-design.md
@@ -16,7 +16,8 @@ sledují svůj vývoj. Aplikace umožní:
    nahoře, vzor feedů a týmového deníku).
 3. Zobrazit testy **na profilu osoby v komunitě** — profil dostane taby
    `Přehled / Eseje / Osobnostní testy` a soubory si může otevřít každý ověřený
-   uživatel.
+   uživatel. Zkratka v **sidebaru** (beta-gate, „Hlavní" sekce) vede na vlastní
+   profil s `?tab=osobnostni-testy`.
 4. **Upravit a smazat** vlastní záznamy (soft-delete + smazání souboru).
 
 **Mimo rozsah** (vědomě, proti textu issue): pole `Výsledek`, `Reflexe`,

--- a/docs/plans/2026-08-18-osobnostni-testy-design.md
+++ b/docs/plans/2026-08-18-osobnostni-testy-design.md
@@ -1,0 +1,143 @@
+# Osobnostní testy — Design
+
+> Issue #59 (popis issue je většinou nepřesný — skutečný rozsah níže).
+> Konzultováno s Ondřejem (brainstorming 18. 8. 2026).
+
+## Co se staví (validovaný rozsah)
+
+Studenti (téčka) si v průběhu studia dělají osobnostní testy (Gallup, MBTI, DISC,
+Big Five, Enneagram, Belbin…), typicky na začátku studia a pak při opakování
+sledují svůj vývoj. Aplikace umožní:
+
+1. **Nahrát soubor** s výsledky testu (PDF nebo obrázek) + vybrat **typ testu**
+   a zadat **datum vyplnění**.
+2. Zobrazit **timeline** vlastních testů — **vertikální časová osa**
+   (svislá linka s tečkami, řazeno sestupně podle data vyplnění — nejnovější
+   nahoře, vzor feedů a týmového deníku).
+3. Zobrazit testy **na profilu osoby v komunitě** — profil dostane taby
+   `Přehled / Eseje / Osobnostní testy` a soubory si může otevřít každý ověřený
+   uživatel.
+4. **Upravit a smazat** vlastní záznamy (soft-delete + smazání souboru).
+
+**Mimo rozsah** (vědomě, proti textu issue): pole `Výsledek`, `Reflexe`,
+`Aplikace v praxi`, porovnání s týmem, tipy na spolupráci, odkazy na externí
+testy. Výsledek je prostě ten nahraný soubor.
+
+**Info karta** (text od Ondřeje, zobrazí se v tabu Osobnostní testy):
+
+> Osobnostní test slouží k hodnocení a pochopení charakterových rysů, chování
+> a preferencí téček. Pomáhá identifikovat silné a slabé stránky, motivace,
+> a způsob interakce s okolím.
+>
+> Osobnostní test si každé téčko dělá v 1. semestru. Následně ho zkonzultuje
+> s některým z koučů. Slouží jako podklad pro Learning contract.
+
+## Rozhodnutí
+
+| Otázka | Rozhodnutí |
+|---|---|
+| Viditelnost | Všichni ověření uživatelé (jako eseje) |
+| Datum v timeline | Datum **vyplnění testu** (uživatelem zadané); datum nahrání jen technicky (created_at) |
+| Typy testů | Enum `personality_test_type` (gallup, mbti, disc, big_five, enneagram, belbin, other) + vlastní text, když `other` |
+| Formáty | PDF + PNG/JPEG/WebP, max **20 MB** |
+| Struktura profilu | Taby: `Přehled / Eseje / Osobnostní testy` (vzor týmové stránky) |
+| Operace | Přidat, upravit (i výměna souboru), smazat (soft-delete + smazání objektu) |
+| Otevření souboru | Serverová route → redirect na podepsanou URL (1 h), nové okno |
+
+## Data a úložiště
+
+Tabulka `personality_tests` (Drizzle, `db/schema/personality-tests.ts`):
+`id`, `profile_id` (FK→profiles, cascade), `test_type` (enum), `test_type_other`
+(text, check: povinné při `other`), `tested_on` (date), `file_path` (text),
+`file_name` (text), `file_size` (int), `removed_at` (soft-delete),
+`created_at`/`updated_at`, audit FK `created_by`/`updated_by_profile_id`.
+Index `(profile_id, tested_on)`.
+
+RLS (helper `current_profile_id()`):
+- select: `removed_at IS NULL` + ověřený uživatel (stejná podmínka jako
+  `profiles`: `users.verified_work_email IS NOT NULL`)
+- insert/update/delete: jen vlastník (`profile_id = current_profile_id()`)
+
+Úložiště: existující private bucket **`documents`** (migrace
+`20260709120000_add_avatars_documents_buckets.sql` ho připravila přesně pro
+tento účel). Klíč `personality-tests/{profileId}/{timestamp}-{uuid}.{ext}`.
+Writes: presigned URL (service role, vzor avatarů). Reads: `getSignedStorageUrl`
+(1 h). Žádné storage RLS — veškerý přístup je serverem zprostředkovaný.
+
+`updated_at` trigger — custom migrace (vzor `team_activities`).
+
+## API
+
+- `POST /api/storage/presign-upload` — **rozšířit** o kontext
+  `personality-test` (vlastní profil + validace PDF/obrázek, 20 MB)
+- `POST /api/personality-tests` — vytvoření záznamu (validace, RLS insert)
+- `PATCH /api/personality-tests/[id]` — úprava typ/datum; při `newKey` i výměna
+  souboru (starý objekt se smaže)
+- `DELETE /api/personality-tests/[id]` — soft-delete + smazání objektu
+- `GET /api/personality-tests/[id]/open` — podepsaná URL → 307 redirect
+
+## UI
+
+- Profilová stránka `/komunita/profil/[id]` přejde na taby (shadcn `Tabs`,
+  server component obaluje sekce — vzor `/komunita/tymy/[id]`); podpora
+  `?tab=` z URL. Počty v tabech přes `TabsTriggerCount`.
+- Tab „Osobnostní testy": `InfoCard` + (vlastní profil) tlačítko „Nahrát test"
+  + **vertikální timeline**: svislá linka (`bg-border`, 1 px) vedoucí mezi
+  záznamy, každý záznam má na lince **tečku** (`size-3`, `bg-primary`,
+  `ring-4 ring-background`, aby linka pod tečkou „neprocházela") a kartu
+  s obsahem: typ testu, datum vyplnění, název souboru, velikost, akce
+  (Otevřít / Upravit / Smazat). Linka je nakreslena po segmentech mezi
+  tečkami (spojnice `top-5 bottom-[-32px]` u každého záznamu kromě
+  posledního), takže nezasahuje nad první ani pod poslední tečku.
+  `aria-hidden` na dekoračních prvcích, sémantické `ol`/`li`.
+- Form dialog: Select typu („Jiný test" → podmíněné textové pole), datum
+  (input type=date, default dnes), soubor (accept + hláška o limitech).
+- Smazání přes `ResponsiveAlertDialog`; prázdné stavy přes `Empty` (vlastní vs.
+  cizí profil), sonner toasty, loading stavy.
+
+## UX analýza (zákony UX aplikované na návrh)
+
+- **Hick's / Choice Overload**: 7 typů v jednom Selectu (v mezích Miller's 5–9);
+  „Jiný test" se odhalí až při výběru (progressive disclosure).
+- **Postel's Law**: datum default = dnes; shovívavá validace s českými hláškami.
+- **Jakob's Law / konzistence**: všechny vzory už v aplikaci existují (InfoCard,
+  taby s počty, AlertDialog, Empty, toasty). Timeline vizuálně navazuje na
+  zavedenou estetiku (karty, semantic tokens), jen layout je časová osa.
+- **Recognition over recall**: na kartě se ukazuje čitelný štítek typu
+  („MBTI") a název souboru — nikdy raw klíč úložiště.
+- **Fitts's Law**: akce na kartě = tlačítka s ikonou + textem na desktopu,
+  `sr-only` label na mobilu (vzor karty týmového deníku).
+- **Doherty Threshold**: loading na submit tlačítku, success/error toast,
+  seznam se aktualizuje z odpovědi API (žádná optimistická UI u nahrávání).
+- **Serial Position / Goal-gradient**: řazení sestupně (novější nahoře,
+  vzor deníku); počet v tabu dává přehled o pokroku; tečka na ose dělá
+  z každého záznamu vizuální „milník".
+- **Von Restorff**: jediné primární CTA „Nahrát test".
+- **A11y timeline**: dekorace (linka, tečky) `aria-hidden`, sémantické
+  `ol`/`li`, obsah vždy v textové formě karty.
+- **Stavy**: prázdný stav rozlišený pro vlastní/cizí profil; chybové stavy
+  formuláře inline; `focus-ring`, obě témata.
+
+## Testování
+
+- **Unit**: `format.ts` (datum, měsíční klíč, velikost souboru) + štítky typů.
+- **Integrace** (`tests/integration/personality-tests.int.test.ts`): RLS —
+  vlastník insert + ověřený select, neověřený nevidí, cizí insert/update/delete
+  zamítnut, soft-delete, check `other` bez textu, cascade při smazání profilu.
+- **E2E** (`tests/e2e/osobnostni-testy.spec.ts`): upload (MBTI) → karta v
+  timeline; edit; delete → prázdný stav; druhý uživatel vidí test a otevře
+  soubor (popup → `/storage/v1/object/sign/`).
+
+## Sekvence implementace
+
+1. Schema + migrace + typy (uživatel spustí `pnpm db:migrate`)
+2. Storage plumbing (kontext, validace, presign)
+3. Lib (types, queries, format + unit testy)
+4. API routes
+5. InfoCard
+6. Form dialog
+7. List/timeline
+8. Profilové taby
+9. Integrační test RLS
+10. E2E
+11. Finální verifikace (`pnpm test`, typecheck, lint, db:doctor)

--- a/docs/plans/2026-08-18-osobnostni-testy-design.md
+++ b/docs/plans/2026-08-18-osobnostni-testy-design.md
@@ -60,7 +60,7 @@ RLS (helper `current_profile_id()`):
 
 Úložiště: existující private bucket **`documents`** (migrace
 `20260709120000_add_avatars_documents_buckets.sql` ho připravila přesně pro
-tento účel). Klíč `personality-tests/{profileId}/{timestamp}-{uuid}.{ext}`.
+tento účel). Klíč `personality-test/{profileId}/{timestamp}-{uuid}.{ext}`.
 Writes: presigned URL (service role, vzor avatarů). Reads: `getSignedStorageUrl`
 (1 h). Žádné storage RLS — veškerý přístup je serverem zprostředkovaný.
 

--- a/docs/plans/2026-08-18-osobnostni-testy-design.md
+++ b/docs/plans/2026-08-18-osobnostni-testy-design.md
@@ -54,8 +54,12 @@ Tabulka `personality_tests` (Drizzle, `db/schema/personality-tests.ts`):
 Index `(profile_id, tested_on)`.
 
 RLS (helper `current_profile_id()`):
-- select: `removed_at IS NULL` + ověřený uživatel (stejná podmínka jako
-  `profiles`: `users.verified_work_email IS NOT NULL`)
+- select: ověřený uživatel (stejná podmínka jako
+  `profiles`: `users.verified_work_email IS NOT NULL`). **Bez `removed_at IS NULL`**
+  — Postgres aplikuje SELECT policy jako kontrolu na NOVÉM řádku při UPDATE,
+  takže `removed_at IS NULL` v select policy by rozbil soft-delete
+  (`update ... set removed_at = now()` by skončil RLS chybou, 403). Soft-deleted
+  řádky filtrují dotazy aplikace (`queries.ts` provádí `.is("removed_at", null)`).
 - insert/update/delete: jen vlastník (`profile_id = current_profile_id()`)
 
 Úložiště: existující private bucket **`documents`** (migrace
@@ -120,7 +124,7 @@ Writes: presigned URL (service role, vzor avatarů). Reads: `getSignedStorageUrl
 
 ## Testování
 
-- **Unit**: `format.ts` (datum, měsíční klíč, velikost souboru) + štítky typů.
+- **Unit**: `format.ts` (datum, velikost souboru) + štítky typů.
 - **Integrace** (`tests/integration/personality-tests.int.test.ts`): RLS —
   vlastník insert + ověřený select, neověřený nevidí, cizí insert/update/delete
   zamítnut, soft-delete, check `other` bez textu, cascade při smazání profilu.

--- a/docs/plans/2026-08-18-osobnostni-testy-plan.md
+++ b/docs/plans/2026-08-18-osobnostni-testy-plan.md
@@ -1,0 +1,1981 @@
+# Osobnostní testy Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Students can upload their personality test result files (PDF/images) with a test type and completion date, view them on a vertical timeline on their own community profile, and any verified user can open them from the profile's new "Osobnostní testy" tab. Issue #59.
+
+**Architecture:** New `personality_tests` DB table (Drizzle schema, owner + verified-viewer RLS) storing the storage key and metadata. Files live in the existing private `documents` bucket, uploaded via the presign→PUT pattern, read via signed URLs. Server routes handle create/update/soft-delete/open; a client timeline component renders the vertical time axis. The community profile page gets tabs `Přehled / Eseje / Osobnostní testy`.
+
+**Scope decisions:**
+- No result/reflection/application fields (issue text is mostly wrong — the file IS the result).
+- Test type = enum (gallup, mbti, disc, big_five, enneagram, belbin) + `other` with free text.
+- Timeline ordered `tested_on` DESC (newest first), vertical axis with dots.
+- `documents` bucket stays without storage RLS — server-mediated access (signed URLs), per the bucket's migration comment.
+
+**Tech Stack:** Next.js 16, Supabase, Drizzle ORM (schema only), shadcn/ui, Tailwind CSS 4, Vitest, Playwright
+
+**Reference feature:**
+- `docs/plans/2026-08-18-tymovy-denik-plan.md` (task template — same module shape)
+- `docs/plans/2026-08-18-osobnostni-testy-design.md` (validated design incl. UX analysis)
+- `db/schema/team-activities.ts` + `supabase/migrations/20260818075139_melted_marvel_zombies.sql` (schema template)
+- `supabase/migrations/20260818075419_wealthy_bloodscream.sql` (updated_at trigger custom-migration template)
+- `src/lib/storage/*` + `src/app/api/storage/*` (storage plumbing to extend)
+- `src/components/tymovy-denik/team-activity-form.tsx` (form pattern)
+- `tests/integration/team-activities.int.test.ts` (RLS test template)
+- `tests/e2e/tymovy-denik.spec.ts` + `tests/e2e/fixtures/auth.ts` (E2E template)
+
+---
+
+### Task 1: Database Schema — `personality_tests` table + updated_at trigger
+
+**Files:**
+- Create: `db/schema/personality-tests.ts`
+- Create (via `pnpm db:generate`): `supabase/migrations/<timestamp>_*.sql`
+- Create (via `pnpm db:generate:custom`): `supabase/migrations/<timestamp>_*.sql`
+- Modify (regenerated): `src/lib/supabase/database.types.ts`
+
+**Step 1: Create schema file**
+
+```ts
+// Schema source of truth (drizzle-kit only; NOT imported at runtime — app uses supabase-js).
+// Please look at CONTRIBUTING.md for more information on how to change the schema.
+import { pgTable, foreignKey, pgPolicy, uuid, text, timestamp, date, integer, index, check, pgEnum } from "drizzle-orm/pg-core"
+import { sql } from "drizzle-orm"
+import { profiles } from "./profiles"
+
+export const personalityTestType = pgEnum("personality_test_type", [
+  "gallup",
+  "mbti",
+  "disc",
+  "big_five",
+  "enneagram",
+  "belbin",
+  "other",
+])
+
+export const personalityTests = pgTable("personality_tests", {
+  id: uuid().defaultRandom().primaryKey().notNull(),
+  profileId: uuid("profile_id").notNull(),
+  testType: personalityTestType("test_type").notNull(),
+  testTypeOther: text("test_type_other"),
+  testedOn: date("tested_on").notNull(),
+  filePath: text("file_path").notNull(),
+  fileName: text("file_name").notNull(),
+  fileSize: integer("file_size").notNull(),
+  removedAt: timestamp("removed_at", { withTimezone: true, mode: 'string' }),
+  createdAt: timestamp("created_at", { withTimezone: true, mode: 'string' }).defaultNow().notNull(),
+  updatedAt: timestamp("updated_at", { withTimezone: true, mode: 'string' }).defaultNow().notNull(),
+  createdByProfileId: uuid("created_by_profile_id").notNull(),
+  updatedByProfileId: uuid("updated_by_profile_id").notNull(),
+}, (table) => [
+  index("personality_tests_profile_tested_on_idx").using("btree", table.profileId.asc().nullsLast().op("uuid_ops"), table.testedOn.asc().nullsLast().op("date_ops")),
+  foreignKey({
+    columns: [table.profileId],
+    foreignColumns: [profiles.id],
+    name: "personality_tests_profile_id_fkey"
+  }).onDelete("cascade"),
+  foreignKey({
+    columns: [table.createdByProfileId],
+    foreignColumns: [profiles.id],
+    name: "personality_tests_created_by_profile_id_fkey"
+  }).onDelete("restrict"),
+  foreignKey({
+    columns: [table.updatedByProfileId],
+    foreignColumns: [profiles.id],
+    name: "personality_tests_updated_by_profile_id_fkey"
+  }).onDelete("restrict"),
+  check("personality_tests_other_type_required", sql`(test_type <> 'other' OR (test_type_other IS NOT NULL AND length(trim(test_type_other)) > 0))`),
+  pgPolicy("Verified users can view personality tests", { as: "permissive", for: "select", to: ["authenticated"], using: sql`(removed_at IS NULL) AND (EXISTS (SELECT 1 FROM users WHERE (users.auth_user_id = (SELECT auth.uid()) AND users.verified_work_email IS NOT NULL)))` }),
+  pgPolicy("Users can create their own personality tests", { as: "permissive", for: "insert", to: ["authenticated"], withCheck: sql`(profile_id = current_profile_id())` }),
+  pgPolicy("Users can update their own personality tests", { as: "permissive", for: "update", to: ["authenticated"], using: sql`(profile_id = current_profile_id())`, withCheck: sql`(profile_id = current_profile_id())` }),
+  pgPolicy("Users can delete their own personality tests", { as: "permissive", for: "delete", to: ["authenticated"], using: sql`(profile_id = current_profile_id())` }),
+]).enableRLS()
+```
+
+**Step 2: Generate the table migration**
+
+Run: `pnpm db:generate`
+Expected: new `supabase/migrations/<timestamp>_*.sql` containing `CREATE TABLE "public"."personality_tests"`, the enum `CREATE TYPE "public"."personality_test_type"`, indexes, policies, and `ALTER TABLE "public"."personality_tests" ENABLE ROW LEVEL SECURITY`.
+
+Verify manually: `grep -n "drop" supabase/migrations/<new-file>` → no unexpected drops.
+
+**Step 3: Generate the custom trigger migration**
+
+Run: `pnpm db:generate:custom`
+Expected: new `supabase/migrations/<timestamp>_*.sql` containing only `-- Custom SQL migration file, put your code below! --`.
+
+Replace its content with (template: `20260818075419_wealthy_bloodscream.sql`):
+
+```sql
+-- Custom SQL migration file, put your code below! --
+
+-- Migration: updated_at trigger for personality_tests.
+-- Mirrors the team_activities trigger (20260818075419_wealthy_bloodscream.sql):
+-- without it, updated_at never changes on UPDATE.
+
+drop trigger if exists personality_tests_updated_at_trigger on public.personality_tests;
+
+create trigger personality_tests_updated_at_trigger
+before update on public.personality_tests
+for each row
+execute function public.handle_updated_at();
+```
+
+**Step 4: Ask the user to apply the migration**
+
+Per AGENTS.md, do NOT run `db:up` yourself. Ask the user to run `pnpm db:migrate` and to check the two new migrations for any unintended drops.
+
+Run (by user): `pnpm db:migrate`
+Expected: both migrations applied, `src/lib/supabase/database.types.ts` regenerated.
+
+Verify manually:
+- `grep -rn "personality_tests" src/lib/supabase/database.types.ts` → `personality_tests` table row shape present
+- `grep -rn "personality_test_type" src/lib/supabase/database.types.ts` → enum union present
+
+**Step 5: Commit**
+
+```bash
+git add db/schema/personality-tests.ts supabase/migrations/ src/lib/supabase/database.types.ts
+git commit -m "feat(db): add personality_tests table"
+```
+
+---
+
+### Task 2: Storage plumbing — `personality-test` context
+
+**Files:**
+- Modify: `src/lib/storage/types.ts:5`
+- Modify: `src/lib/storage/buckets.ts:33-41`
+- Modify: `src/lib/storage/authorization.ts:16-34`
+- Modify: `src/lib/storage/validation.ts`
+- Modify: `src/app/api/storage/presign-upload/route.ts`
+
+**Step 1: Extend the StorageContext union**
+
+`src/lib/storage/types.ts`:
+
+```ts
+export type StorageContext = "profile" | "team" | "book" | "personality-test";
+```
+
+**Step 2: Map the new context to the documents bucket**
+
+`src/lib/storage/buckets.ts`, inside `contextToBucket` (the switch is exhaustive — TypeScript will flag this until added):
+
+```ts
+    case "personality-test":
+      return "documents";
+```
+
+**Step 3: Authorize the new context**
+
+`src/lib/storage/authorization.ts`, at the top of `authorizeAction` (before the `profile` branch):
+
+```ts
+  if (context === "personality-test") {
+    if (entityId !== profile.id) {
+      return "Nemůžeš nahrát soubor pro jinou osobu";
+    }
+    return null;
+  }
+```
+
+**Step 4: Add document validation**
+
+`src/lib/storage/validation.ts` — add after the existing image constants:
+
+```ts
+export const ALLOWED_DOCUMENT_TYPES = [
+  "application/pdf",
+  "image/png",
+  "image/jpeg",
+  "image/webp",
+] as const;
+
+// Max size for personality test uploads (PDF reports with graphics)
+export const MAX_DOCUMENT_SIZE = 20 * 1024 * 1024; // 20MB
+```
+
+Add after `validateImageUpload`:
+
+```ts
+/**
+ * Validate personality test upload constraints
+ */
+export function validatePersonalityTestUpload(
+  contentType: string,
+  fileSize: number
+): ValidationError | null {
+  if (!(ALLOWED_DOCUMENT_TYPES as readonly string[]).includes(contentType)) {
+    return {
+      field: "contentType",
+      message: "Povolené formáty: PDF, PNG, JPEG, WebP",
+    };
+  }
+
+  if (fileSize > MAX_DOCUMENT_SIZE) {
+    return {
+      field: "fileSize",
+      message: `Maximální velikost souboru je ${MAX_DOCUMENT_SIZE / 1024 / 1024}MB`,
+    };
+  }
+
+  return null;
+}
+```
+
+Extend `getFileExtension` map:
+
+```ts
+  const map: Record<string, string> = {
+    "image/jpeg": "jpg",
+    "image/png": "png",
+    "image/webp": "webp",
+    "application/pdf": "pdf",
+  };
+```
+
+**Step 5: Branch the presign route**
+
+`src/app/api/storage/presign-upload/route.ts`:
+- Add `validatePersonalityTestUpload` to the import from `@/lib/storage/validation`.
+- Replace the file validation call (line ~49):
+
+```ts
+    // Validate file type and size
+    const validationError =
+      context === "personality-test"
+        ? validatePersonalityTestUpload(contentType, fileSize)
+        : validateImageUpload(contentType, fileSize);
+```
+
+- Add a context branch before the existing `if (context === "profile")` (line ~67):
+
+```ts
+    if (context === "personality-test") {
+      // Users can only upload to their own profile
+      if (entityId !== profile.id) {
+        return NextResponse.json(
+          { error: "Nemůžeš nahrát soubor pro jinou osobu" },
+          { status: 403 }
+        );
+      }
+    } else if (context === "profile") {
+```
+
+**Step 6: Verify and commit**
+
+Run: `pnpm typecheck`
+Expected: PASS.
+
+```bash
+git add src/lib/storage/ src/app/api/storage/presign-upload/route.ts
+git commit -m "feat: add personality-test storage context and document validation"
+```
+
+---
+
+### Task 3: Types, queries, format helpers (TDD)
+
+**Files:**
+- Create: `src/lib/personality-tests/types.ts`
+- Create: `src/lib/personality-tests/queries.ts`
+- Create: `src/lib/personality-tests/format.ts`
+- Test: `src/lib/personality-tests/format.test.ts`
+
+**Step 1: Write the failing test**
+
+`src/lib/personality-tests/format.test.ts`:
+
+```ts
+import { describe, expect, it } from "vitest"
+import { formatTestDate, formatFileSize } from "./format"
+import { getTestTypeLabel } from "./types"
+
+describe("personality test format helpers", () => {
+  it("formats a date as day. month. year", () => {
+    expect(formatTestDate("2026-03-12")).toBe("12. 3. 2026")
+  })
+
+  it("formats file sizes in B, KB and MB with a Czech decimal comma", () => {
+    expect(formatFileSize(512)).toBe("512 B")
+    expect(formatFileSize(2048)).toBe("2 KB")
+    expect(formatFileSize(2 * 1024 * 1024 + 512 * 1024)).toBe("2,5 MB")
+  })
+})
+
+describe("personality test type labels", () => {
+  it("labels known types from the enum", () => {
+    expect(getTestTypeLabel({ test_type: "mbti", test_type_other: null })).toBe("MBTI")
+    expect(getTestTypeLabel({ test_type: "disc", test_type_other: null })).toBe("DISC")
+  })
+
+  it("uses the custom name for other", () => {
+    expect(
+      getTestTypeLabel({ test_type: "other", test_type_other: "Hogan Assessment" }),
+    ).toBe("Hogan Assessment")
+  })
+})
+```
+
+**Step 2: Run test to verify it fails**
+
+Run: `pnpm vitest run --project unit src/lib/personality-tests/format.test.ts`
+Expected: FAIL — module `./format` / `./types` not found.
+
+**Step 3: Write the implementation**
+
+`src/lib/personality-tests/types.ts`:
+
+```ts
+import type { Tables } from "@/lib/supabase/tables"
+
+export type PersonalityTest = Tables<"personality_tests">
+
+export const PERSONALITY_TEST_TYPES = [
+  "gallup",
+  "mbti",
+  "disc",
+  "big_five",
+  "enneagram",
+  "belbin",
+  "other",
+] as const
+
+export type PersonalityTestType = (typeof PERSONALITY_TEST_TYPES)[number]
+
+export const PERSONALITY_TEST_TYPE_LABELS: Record<PersonalityTestType, string> = {
+  gallup: "Gallup",
+  mbti: "MBTI",
+  disc: "DISC",
+  big_five: "Big Five",
+  enneagram: "Enneagram",
+  belbin: "Belbin",
+  other: "Jiný test",
+}
+
+export function getTestTypeLabel(
+  test: Pick<PersonalityTest, "test_type" | "test_type_other">,
+): string {
+  return test.test_type === "other"
+    ? test.test_type_other ?? PERSONALITY_TEST_TYPE_LABELS.other
+    : PERSONALITY_TEST_TYPE_LABELS[test.test_type]
+}
+```
+
+`src/lib/personality-tests/queries.ts`:
+
+```ts
+import type { SupabaseClient } from "@supabase/supabase-js"
+import type { Database } from "@/lib/supabase/database.types"
+import type { PersonalityTest } from "./types"
+
+export async function listPersonalityTests(
+  supabase: SupabaseClient<Database>,
+  profileId: string,
+): Promise<PersonalityTest[]> {
+  const { data, error } = await supabase
+    .from("personality_tests")
+    .select("*")
+    .is("removed_at", null)
+    .eq("profile_id", profileId)
+    .order("tested_on", { ascending: false })
+
+  if (error) throw error
+  return (data ?? []) as PersonalityTest[]
+}
+```
+
+`src/lib/personality-tests/format.ts`:
+
+```ts
+export function formatTestDate(dateStr: string): string {
+  const [year, month, day] = dateStr.split("-")
+  return `${Number(day)}. ${Number(month)}. ${year}`
+}
+
+export function formatFileSize(bytes: number): string {
+  if (bytes < 1024) return `${bytes} B`
+  if (bytes < 1024 * 1024) return `${Math.round(bytes / 1024)} KB`
+  return `${(bytes / 1024 / 1024).toFixed(1).replace(".", ",")} MB`
+}
+```
+
+**Step 4: Run test to verify it passes**
+
+Run: `pnpm vitest run --project unit src/lib/personality-tests/format.test.ts`
+Expected: PASS (all 4 tests green).
+
+**Step 5: Commit**
+
+```bash
+git add src/lib/personality-tests/
+git commit -m "feat: add personality test types, queries and format helpers"
+```
+
+---
+
+### Task 4: API routes
+
+**Files:**
+- Create: `src/app/api/personality-tests/route.ts`
+- Create: `src/app/api/personality-tests/[id]/route.ts`
+- Create: `src/app/api/personality-tests/[id]/open/route.ts`
+
+**Step 1: Create route — POST (create)**
+
+`src/app/api/personality-tests/route.ts`:
+
+```ts
+import { NextRequest, NextResponse } from "next/server";
+import { createClient } from "@/lib/supabase/server";
+import { getCurrentUserProfile } from "@/lib/auth-helpers";
+import { MAX_DOCUMENT_SIZE } from "@/lib/storage/validation";
+import { PERSONALITY_TEST_TYPES } from "@/lib/personality-tests/types";
+import type { Insertable } from "@/lib/supabase/tables";
+
+interface CreatePersonalityTestRequest {
+  profileId: string;
+  key: string;
+  testType: string;
+  testTypeOther?: string;
+  testedOn: string;
+  fileName: string;
+  fileSize: number;
+}
+
+const DATE_RE = /^\d{4}-\d{2}-\d{2}$/;
+
+export async function POST(request: NextRequest) {
+  try {
+    const supabase = await createClient();
+    const { data: { user } } = await supabase.auth.getUser();
+
+    if (!user) {
+      return NextResponse.json({ error: "Neautorizováno" }, { status: 401 });
+    }
+
+    const profile = await getCurrentUserProfile(supabase, { user });
+    if (!profile) {
+      return NextResponse.json({ error: "Profil nenalezen" }, { status: 403 });
+    }
+
+    const body: CreatePersonalityTestRequest = await request.json();
+    const { profileId, key, testType, testTypeOther, testedOn, fileName, fileSize } = body;
+
+    if (profileId !== profile.id) {
+      return NextResponse.json({ error: "Nemůžeš nahrát test pro jinou osobu" }, { status: 403 });
+    }
+    if (!(PERSONALITY_TEST_TYPES as readonly string[]).includes(testType)) {
+      return NextResponse.json({ error: "Neplatný typ testu" }, { status: 400 });
+    }
+    if (testType === "other" && !testTypeOther?.trim()) {
+      return NextResponse.json({ error: "Zadej název testu" }, { status: 400 });
+    }
+    if (!DATE_RE.test(testedOn)) {
+      return NextResponse.json({ error: "Neplatné datum" }, { status: 400 });
+    }
+    if (!fileName?.trim() || fileName.length > 255) {
+      return NextResponse.json({ error: "Neplatný název souboru" }, { status: 400 });
+    }
+    if (!Number.isFinite(fileSize) || fileSize <= 0 || fileSize > MAX_DOCUMENT_SIZE) {
+      return NextResponse.json({ error: "Neplatná velikost souboru" }, { status: 400 });
+    }
+    if (!key.startsWith(`personality-tests/${profileId}/`)) {
+      return NextResponse.json({ error: "Neplatný klíč souboru" }, { status: 400 });
+    }
+
+    const payload: Insertable<"personality_tests"> = {
+      profile_id: profileId,
+      test_type: testType as Insertable<"personality_tests">["test_type"],
+      test_type_other: testType === "other" ? testTypeOther.trim() : null,
+      tested_on: testedOn,
+      file_path: key,
+      file_name: fileName.trim(),
+      file_size: fileSize,
+      created_by_profile_id: profile.id,
+      updated_by_profile_id: profile.id,
+    };
+
+    const { data, error } = await supabase
+      .from("personality_tests")
+      .insert(payload)
+      .select()
+      .single();
+
+    if (error) {
+      console.error("POST /api/personality-tests insert error:", error);
+      return NextResponse.json({ error: "Nepodařilo se uložit test" }, { status: 500 });
+    }
+
+    return NextResponse.json({ success: true, data });
+  } catch (error) {
+    console.error("POST /api/personality-tests error:", error);
+    return NextResponse.json({ error: "Nepodařilo se uložit test" }, { status: 500 });
+  }
+}
+```
+
+Note: the `test_type as Insertable<...>["test_type"]` cast is needed because the request body types the field as `string` while the generated DB type is the enum union (derived types per AGENTS.md — never hand-write them).
+
+**Step 2: Create route — PATCH + DELETE**
+
+`src/app/api/personality-tests/[id]/route.ts`:
+
+```ts
+import { NextRequest, NextResponse } from "next/server";
+import { createClient } from "@/lib/supabase/server";
+import { getCurrentUserProfile } from "@/lib/auth-helpers";
+import { deleteFile } from "@/lib/storage/service";
+import { MAX_DOCUMENT_SIZE } from "@/lib/storage/validation";
+import { PERSONALITY_TEST_TYPES } from "@/lib/personality-tests/types";
+import type { Updatable } from "@/lib/supabase/tables";
+
+interface UpdatePersonalityTestRequest {
+  testType?: string;
+  testTypeOther?: string;
+  testedOn?: string;
+  newKey?: string;
+  fileName?: string;
+  fileSize?: number;
+}
+
+const DATE_RE = /^\d{4}-\d{2}-\d{2}$/;
+
+export async function PATCH(request: NextRequest, { params }: { params: Promise<{ id: string }> }) {
+  try {
+    const { id } = await params;
+    const supabase = await createClient();
+    const { data: { user } } = await supabase.auth.getUser();
+
+    if (!user) {
+      return NextResponse.json({ error: "Neautorizováno" }, { status: 401 });
+    }
+
+    const profile = await getCurrentUserProfile(supabase, { user });
+    if (!profile) {
+      return NextResponse.json({ error: "Profil nenalezen" }, { status: 403 });
+    }
+
+    const body: UpdatePersonalityTestRequest = await request.json();
+    const { testType, testTypeOther, testedOn, newKey, fileName, fileSize } = body;
+
+    const existing = await supabase
+      .from("personality_tests")
+      .select("id, profile_id, file_path, removed_at")
+      .eq("id", id)
+      .is("removed_at", null)
+      .maybeSingle();
+
+    if (existing.error || !existing.data) {
+      return NextResponse.json({ error: "Test nenalezen" }, { status: 404 });
+    }
+
+    if (testType !== undefined && !(PERSONALITY_TEST_TYPES as readonly string[]).includes(testType)) {
+      return NextResponse.json({ error: "Neplatný typ testu" }, { status: 400 });
+    }
+    if (testType === "other" && !testTypeOther?.trim()) {
+      return NextResponse.json({ error: "Zadej název testu" }, { status: 400 });
+    }
+    if (testedOn !== undefined && !DATE_RE.test(testedOn)) {
+      return NextResponse.json({ error: "Neplatné datum" }, { status: 400 });
+    }
+    if (newKey !== undefined) {
+      if (!newKey.startsWith(`personality-tests/${existing.data.profile_id}/`)) {
+        return NextResponse.json({ error: "Neplatný klíč souboru" }, { status: 400 });
+      }
+      if (!fileName?.trim() || fileName.length > 255) {
+        return NextResponse.json({ error: "Neplatný název souboru" }, { status: 400 });
+      }
+      if (!Number.isFinite(fileSize) || fileSize <= 0 || fileSize > MAX_DOCUMENT_SIZE) {
+        return NextResponse.json({ error: "Neplatná velikost souboru" }, { status: 400 });
+      }
+    }
+
+    const update: Updatable<"personality_tests"> = { updated_by_profile_id: profile.id };
+    if (testType !== undefined) {
+      update.test_type = testType as Updatable<"personality_tests">["test_type"];
+      update.test_type_other = testType === "other" ? testTypeOther.trim() : null;
+    }
+    if (testedOn !== undefined) {
+      update.tested_on = testedOn;
+    }
+    if (newKey !== undefined) {
+      update.file_path = newKey;
+      update.file_name = fileName.trim();
+      update.file_size = fileSize;
+    }
+
+    const { data: updated, error: updateError } = await supabase
+      .from("personality_tests")
+      .update(update)
+      .eq("id", id)
+      .select()
+      .maybeSingle();
+
+    if (updateError || !updated) {
+      return NextResponse.json({ error: "Nepodařilo se uložit změny" }, { status: 403 });
+    }
+
+    if (newKey !== undefined && newKey !== existing.data.file_path) {
+      try {
+        await deleteFile("documents", existing.data.file_path);
+      } catch (error) {
+        console.error("Error deleting old personality test file:", error);
+      }
+    }
+
+    return NextResponse.json({ success: true, data: updated });
+  } catch (error) {
+    console.error("PATCH /api/personality-tests/[id] error:", error);
+    return NextResponse.json({ error: "Nepodařilo se uložit změny" }, { status: 500 });
+  }
+}
+
+export async function DELETE(request: NextRequest, { params }: { params: Promise<{ id: string }> }) {
+  try {
+    const { id } = await params;
+    const supabase = await createClient();
+    const { data: { user } } = await supabase.auth.getUser();
+
+    if (!user) {
+      return NextResponse.json({ error: "Neautorizováno" }, { status: 401 });
+    }
+
+    const profile = await getCurrentUserProfile(supabase, { user });
+    if (!profile) {
+      return NextResponse.json({ error: "Profil nenalezen" }, { status: 403 });
+    }
+
+    const existing = await supabase
+      .from("personality_tests")
+      .select("id, file_path")
+      .eq("id", id)
+      .is("removed_at", null)
+      .maybeSingle();
+
+    if (existing.error || !existing.data) {
+      return NextResponse.json({ error: "Test nenalezen" }, { status: 404 });
+    }
+
+    const { data: removed, error: updateError } = await supabase
+      .from("personality_tests")
+      .update({ removed_at: new Date().toISOString(), updated_by_profile_id: profile.id })
+      .eq("id", id)
+      .select("id")
+      .maybeSingle();
+
+    if (updateError || !removed) {
+      return NextResponse.json({ error: "Nepodařilo se odstranit test" }, { status: 403 });
+    }
+
+    try {
+      await deleteFile("documents", existing.data.file_path);
+    } catch (error) {
+      console.error("Error deleting personality test file:", error);
+    }
+
+    return NextResponse.json({ success: true });
+  } catch (error) {
+    console.error("DELETE /api/personality-tests/[id] error:", error);
+    return NextResponse.json({ error: "Nepodařilo se odstranit test" }, { status: 500 });
+  }
+}
+```
+
+**Step 3: Create route — GET (open)**
+
+`src/app/api/personality-tests/[id]/open/route.ts`:
+
+```ts
+import { NextRequest, NextResponse } from "next/server";
+import { createClient } from "@/lib/supabase/server";
+import { getSignedStorageUrl } from "@/lib/storage/service";
+
+export async function GET(request: NextRequest, { params }: { params: Promise<{ id: string }> }) {
+  try {
+    const { id } = await params;
+    const supabase = await createClient();
+    const { data: { user } } = await supabase.auth.getUser();
+
+    if (!user) {
+      return NextResponse.json({ error: "Neautorizováno" }, { status: 401 });
+    }
+
+    const { data, error } = await supabase
+      .from("personality_tests")
+      .select("file_path")
+      .eq("id", id)
+      .is("removed_at", null)
+      .maybeSingle();
+
+    if (error || !data) {
+      return NextResponse.json({ error: "Test nenalezen" }, { status: 404 });
+    }
+
+    const url = await getSignedStorageUrl("documents", data.file_path);
+    return NextResponse.redirect(url, 307);
+  } catch (error) {
+    console.error("GET /api/personality-tests/[id]/open error:", error);
+    return NextResponse.json({ error: "Nepodařilo se otevřít soubor" }, { status: 500 });
+  }
+}
+```
+
+Note: the row select goes through RLS (`Verified users can view personality tests`), so an unverified user gets 404 — the signed URL is never created for them.
+
+**Step 4: Verify and commit**
+
+Run: `pnpm typecheck`
+Expected: PASS.
+
+```bash
+git add src/app/api/personality-tests/
+git commit -m "feat: add personality test API routes"
+```
+
+---
+
+### Task 5: InfoCard component
+
+**Files:**
+- Create: `src/components/personality-tests/info-card.tsx`
+
+**Step 1: Create InfoCard**
+
+Copy the team-diary InfoCard shell, with the approved copy from the design doc:
+
+```tsx
+import { Info } from "lucide-react"
+
+export function InfoCard() {
+  return (
+    <div className="flex gap-2 rounded-lg border border-border/50 bg-muted/30 p-3 text-xs leading-relaxed text-muted-foreground">
+      <Info className="mt-0.5 size-4 shrink-0 text-muted-foreground/50" />
+      <div className="space-y-1">
+        <p>
+          <strong>Osobnostní test</strong> slouží k hodnocení a pochopení charakterových rysů,
+          chování a preferencí téček. Pomáhá identifikovat silné a slabé stránky, motivace
+          a způsob interakce s okolím.
+        </p>
+        <p>
+          Osobnostní test si každé téčko dělá v 1. semestru. Následně ho zkonzultuje
+          s některým z koučů. Slouží jako podklad pro Learning contract.
+        </p>
+      </div>
+    </div>
+  )
+}
+```
+
+Copy check: run the `inclusive-czech-writing` skill over both paragraphs. The text is user-provided — flag the phrase „s některým z koučů" (generic masculine, possible rewrite to „s někým z kouči:ek") and confirm with the user before changing it.
+
+**Step 2: Commit**
+
+```bash
+git add src/components/personality-tests/info-card.tsx
+git commit -m "feat: add personality test info card"
+```
+
+---
+
+### Task 6: Form dialog (create + edit)
+
+**Files:**
+- Create: `src/components/personality-tests/personality-test-form.tsx`
+
+**Step 1: Create the form**
+
+Pattern: `team-activity-form.tsx` (controlled `useState` + manual validation — features do not use react-hook-form/zod).
+
+```tsx
+"use client"
+
+import { useState } from "react"
+import { Loader2 } from "lucide-react"
+import { Button } from "@/components/ui/button"
+import { Input } from "@/components/ui/input"
+import { Label } from "@/components/ui/label"
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select"
+import { toast } from "sonner"
+import { ALLOWED_DOCUMENT_TYPES, MAX_DOCUMENT_SIZE } from "@/lib/storage/validation"
+import type { PersonalityTest } from "@/lib/personality-tests/types"
+import { PERSONALITY_TEST_TYPES, PERSONALITY_TEST_TYPE_LABELS } from "@/lib/personality-tests/types"
+
+function today(): string {
+  const now = new Date()
+  return `${now.getFullYear()}-${String(now.getMonth() + 1).padStart(2, "0")}-${String(now.getDate()).padStart(2, "0")}`
+}
+
+interface PersonalityTestFormProps {
+  profileId: string
+  initial?: PersonalityTest
+  onSuccess: (test: PersonalityTest) => void
+  onCancel: () => void
+}
+
+export function PersonalityTestForm({ profileId, initial, onSuccess, onCancel }: PersonalityTestFormProps) {
+  const [loading, setLoading] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+  const [testType, setTestType] = useState<string>(initial?.test_type ?? "")
+  const [testTypeOther, setTestTypeOther] = useState(initial?.test_type_other ?? "")
+  const [testedOn, setTestedOn] = useState(initial?.tested_on ?? today())
+  const [file, setFile] = useState<File | null>(null)
+
+  async function handleSubmit(e: React.FormEvent) {
+    e.preventDefault()
+    setError(null)
+
+    if (!(PERSONALITY_TEST_TYPES as readonly string[]).includes(testType)) {
+      setError("Vyberte typ testu.")
+      return
+    }
+    if (testType === "other" && !testTypeOther.trim()) {
+      setError("Zadejte název testu.")
+      return
+    }
+    if (!testedOn) {
+      setError("Zadejte datum testu.")
+      return
+    }
+    if (!initial && !file) {
+      setError("Nahrajte soubor s výsledky.")
+      return
+    }
+    if (file && !(ALLOWED_DOCUMENT_TYPES as readonly string[]).includes(file.type)) {
+      setError("Povolené formáty: PDF, PNG, JPEG, WebP.")
+      return
+    }
+    if (file && file.size > MAX_DOCUMENT_SIZE) {
+      setError(`Maximální velikost souboru je ${MAX_DOCUMENT_SIZE / 1024 / 1024}MB.`)
+      return
+    }
+
+    setLoading(true)
+    try {
+      let newKey: string | null = null
+      let fileName: string | null = null
+      let fileSize: number | null = null
+
+      if (file) {
+        const presignRes = await fetch("/api/storage/presign-upload", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({
+            context: "personality-test",
+            entityId: profileId,
+            contentType: file.type,
+            fileSize: file.size,
+          }),
+        })
+        const presignJson = await presignRes.json()
+        if (!presignRes.ok || !presignJson.data) {
+          throw new Error(presignJson.error ?? "Nepodařilo se připravit nahrávání")
+        }
+        const { url, key } = presignJson.data as { url: string; key: string }
+
+        const putRes = await fetch(url, {
+          method: "PUT",
+          headers: { "Content-Type": file.type },
+          body: file,
+        })
+        if (!putRes.ok) throw new Error("Nepodařilo se nahrát soubor")
+
+        newKey = key
+        fileName = file.name
+        fileSize = file.size
+      }
+
+      let result: PersonalityTest
+      if (initial?.id) {
+        const patchRes = await fetch(`/api/personality-tests/${initial.id}`, {
+          method: "PATCH",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({
+            testType,
+            testTypeOther: testType === "other" ? testTypeOther.trim() : null,
+            testedOn,
+            ...(newKey ? { newKey, fileName, fileSize } : {}),
+          }),
+        })
+        const patchJson = await patchRes.json()
+        if (!patchRes.ok) throw new Error(patchJson.error ?? "Nepodařilo se uložit změny")
+        result = patchJson.data as PersonalityTest
+        toast.success("Test aktualizován")
+      } else {
+        const createRes = await fetch("/api/personality-tests", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({
+            profileId,
+            key: newKey!,
+            testType,
+            testTypeOther: testType === "other" ? testTypeOther.trim() : null,
+            testedOn,
+            fileName,
+            fileSize,
+          }),
+        })
+        const createJson = await createRes.json()
+        if (!createRes.ok) throw new Error(createJson.error ?? "Nepodařilo se uložit test")
+        result = createJson.data as PersonalityTest
+        toast.success("Test nahrán")
+      }
+
+      onSuccess(result)
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Neznámá chyba")
+      toast.error("Nepodařilo se uložit test")
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  return (
+    <form onSubmit={handleSubmit} className="space-y-4">
+      {error && (
+        <div className="rounded-md bg-destructive/10 p-3 text-sm text-destructive">
+          {error}
+        </div>
+      )}
+
+      <div className="space-y-2">
+        <Label>Typ testu</Label>
+        <Select value={testType} onValueChange={setTestType}>
+          <SelectTrigger className="w-full">
+            <SelectValue placeholder="Vyberte typ testu" />
+          </SelectTrigger>
+          <SelectContent>
+            {PERSONALITY_TEST_TYPES.map((type) => (
+              <SelectItem key={type} value={type}>
+                {PERSONALITY_TEST_TYPE_LABELS[type]}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+      </div>
+
+      {testType === "other" && (
+        <div className="space-y-2">
+          <Label htmlFor="test-type-other">Název testu</Label>
+          <Input
+            id="test-type-other"
+            value={testTypeOther}
+            onChange={(e) => setTestTypeOther(e.target.value)}
+            placeholder="Např. Hogan Assessment"
+          />
+        </div>
+      )}
+
+      <div className="space-y-2">
+        <Label htmlFor="tested-on">Datum testu</Label>
+        <Input
+          id="tested-on"
+          type="date"
+          value={testedOn}
+          onChange={(e) => setTestedOn(e.target.value)}
+        />
+      </div>
+
+      <div className="space-y-2">
+        <Label htmlFor="test-file">Soubor s výsledky</Label>
+        <Input
+          id="test-file"
+          type="file"
+          accept=".pdf,image/png,image/jpeg,image/webp"
+          onChange={(e) => setFile(e.target.files?.[0] ?? null)}
+        />
+        <p className="text-xs text-muted-foreground">
+          {initial?.file_name
+            ? `Aktuální soubor: ${initial.file_name} — nový soubor ho nahradí.`
+            : "PDF, PNG, JPEG nebo WebP · max 20 MB"}
+        </p>
+      </div>
+
+      <div className="flex items-center justify-end gap-2">
+        <Button type="button" variant="outline" onClick={onCancel} disabled={loading}>
+          Zrušit
+        </Button>
+        <Button type="submit" disabled={loading}>
+          {loading && <Loader2 className="size-4 animate-spin" />}
+          {initial?.id ? "Uložit změny" : "Nahrát test"}
+        </Button>
+      </div>
+    </form>
+  )
+}
+```
+
+**Step 2: Commit**
+
+```bash
+git add src/components/personality-tests/personality-test-form.tsx
+git commit -m "feat: add personality test form"
+```
+
+---
+
+### Task 7: Timeline component
+
+**Files:**
+- Create: `src/components/personality-tests/personality-test-timeline.tsx`
+
+**Step 1: Create the timeline**
+
+Vertical time axis: the connector line is drawn per item (except the last) as a 1 px `bg-border` segment from just below the dot (`top-5`) to the next item's dot (`bottom-[-32px]`; items are spaced `space-y-6` = 24px, the next dot sits 8px below the next li's top). Dots are `size-3 bg-primary ring-4 ring-background` so the line visually stops at each dot. Decorative spans are `aria-hidden`; structure is a semantic `ol`/`li`.
+
+```tsx
+"use client"
+
+import { useMemo, useState } from "react"
+import { ExternalLink, FileText, Loader2, Pencil, Trash2, Upload } from "lucide-react"
+import { Button } from "@/components/ui/button"
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from "@/components/ui/responsive-dialog"
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from "@/components/ui/alert-dialog"
+import {
+  Empty,
+  EmptyMedia,
+  EmptyHeader,
+  EmptyTitle,
+  EmptyDescription,
+  EmptyContent,
+} from "@/components/ui/empty"
+import { toast } from "sonner"
+import { PersonalityTestForm } from "./personality-test-form"
+import { formatFileSize, formatTestDate } from "@/lib/personality-tests/format"
+import { getTestTypeLabel } from "@/lib/personality-tests/types"
+import type { PersonalityTest } from "@/lib/personality-tests/types"
+
+interface PersonalityTestTimelineProps {
+  initialTests: PersonalityTest[]
+  profileId: string
+  isOwnProfile: boolean
+}
+
+export function PersonalityTestTimeline({ initialTests, profileId, isOwnProfile }: PersonalityTestTimelineProps) {
+  const [items, setItems] = useState(initialTests)
+  const [createOpen, setCreateOpen] = useState(false)
+  const [editing, setEditing] = useState<PersonalityTest | null>(null)
+  const [deleting, setDeleting] = useState<PersonalityTest | null>(null)
+  const [deletingId, setDeletingId] = useState<string | null>(null)
+
+  const sorted = useMemo(
+    () => [...items].sort((a, b) => b.tested_on.localeCompare(a.tested_on)),
+    [items],
+  )
+
+  function handleCreated(test: PersonalityTest) {
+    setItems((prev) => [...prev, test])
+    setCreateOpen(false)
+  }
+
+  function handleUpdated(test: PersonalityTest) {
+    setItems((prev) => prev.map((t) => (t.id === test.id ? test : t)))
+    setEditing(null)
+  }
+
+  async function handleDelete() {
+    if (!deleting) return
+    setDeletingId(deleting.id)
+    try {
+      const res = await fetch(`/api/personality-tests/${deleting.id}`, { method: "DELETE" })
+      const json = await res.json()
+      if (!res.ok) throw new Error(json.error ?? "Nepodařilo se odstranit test")
+      setItems((prev) => prev.filter((t) => t.id !== deleting.id))
+      toast.success("Test odstraněn")
+      setDeleting(null)
+    } catch (err) {
+      toast.error(err instanceof Error ? err.message : "Nepodařilo se odstranit test")
+    } finally {
+      setDeletingId(null)
+    }
+  }
+
+  return (
+    <div className="space-y-4 sm:space-y-6">
+      {isOwnProfile && (
+        <div className="flex items-center justify-end">
+          <Dialog open={createOpen} onOpenChange={setCreateOpen}>
+            <DialogTrigger asChild>
+              <Button size="sm">
+                <Upload className="size-4" />
+                Nahrát test
+              </Button>
+            </DialogTrigger>
+            <DialogContent className="sm:max-w-lg">
+              <DialogHeader>
+                <DialogTitle>Nový osobnostní test</DialogTitle>
+              </DialogHeader>
+              <PersonalityTestForm
+                profileId={profileId}
+                onSuccess={handleCreated}
+                onCancel={() => setCreateOpen(false)}
+              />
+            </DialogContent>
+          </Dialog>
+        </div>
+      )}
+
+      {sorted.length === 0 ? (
+        <Empty>
+          <EmptyMedia variant="icon">
+            <FileText className="size-6" />
+          </EmptyMedia>
+          <EmptyHeader>
+            <EmptyTitle>
+              {isOwnProfile ? "Zatím nemáš nahraný žádný osobnostní test" : "Zatím žádné osobnostní testy"}
+            </EmptyTitle>
+            <EmptyDescription>
+              {isOwnProfile
+                ? "Nahraj výsledky svého osobnostního testu jako soubor PDF nebo obrázek. Timeline ukáže, jak se v průběhu studia vyvíjíš."
+                : "Tato osoba zatím nenahrála žádné osobnostní testy."}
+            </EmptyDescription>
+          </EmptyHeader>
+          {isOwnProfile && (
+            <EmptyContent>
+              <Button size="sm" onClick={() => setCreateOpen(true)}>
+                <Upload className="size-4" />
+                Nahrát test
+              </Button>
+            </EmptyContent>
+          )}
+        </Empty>
+      ) : (
+        <ol className="space-y-6">
+          {sorted.map((test, index) => (
+            <li key={test.id} className="relative pl-6 sm:pl-8">
+              {index < sorted.length - 1 && (
+                <span
+                  aria-hidden
+                  className="absolute left-0 top-5 bottom-[-32px] w-px bg-border"
+                />
+              )}
+              <span
+                aria-hidden
+                className="absolute left-0 top-2 size-3 -translate-x-1/2 rounded-full bg-primary ring-4 ring-background"
+              />
+              <div className="flex items-center gap-3 rounded-xl border bg-card px-3.5 py-3">
+                <div className="flex size-10 shrink-0 items-center justify-center rounded-lg bg-primary/10 text-primary">
+                  <FileText className="size-5" />
+                </div>
+                <div className="min-w-0 flex-1">
+                  <p className="truncate text-sm font-semibold">{getTestTypeLabel(test)}</p>
+                  <p className="truncate text-xs text-muted-foreground">
+                    {formatTestDate(test.tested_on)} · {test.file_name} · {formatFileSize(test.file_size)}
+                  </p>
+                </div>
+                <div className="flex shrink-0 items-center gap-1">
+                  <Button asChild variant="outline" size="sm">
+                    <a
+                      href={`/api/personality-tests/${test.id}/open`}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                    >
+                      <ExternalLink className="size-3.5" />
+                      <span className="sr-only sm:not-sr-only sm:inline">Otevřít</span>
+                    </a>
+                  </Button>
+                  {isOwnProfile && (
+                    <>
+                      <Button
+                        variant="outline"
+                        size="sm"
+                        aria-label="Upravit test"
+                        onClick={() => setEditing(test)}
+                      >
+                        <Pencil className="size-4" />
+                        <span className="sr-only sm:not-sr-only sm:inline">Upravit</span>
+                      </Button>
+                      <Button
+                        variant="outline"
+                        size="sm"
+                        className="text-destructive"
+                        aria-label="Smazat test"
+                        onClick={() => setDeleting(test)}
+                      >
+                        <Trash2 className="size-4" />
+                        <span className="sr-only sm:not-sr-only sm:inline">Smazat</span>
+                      </Button>
+                    </>
+                  )}
+                </div>
+              </div>
+            </li>
+          ))}
+        </ol>
+      )}
+
+      <Dialog
+        open={editing !== null}
+        onOpenChange={(open) => {
+          if (!open) setEditing(null)
+        }}
+      >
+        <DialogContent className="sm:max-w-lg">
+          <DialogHeader>
+            <DialogTitle>Upravit test</DialogTitle>
+          </DialogHeader>
+          {editing && (
+            <PersonalityTestForm
+              profileId={profileId}
+              initial={editing}
+              onSuccess={handleUpdated}
+              onCancel={() => setEditing(null)}
+            />
+          )}
+        </DialogContent>
+      </Dialog>
+
+      <AlertDialog
+        open={deleting !== null}
+        onOpenChange={(open) => {
+          if (!open) setDeleting(null)
+        }}
+      >
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>Odstranit test?</AlertDialogTitle>
+            <AlertDialogDescription>
+              {deleting && (
+                <>
+                  Test <strong>{getTestTypeLabel(deleting)}</strong> ({formatTestDate(deleting.tested_on)}){" "}
+                  odebereš ze svého profilu. Nahraný soubor bude smazán.
+                </>
+              )}
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel disabled={deletingId !== null}>Zrušit</AlertDialogCancel>
+            <AlertDialogAction
+              onClick={handleDelete}
+              disabled={deletingId !== null}
+              className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
+            >
+              {deletingId !== null && <Loader2 className="size-4 animate-spin" />}
+              Odstranit
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+    </div>
+  )
+}
+```
+
+Verify the timeline geometry visually in both themes and at mobile width (`sm:pl-8` padding vs `pl-6`): dots must sit on the line with no overhang above the first or below the last dot.
+
+**Step 2: Commit**
+
+```bash
+git add src/components/personality-tests/personality-test-timeline.tsx
+git commit -m "feat: add personality test timeline"
+```
+
+---
+
+### Task 8: Profile page — tabs restructure
+
+**Files:**
+- Modify: `src/app/(main)/komunita/profil/[id]/page.tsx`
+
+**Step 1: Restructure the page**
+
+Add imports:
+
+```tsx
+import { UserRound, Brain } from 'lucide-react';
+import { Tabs, TabsContent, TabsList, TabsTrigger, TabsTriggerCount } from '@/components/ui/tabs';
+import { InfoCard } from '@/components/personality-tests/info-card';
+import { PersonalityTestTimeline } from '@/components/personality-tests/personality-test-timeline';
+import { listPersonalityTests } from '@/lib/personality-tests/queries';
+```
+
+Change the `searchParams` type and add the tests fetch + active tab (after the existing `countIndividualCoachingSessions` query, line ~38-43):
+
+```tsx
+  const [essays, stats, meetingCount, coachingSessionCount, personalityTests] = await Promise.all([
+    getEssays(supabase, { authorProfileId: id, sort: 'best', pageSize: 100 }),
+    getUserBookPointsStats(supabase, id),
+    countCustomerMeetings(supabase, id).catch(() => 0),
+    countIndividualCoachingSessions(supabase, id).catch(() => 0),
+    listPersonalityTests(supabase, id),
+  ]);
+```
+
+```tsx
+  const activeTab = tab === 'eseje' || tab === 'osobnostni-testy' ? tab : 'prehled';
+```
+
+Replace the stats/contact block (lines ~121-164) and the essays block (lines ~166-264) — everything between the profile header and the closing `</PageShell>` — with:
+
+```tsx
+        <Tabs defaultValue={activeTab} className="mt-4">
+          <TabsList>
+            <TabsTrigger value="prehled">
+              <UserRound />
+              Přehled
+            </TabsTrigger>
+            <TabsTrigger value="eseje">
+              <BookOpen />
+              Eseje
+              <TabsTriggerCount count={essays.length} />
+            </TabsTrigger>
+            <TabsTrigger value="osobnostni-testy">
+              <Brain />
+              Osobnostní testy
+              <TabsTriggerCount count={personalityTests.length} />
+            </TabsTrigger>
+          </TabsList>
+
+          {/* Stats + contact */}
+          <TabsContent value="prehled">
+            <div className="flex flex-wrap items-center gap-x-6 gap-y-4 py-4">
+              <div className="flex items-center gap-6">
+                {[
+                  { value: stats.approved_points, label: pts(stats.approved_points) },
+                  { value: stats.essay_count,    label: eseje(stats.essay_count) },
+                  { value: totalVotes,           label: hlasy(totalVotes) },
+                  { value: meetingCount,         label: schuzky(meetingCount) },
+                  { value: coachingSessionCount, label: koucovaniLabel },
+                ].map(({ value, label }) => (
+                  <div key={label} className="text-center">
+                    <p className="text-xl font-bold tabular-nums leading-none">{value}</p>
+                    <p className="text-xs text-muted-foreground mt-0.5">{label}</p>
+                  </div>
+                ))}
+              </div>
+
+              <div className="h-8 w-px bg-border hidden sm:block" />
+
+              <div className="flex flex-wrap gap-x-5 gap-y-1.5 min-w-0">
+                <a href={`mailto:${profile.work_email}`} className="inline-flex items-center gap-1.5 text-xs text-muted-foreground hover:text-foreground transition-colors min-w-0">
+                  <Mail className="size-3.5 shrink-0" /><span className="truncate">{profile.work_email}</span>
+                </a>
+                {profile.personal_email && (
+                  <a href={`mailto:${profile.personal_email}`} className="inline-flex items-center gap-1.5 text-xs text-muted-foreground hover:text-foreground transition-colors min-w-0">
+                    <Mail className="size-3.5 shrink-0" /><span className="truncate">{profile.personal_email}</span>
+                  </a>
+                )}
+                {profile.phone_number && (
+                  <a href={`tel:${profile.phone_number}`} className="inline-flex items-center gap-1.5 text-xs text-muted-foreground hover:text-foreground transition-colors">
+                    <Phone className="size-3.5" />{profile.phone_number}
+                  </a>
+                )}
+                {profile.date_of_birth && (
+                  <span className="inline-flex items-center gap-1.5 text-xs text-muted-foreground">
+                    <Cake className="size-3.5" />
+                    {new Date(profile.date_of_birth).toLocaleDateString('cs-CZ', { day: 'numeric', month: 'long', year: 'numeric' })}
+                  </span>
+                )}
+              </div>
+            </div>
+          </TabsContent>
+
+          {/* Essays */}
+          <TabsContent value="eseje" className="mt-4">
+            <div className="space-y-4">
+              <h2 className="font-semibold text-base">
+                Eseje
+                {essays.length > 0 && <span className="ml-2 font-normal text-muted-foreground text-sm">{essays.length}</span>}
+              </h2>
+
+              {essays.length === 0 ? (
+                <p className="text-sm text-muted-foreground py-8 text-center">Zatím žádné eseje</p>
+              ) : (
+                <>
+                  {bookEssays.length > 0 && (
+                    <div className="grid sm:grid-cols-2 gap-3">
+                      {[...bookEssays].sort((a, b) => {
+                        if (a.pinned_at && !b.pinned_at) return -1;
+                        if (!a.pinned_at && b.pinned_at) return 1;
+                        return 0;
+                      }).map((essay) => {
+                        const excerpt = essay.content_text?.trim().replace(/\s+/g, ' ').slice(0, 120);
+                        return (
+                          <div key={essay.id} className="flex gap-3 rounded-xl border bg-card px-3.5 py-3 group hover:shadow-sm transition-shadow">
+                            <Link href={`/cteni/eseje/${essay.id}`} className="focus-ring shrink-0 w-11 h-15 rounded-md overflow-hidden bg-muted flex items-center justify-center mt-0.5">
+                              {essay.book!.google_books_cover_url ? (
+                                <StorageImage storageKey={essay.book!.google_books_cover_url} alt={essay.book!.title_cs} width={44} height={60} className="w-full h-full object-cover" />
+                              ) : (
+                                <BookOpen className="size-4 text-muted-foreground/30" />
+                              )}
+                            </Link>
+                            <div className="flex-1 min-w-0 space-y-1">
+                              <Link href={`/cteni/eseje/${essay.id}`} className="focus-ring flex min-w-0 items-center gap-1.5 rounded-sm">
+                                {essay.pinned_at && <Pin className="size-3 shrink-0 text-primary fill-primary" />}
+                                <span className="font-semibold text-sm leading-snug truncate group-hover:text-primary transition-colors">
+                                  {essay.title}
+                                </span>
+                              </Link>
+                              <p className="flex items-center gap-1.5 text-xs text-muted-foreground truncate">
+                                {essay.book!.title_cs}
+                                <BookStatusBadges book={essay.book!} />
+                                {pointsNumber(essay.book!.book_points) > 0 && <span className="ml-1 font-medium text-foreground">· {formatPointsWithLabel(essay.book!.book_points)}</span>}
+                              </p>
+                              {excerpt && excerpt.length > 20 && (
+                                <p className="text-xs text-muted-foreground/60 line-clamp-2 leading-relaxed">{excerpt}…</p>
+                              )}
+                              <EssayVoteButton essayId={essay.id} initialVoteCount={essay.vote_count} initialVoted={votedIds.has(essay.id)} size="sm" />
+                            </div>
+                          </div>
+                        );
+                      })}
+                    </div>
+                  )}
+
+                  {topicEssays.length > 0 && (
+                    <section className="space-y-3">
+                      <div className="flex items-center gap-2 pt-2">
+                        <Sparkles className="size-4 text-warning-strong" />
+                        <h3 className="font-semibold text-sm text-warning-strong">
+                          Nad rámec četby
+                        </h3>
+                      </div>
+                      <p className="text-xs text-muted-foreground/60 leading-relaxed -mt-1">
+                        Myšlenky, postřehy a záznamy, které nevznikly z přečtené knihy, ale z vlastní potřeby sdílet — bez nároku na body.
+                      </p>
+                      <div className="grid sm:grid-cols-2 gap-3">
+                        {[...topicEssays].sort((a, b) => {
+                          if (a.pinned_at && !b.pinned_at) return -1;
+                          if (!a.pinned_at && b.pinned_at) return 1;
+                          return 0;
+                        }).map((essay) => {
+                          const excerpt = essay.content_text?.trim().replace(/\s+/g, ' ').slice(0, 120);
+                          return (
+                            <div key={essay.id} className="flex gap-3 rounded-xl border border-warning/20 bg-warning/10 px-3.5 py-3 group hover:shadow-sm transition-shadow">
+                              <Link href={`/cteni/eseje/${essay.id}`} className="focus-ring shrink-0 w-11 h-15 rounded-md overflow-hidden bg-warning/10 flex items-center justify-center mt-0.5">
+                                <Sparkles className="size-4 text-warning/40" />
+                              </Link>
+                              <div className="flex-1 min-w-0 space-y-1">
+                                <Link href={`/cteni/eseje/${essay.id}`} className="focus-ring flex min-w-0 items-center gap-1.5 rounded-sm">
+                                  {essay.pinned_at && <Pin className="size-3 shrink-0 text-primary fill-primary" />}
+                                  <span className="font-semibold text-sm leading-snug truncate group-hover:text-warning-strong transition-colors">
+                                    {essay.title}
+                                  </span>
+                                </Link>
+                                <p className="text-xs text-warning-strong flex items-center gap-1">
+                                  <Sparkles className="size-3" />
+                                  Nad rámec četby
+                                </p>
+                                {excerpt && excerpt.length > 20 && (
+                                  <p className="text-xs text-muted-foreground/60 line-clamp-2 leading-relaxed">{excerpt}…</p>
+                                )}
+                                <EssayVoteButton essayId={essay.id} initialVoteCount={essay.vote_count} initialVoted={votedIds.has(essay.id)} size="sm" />
+                              </div>
+                            </div>
+                          );
+                        })}
+                      </div>
+                    </section>
+                  )}
+                </>
+              )}
+            </div>
+          </TabsContent>
+
+          {/* Personality tests */}
+          <TabsContent value="osobnostni-testy" className="mt-4 space-y-4">
+            <InfoCard />
+            <PersonalityTestTimeline
+              initialTests={personalityTests}
+              profileId={profile.id}
+              isOwnProfile={isOwnProfile}
+            />
+          </TabsContent>
+        </Tabs>
+```
+
+Also change `searchParams` in `PageProps`:
+
+```tsx
+  searchParams: Promise<{ from?: string; tab?: string }>;
+```
+
+and the destructure at the top of the component:
+
+```tsx
+  const { from, tab } = await searchParams;
+```
+
+Notes:
+- The `border-y` on the stats block becomes a simple `py-4` (the tabs already separate the header).
+- Check the tab bar at mobile width — the three triggers must not overflow; if they do, add `flex-wrap` to `TabsList` (the repo's custom TabsList variant handles most widths; verify in the browser).
+
+**Step 2: Verify and commit**
+
+Run: `pnpm typecheck`
+Expected: PASS.
+
+```bash
+git add src/app/"(main)"/komunita/profil/"[id]"/page.tsx
+git commit -m "feat: add tabs to community profile page with personality tests"
+```
+
+---
+
+### Task 9: Integration RLS tests
+
+**Files:**
+- Create: `tests/integration/personality-tests.int.test.ts`
+
+**Step 1: Create the test**
+
+Mirror `tests/integration/team-activities.int.test.ts` (withRollback, insertAuthUser, asClaims):
+
+```ts
+import { describe, expect, it } from "vitest";
+import { withRollback } from "@/tests/setup/tx";
+import { insertAuthUser } from "@/tests/setup/factories";
+import { asClaims } from "@/tests/setup/rls";
+import type { PoolClient } from "pg";
+
+async function seed(client: PoolClient) {
+  const ownerAuth = await insertAuthUser(client);
+  const otherAuth = await insertAuthUser(client);
+  const unverifiedAuth = await insertAuthUser(client);
+
+  const { rows: ownerUserRows } = await client.query(
+    "select id from public.users where auth_user_id = $1",
+    [ownerAuth.id],
+  );
+  const { rows: otherUserRows } = await client.query(
+    "select id from public.users where auth_user_id = $1",
+    [otherAuth.id],
+  );
+  const { rows: unverifiedUserRows } = await client.query(
+    "select id from public.users where auth_user_id = $1",
+    [unverifiedAuth.id],
+  );
+
+  // owner + other verified, unverified stays unverified
+  await client.query(
+    "update public.users set verified_work_email = google_email, verified_work_email_at = now() where id = any($1)",
+    [[ownerUserRows[0].id, otherUserRows[0].id]],
+  );
+
+  const profile = async (name: string, email: string, userId: string) => {
+    const { rows } = await client.query(
+      `insert into public.profiles (name, work_email, user_id, role)
+       values ($1, $2, $3, 'student') returning id`,
+      [name, email, userId],
+    );
+    return rows[0].id as string;
+  };
+
+  const ownerProfileId = await profile("Owner", "pt-owner@studenti.czu.cz", ownerUserRows[0].id);
+  const otherProfileId = await profile("Other", "pt-other@studenti.czu.cz", otherUserRows[0].id);
+  const unverifiedProfileId = await profile("Unverified", "pt-unverified@studenti.czu.cz", unverifiedUserRows[0].id);
+
+  return {
+    ownerProfileId,
+    otherProfileId,
+    unverifiedProfileId,
+    ownerAuthId: ownerAuth.id as string,
+    otherAuthId: otherAuth.id as string,
+    unverifiedAuthId: unverifiedAuth.id as string,
+  };
+}
+
+async function insertTest(
+  client: PoolClient,
+  profileId: string,
+  testType = "mbti",
+  overrides: { testTypeOther?: string | null } = {},
+) {
+  const { rows } = await client.query(
+    `insert into public.personality_tests
+       (profile_id, test_type, test_type_other, tested_on, file_path, file_name, file_size, created_by_profile_id, updated_by_profile_id)
+     values ($1, $2, $3, '2026-03-10', 'personality-tests/p1/x.pdf', 'x.pdf', 1024, $4, $4)
+     returning id`,
+    [profileId, testType, overrides.testTypeOther ?? null, profileId],
+  );
+  return rows[0].id as string;
+}
+
+describe("personality_tests RLS", () => {
+  it("lets the owner insert and another verified user select their tests", async () => {
+    await withRollback(async (client) => {
+      const { ownerProfileId, ownerAuthId, otherAuthId } = await seed(client);
+
+      await asClaims(client, { sub: ownerAuthId });
+      await insertTest(client, ownerProfileId);
+
+      await asClaims(client, { sub: otherAuthId });
+      const { rows } = await client.query(
+        "select test_type from public.personality_tests where profile_id = $1",
+        [ownerProfileId],
+      );
+      expect(rows).toHaveLength(1);
+      expect(rows[0].test_type).toBe("mbti");
+    });
+  });
+
+  it("does not let an unverified user select tests", async () => {
+    await withRollback(async (client) => {
+      const { ownerProfileId, ownerAuthId, unverifiedAuthId } = await seed(client);
+
+      await asClaims(client, { sub: ownerAuthId });
+      await insertTest(client, ownerProfileId);
+
+      await asClaims(client, { sub: unverifiedAuthId });
+      const { rows } = await client.query(
+        "select id from public.personality_tests where profile_id = $1",
+        [ownerProfileId],
+      );
+      expect(rows).toHaveLength(0); // RLS filters it out silently
+    });
+  });
+
+  it("does not let another user insert a test for someone else", async () => {
+    await withRollback(async (client) => {
+      const { ownerProfileId, otherAuthId } = await seed(client);
+
+      await asClaims(client, { sub: otherAuthId });
+      await expect(
+        client.query(
+          `insert into public.personality_tests
+             (profile_id, test_type, tested_on, file_path, file_name, file_size, created_by_profile_id, updated_by_profile_id)
+           values ($1, 'mbti', '2026-03-10', 'personality-tests/p1/x.pdf', 'x.pdf', 1024, $2, $2)`,
+          [ownerProfileId, otherAuthId],
+        ),
+      ).rejects.toThrow();
+    });
+  });
+
+  it("lets the owner update and soft-delete their test; other users cannot", async () => {
+    await withRollback(async (client) => {
+      const { ownerProfileId, ownerAuthId, otherAuthId } = await seed(client);
+      const testId = await insertTest(client, ownerProfileId);
+
+      await asClaims(client, { sub: ownerAuthId });
+      await client.query(
+        `update public.personality_tests
+           set tested_on = '2026-04-01', updated_by_profile_id = $2
+         where id = $1`,
+        [testId, ownerProfileId],
+      );
+      await client.query(
+        `update public.personality_tests
+           set removed_at = now(), updated_by_profile_id = $2
+         where id = $1`,
+        [testId, ownerProfileId],
+      );
+
+      const { rows } = await client.query(
+        "select tested_on, removed_at from public.personality_tests where id = $1",
+        [testId],
+      );
+      expect(rows[0].tested_on).toBe("2026-04-01");
+      expect(rows[0].removed_at).not.toBeNull();
+
+      const { rows: activeRows } = await client.query(
+        "select id from public.personality_tests where profile_id = $1 and removed_at is null",
+        [ownerProfileId],
+      );
+      expect(activeRows).toHaveLength(0); // soft-deleted rows are filtered by the app query
+
+      await asClaims(client, { sub: otherAuthId });
+      const updateResult = await client.query(
+        "update public.personality_tests set test_type = 'disc' where id = $1",
+        [testId],
+      );
+      expect(updateResult.rowCount).toBe(0); // RLS filters the row out
+
+      const deleteResult = await client.query(
+        "delete from public.personality_tests where id = $1",
+        [testId],
+      );
+      expect(deleteResult.rowCount).toBe(0);
+    });
+  });
+
+  it("rejects 'other' test type without a custom name", async () => {
+    await withRollback(async (client) => {
+      const { ownerProfileId, ownerAuthId } = await seed(client);
+
+      await asClaims(client, { sub: ownerAuthId });
+      await expect(
+        client.query(
+          `insert into public.personality_tests
+             (profile_id, test_type, tested_on, file_path, file_name, file_size, created_by_profile_id, updated_by_profile_id)
+           values ($1, 'other', '2026-03-10', 'personality-tests/p1/x.pdf', 'x.pdf', 1024, $2, $2)`,
+          [ownerProfileId, ownerAuthId],
+        ),
+      ).rejects.toThrow();
+    });
+  });
+
+  it("cascades delete when the profile is removed", async () => {
+    await withRollback(async (client) => {
+      const { ownerProfileId, ownerAuthId } = await seed(client);
+
+      await asClaims(client, { sub: ownerAuthId });
+      await insertTest(client, ownerProfileId);
+
+      await client.query("set local role service_role");
+      await client.query("delete from public.profiles where id = $1", [ownerProfileId]);
+
+      const { rows } = await client.query(
+        "select count(*)::int as cnt from public.personality_tests where profile_id = $1",
+        [ownerProfileId],
+      );
+      expect(rows[0].cnt).toBe(0);
+    });
+  });
+});
+```
+
+**Step 2: Run and verify**
+
+Run: `pnpm vitest run --project integration tests/integration/personality-tests.int.test.ts`
+Expected: PASS (6 tests).
+
+**Step 3: Commit**
+
+```bash
+git add tests/integration/personality-tests.int.test.ts
+git commit -m "test: add RLS integration test for personality_tests"
+```
+
+---
+
+### Task 10: E2E tests
+
+**Files:**
+- Create: `tests/e2e/personality-tests.spec.ts`
+
+**Step 1: Create the spec**
+
+Mirror `tests/e2e/tymovy-denik.spec.ts` (fixtures: `createTestTeam`, `getSetupSessionCookie`, `setAuthCookie`, `cleanupTestData`). Use the unique-name trick via `other` + a timestamped name for unambiguous assertions; known types (MBTI → DISC) for the select flow.
+
+```ts
+import { expect, test } from "@playwright/test";
+import {
+  cleanupTestData,
+  createTestTeam,
+  getSetupSessionCookie,
+  setAuthCookie,
+} from "./fixtures/auth";
+
+const TEST_PDF = {
+  name: "mbti-vysledky.pdf",
+  mimeType: "application/pdf",
+  buffer: Buffer.from("%PDF-1.4 test"),
+};
+
+async function uploadTest(page: import("@playwright/test").Page, typeLabel: string) {
+  await page.getByRole("button", { name: /Nahrát test/i }).first().click();
+  const dialog = page.getByRole("dialog");
+  await dialog.getByRole("combobox").click();
+  await page.getByRole("option", { name: typeLabel }).click();
+  await dialog.getByLabel("Soubor s výsledky").setInputFiles(TEST_PDF);
+  await dialog.getByRole("button", { name: "Nahrát test" }).click();
+  await expect(dialog).toHaveCount(0);
+}
+
+async function uploadCustomTest(page: import("@playwright/test").Page, testName: string) {
+  await page.getByRole("button", { name: /Nahrát test/i }).first().click();
+  const dialog = page.getByRole("dialog");
+  await dialog.getByRole("combobox").click();
+  await page.getByRole("option", { name: "Jiný test" }).click();
+  await dialog.getByLabel("Název testu").fill(testName);
+  await dialog.getByLabel("Soubor s výsledky").setInputFiles(TEST_PDF);
+  await dialog.getByRole("button", { name: "Nahrát test" }).click();
+  await expect(dialog).toHaveCount(0);
+}
+
+test.describe("osobnostní testy - single user", () => {
+  let cookieValue: string;
+  let profileId: string;
+
+  test.beforeAll(async () => {
+    const teamId = await createTestTeam();
+    const user = await getSetupSessionCookie(teamId);
+    cookieValue = user.cookie;
+    profileId = user.profileId;
+  });
+
+  test.beforeEach(async ({ context }) => {
+    await setAuthCookie(context, cookieValue);
+  });
+
+  test.afterAll(async () => {
+    await cleanupTestData();
+  });
+
+  test("profile shows empty state on the personality tests tab", async ({ page }) => {
+    await page.goto(`/komunita/profil/${profileId}?tab=osobnostni-testy`);
+    await expect(page.getByRole("heading", { name: "Osobnostní testy" })).toBeVisible();
+    await expect(page.getByText("Zatím nemáš nahraný žádný osobnostní test")).toBeVisible();
+  });
+
+  test("uploading a test adds it to the timeline", async ({ page }) => {
+    const testName = `E2E test ${Date.now()}`;
+    await page.goto(`/komunita/profil/${profileId}?tab=osobnostni-testy`);
+
+    await page.getByRole("button", { name: /Nahrát test/i }).first().click();
+    const dialog = page.getByRole("dialog");
+    await dialog.getByRole("combobox").click();
+    await page.getByRole("option", { name: "Jiný test" }).click();
+    await dialog.getByLabel("Název testu").fill(testName);
+    await dialog.getByLabel("Soubor s výsledky").setInputFiles(TEST_PDF);
+    await dialog.getByRole("button", { name: "Nahrát test" }).click();
+
+    await expect(dialog).toHaveCount(0);
+    await expect(page.getByText(testName)).toBeVisible();
+    await expect(page.getByText("mbti-vysledky.pdf")).toBeVisible();
+  });
+
+  test("editing a test changes its type", async ({ page }) => {
+    const testName = `E2E uprava ${Date.now()}`;
+    await page.goto(`/komunita/profil/${profileId}?tab=osobnostni-testy`);
+
+    await page.getByRole("button", { name: /Nahrát test/i }).first().click();
+    const dialog = page.getByRole("dialog");
+    await dialog.getByRole("combobox").click();
+    await page.getByRole("option", { name: "Jiný test" }).click();
+    await dialog.getByLabel("Název testu").fill(testName);
+    await dialog.getByLabel("Soubor s výsledky").setInputFiles(TEST_PDF);
+    await dialog.getByRole("button", { name: "Nahrát test" }).click();
+    await expect(dialog).toHaveCount(0);
+
+    await page.getByRole("button", { name: "Upravit test" }).click();
+    const editDialog = page.getByRole("dialog");
+    await editDialog.getByRole("combobox").click();
+    await page.getByRole("option", { name: "DISC" }).click();
+    await editDialog.getByRole("button", { name: "Uložit změny" }).click();
+
+    await expect(editDialog).toHaveCount(0);
+    await expect(page.getByText("DISC")).toBeVisible();
+    await expect(page.getByText(testName)).toHaveCount(0);
+  });
+
+  test("deleting a test removes it from the timeline", async ({ page }) => {
+    const testName = `E2E smazat ${Date.now()}`;
+    await page.goto(`/komunita/profil/${profileId}?tab=osobnostni-testy`);
+
+    await uploadCustomTest(page, testName);
+    await expect(page.getByText(testName)).toBeVisible();
+
+    await page.getByRole("button", { name: "Smazat test" }).click();
+    await page.getByRole("button", { name: "Odstranit" }).click();
+
+    await expect(page.getByText(testName)).toHaveCount(0);
+    await expect(page.getByText("Zatím nemáš nahraný žádný osobnostní test")).toBeVisible();
+  });
+});
+
+test.describe("osobnostní testy - two users", () => {
+  let ownerCookie: string;
+  let ownerProfileId: string;
+  let viewerCookie: string;
+
+  test.beforeAll(async () => {
+    const teamId = await createTestTeam();
+    const owner = await getSetupSessionCookie(teamId);
+    const viewer = await getSetupSessionCookie(teamId);
+    ownerCookie = owner.cookie;
+    ownerProfileId = owner.profileId;
+    viewerCookie = viewer.cookie;
+  });
+
+  test.afterAll(async () => {
+    await cleanupTestData();
+  });
+
+  test("another verified user sees the test and can open the file", async ({ context, page }) => {
+    const testName = `E2E sdileni ${Date.now()}`;
+
+    await setAuthCookie(context, ownerCookie);
+    await page.goto(`/komunita/profil/${ownerProfileId}?tab=osobnostni-testy`);
+    await uploadCustomTest(page, testName);
+    await expect(page.getByText(testName)).toBeVisible();
+
+    await context.clearCookies();
+    await setAuthCookie(context, viewerCookie);
+    await page.goto(`/komunita/profil/${ownerProfileId}?tab=osobnostni-testy`);
+
+    await expect(page.getByText(testName)).toBeVisible();
+    await expect(page.getByText("mbti-vysledky.pdf")).toBeVisible();
+
+    const popupPromise = page.waitForEvent("popup");
+    await page.getByRole("link", { name: /Otevřít/ }).click();
+    const popup = await popupPromise;
+    await popup.waitForURL(/\/storage\/v1\/object\/sign\//, { timeout: 15000 });
+  });
+});
+```
+
+Notes:
+- The empty state and the header both render a „Nahrát test" trigger — the helpers always click `.first()` (header) to open the dialog.
+- The popup assertion checks the browser navigates to the signed storage URL (PDF opens in the viewer).
+
+**Step 2: Run and verify**
+
+Run: `pnpm test:e2e personality-tests.spec.ts`
+Expected: PASS (6 tests).
+
+**Step 3: Commit**
+
+```bash
+git add tests/e2e/personality-tests.spec.ts
+git commit -m "test: add E2E tests for personality tests"
+```
+
+---
+
+### Task 11: Final verification
+
+**Step 1: Run the full test suite**
+
+Run: `pnpm test`
+Expected: PASS (unit + component).
+
+Run: `pnpm vitest run --project integration tests/integration/personality-tests.int.test.ts`
+Expected: PASS.
+
+Run: `pnpm typecheck`
+Expected: PASS.
+
+Run: `pnpm lint`
+Expected: PASS.
+
+**Step 2: Manual QA checklist**
+
+- Own profile → Osobnostní testy tab: upload MBTI (PDF), verify it appears on the timeline with today's date, type label and file name.
+- Reload — the entry persists.
+- Edit → change type to DISC and the date; verify the timeline re-sorts if the date changes.
+- Edit → replace the file; verify the old storage object is gone (check the bucket or that the old file name is replaced).
+- Delete → confirm dialog → entry gone, empty state shows.
+- Community (second user): open the same profile, open the file in a new tab, verify PDF renders.
+- Both light and dark theme: timeline line/dots/rings look right.
+- Mobile width: tabs don't overflow, timeline dots sit on the line, action buttons are reachable.
+- `?tab=eseje` and `?tab=osobnostni-testy` deep links select the right tab.
+
+**Step 3: Final commit if anything was touched**
+
+```bash
+git add -A
+git commit -m "chore: final verification fixes"
+```

--- a/docs/plans/2026-08-18-osobnostni-testy-plan.md
+++ b/docs/plans/2026-08-18-osobnostni-testy-plan.md
@@ -85,12 +85,14 @@ export const personalityTests = pgTable("personality_tests", {
     name: "personality_tests_updated_by_profile_id_fkey"
   }).onDelete("restrict"),
   check("personality_tests_other_type_required", sql`(test_type <> 'other' OR (test_type_other IS NOT NULL AND length(trim(test_type_other)) > 0))`),
-  pgPolicy("Verified users can view personality tests", { as: "permissive", for: "select", to: ["authenticated"], using: sql`(removed_at IS NULL) AND (EXISTS (SELECT 1 FROM users WHERE (users.auth_user_id = (SELECT auth.uid()) AND users.verified_work_email IS NOT NULL)))` }),
+  pgPolicy("Verified users can view personality tests", { as: "permissive", for: "select", to: ["authenticated"], using: sql`(EXISTS (SELECT 1 FROM users WHERE (users.auth_user_id = (SELECT auth.uid()) AND users.verified_work_email IS NOT NULL)))` }),
   pgPolicy("Users can create their own personality tests", { as: "permissive", for: "insert", to: ["authenticated"], withCheck: sql`(profile_id = current_profile_id())` }),
   pgPolicy("Users can update their own personality tests", { as: "permissive", for: "update", to: ["authenticated"], using: sql`(profile_id = current_profile_id())`, withCheck: sql`(profile_id = current_profile_id())` }),
   pgPolicy("Users can delete their own personality tests", { as: "permissive", for: "delete", to: ["authenticated"], using: sql`(profile_id = current_profile_id())` }),
 ]).enableRLS()
 ```
+
+Note: the select policy deliberately omits `removed_at IS NULL` — Postgres applies a select policy's `using` as a check on the NEW row during UPDATE, so filtering `removed_at` there would make every soft-delete (`update ... set removed_at = now()`) fail with an RLS error (403). Soft-deleted rows are filtered by the app's queries instead (`listPersonalityTests` does `.is("removed_at", null)`).
 
 **Step 2: Generate the table migration**
 

--- a/docs/plans/2026-08-18-osobnostni-testy-plan.md
+++ b/docs/plans/2026-08-18-osobnostni-testy-plan.md
@@ -481,7 +481,7 @@ export async function POST(request: NextRequest) {
     if (!Number.isFinite(fileSize) || fileSize <= 0 || fileSize > MAX_DOCUMENT_SIZE) {
       return NextResponse.json({ error: "Neplatná velikost souboru" }, { status: 400 });
     }
-    if (!key.startsWith(`personality-tests/${profileId}/`)) {
+    if (!key.startsWith(`personality-test/${profileId}/`)) {
       return NextResponse.json({ error: "Neplatný klíč souboru" }, { status: 400 });
     }
 
@@ -581,7 +581,7 @@ export async function PATCH(request: NextRequest, { params }: { params: Promise<
       return NextResponse.json({ error: "Neplatné datum" }, { status: 400 });
     }
     if (newKey !== undefined) {
-      if (!newKey.startsWith(`personality-tests/${existing.data.profile_id}/`)) {
+      if (!newKey.startsWith(`personality-test/${existing.data.profile_id}/`)) {
         return NextResponse.json({ error: "Neplatný klíč souboru" }, { status: 400 });
       }
       if (!fileName?.trim() || fileName.length > 255) {
@@ -1606,7 +1606,7 @@ async function insertTest(
   const { rows } = await client.query(
     `insert into public.personality_tests
        (profile_id, test_type, test_type_other, tested_on, file_path, file_name, file_size, created_by_profile_id, updated_by_profile_id)
-     values ($1, $2, $3, '2026-03-10', 'personality-tests/p1/x.pdf', 'x.pdf', 1024, $4, $4)
+     values ($1, $2, $3, '2026-03-10', 'personality-test/p1/x.pdf', 'x.pdf', 1024, $4, $4)
      returning id`,
     [profileId, testType, overrides.testTypeOther ?? null, profileId],
   );
@@ -1656,7 +1656,7 @@ describe("personality_tests RLS", () => {
         client.query(
           `insert into public.personality_tests
              (profile_id, test_type, tested_on, file_path, file_name, file_size, created_by_profile_id, updated_by_profile_id)
-           values ($1, 'mbti', '2026-03-10', 'personality-tests/p1/x.pdf', 'x.pdf', 1024, $2, $2)`,
+           values ($1, 'mbti', '2026-03-10', 'personality-test/p1/x.pdf', 'x.pdf', 1024, $2, $2)`,
           [ownerProfileId, otherAuthId],
         ),
       ).rejects.toThrow();
@@ -1719,7 +1719,7 @@ describe("personality_tests RLS", () => {
         client.query(
           `insert into public.personality_tests
              (profile_id, test_type, tested_on, file_path, file_name, file_size, created_by_profile_id, updated_by_profile_id)
-           values ($1, 'other', '2026-03-10', 'personality-tests/p1/x.pdf', 'x.pdf', 1024, $2, $2)`,
+           values ($1, 'other', '2026-03-10', 'personality-test/p1/x.pdf', 'x.pdf', 1024, $2, $2)`,
           [ownerProfileId, ownerAuthId],
         ),
       ).rejects.toThrow();

--- a/src/app/(main)/komunita/profil/[id]/page.tsx
+++ b/src/app/(main)/komunita/profil/[id]/page.tsx
@@ -1,12 +1,13 @@
 import { notFound } from 'next/navigation';
 import Link from 'next/link';
-import { ArrowLeft, Mail, Users, Phone, Cake, BookOpen, Sparkles, Pin } from 'lucide-react';
+import { ArrowLeft, Mail, Users, Phone, Cake, BookOpen, Sparkles, Pin, UserRound, Brain } from 'lucide-react';
 import { createClient } from '@/lib/supabase/server';
 import { getProfileById, getTeamPictureUrl } from '@/lib/komunita/queries';
 import { getCurrentUserProfile } from '@/lib/auth-helpers';
 import { getEssays, getUserBookPointsStats } from '@/lib/essays/queries';
 import { countCustomerMeetings } from '@/lib/customer-meetings/queries';
 import { countIndividualCoachingSessions } from '@/lib/individual-coaching-sessions/queries';
+import { listPersonalityTests } from '@/lib/personality-tests/queries';
 import { ProfilePictureSection } from '@/components/komunita/profile-picture-section';
 import { ProfilePicture } from '@/components/profile-picture';
 import { EssayVoteButton } from '@/components/essays/essay-vote-button';
@@ -14,18 +15,21 @@ import { StorageImage } from '@/components/storage/storage-image';
 import { BookStatusBadges } from '@/components/books/book-status-badges';
 import { Badge } from '@/components/ui/badge';
 import { PageShell } from '@/components/ui/page-shell';
+import { Tabs, TabsContent, TabsList, TabsTrigger, TabsTriggerCount } from '@/components/ui/tabs';
+import { InfoCard } from '@/components/personality-tests/info-card';
+import { PersonalityTestTimeline } from '@/components/personality-tests/personality-test-timeline';
 import { ROLE_LABELS, ROLE_COLORS } from '@/lib/komunita/types';
 import { formatPointsWithLabel, pointsNumber } from '@/lib/books/points';
 import { cn } from '@/lib/utils';
 
 interface PageProps {
   params: Promise<{ id: string }>;
-  searchParams: Promise<{ from?: string }>;
+  searchParams: Promise<{ from?: string; tab?: string }>;
 }
 
 export default async function ProfilePage({ params, searchParams }: PageProps) {
   const { id } = await params;
-  const { from } = await searchParams;
+  const { from, tab } = await searchParams;
   const supabase = await createClient();
 
   const [profile, currentUserProfile] = await Promise.all([
@@ -35,11 +39,12 @@ export default async function ProfilePage({ params, searchParams }: PageProps) {
 
   if (!profile) notFound();
 
-  const [essays, stats, meetingCount, coachingSessionCount] = await Promise.all([
+  const [essays, stats, meetingCount, coachingSessionCount, personalityTests] = await Promise.all([
     getEssays(supabase, { authorProfileId: id, sort: 'best', pageSize: 100 }),
     getUserBookPointsStats(supabase, id),
     countCustomerMeetings(supabase, id).catch(() => 0),
     countIndividualCoachingSessions(supabase, id).catch(() => 0),
+    listPersonalityTests(supabase, id),
   ]);
 
   const votedIds = new Set<string>();
@@ -58,6 +63,7 @@ export default async function ProfilePage({ params, searchParams }: PageProps) {
   const teamPictureUrl = profile.team ? getTeamPictureUrl(supabase, profile.team) : null;
   const isOwnProfile = currentUserProfile?.id === profile.id;
   const teamColor = profile.team?.color ?? null;
+  const activeTab = tab === 'eseje' || tab === 'osobnostni-testy' ? tab : 'prehled';
 
   const pts   = (n: number) => n === 1 ? 'bod' : n >= 2 && n <= 4 ? 'body' : 'bodů';
   const eseje = (n: number) => n === 1 ? 'esej' : n >= 2 && n <= 4 ? 'eseje' : 'esejí';
@@ -118,53 +124,74 @@ export default async function ProfilePage({ params, searchParams }: PageProps) {
           </div>
         </div>
 
-        {/* Stats + contact row */}
-        <div className="flex flex-wrap items-center gap-x-6 gap-y-4 py-4 border-y">
-          {/* Stats */}
-          <div className="flex items-center gap-6">
-            {[
-              { value: stats.approved_points, label: pts(stats.approved_points) },
-              { value: stats.essay_count,    label: eseje(stats.essay_count) },
-              { value: totalVotes,           label: hlasy(totalVotes) },
-              { value: meetingCount,         label: schuzky(meetingCount) },
-              { value: coachingSessionCount, label: koucovaniLabel },
-            ].map(({ value, label }) => (
-              <div key={label} className="text-center">
-                <p className="text-xl font-bold tabular-nums leading-none">{value}</p>
-                <p className="text-xs text-muted-foreground mt-0.5">{label}</p>
+        <Tabs defaultValue={activeTab} className="mt-4">
+          <TabsList>
+            <TabsTrigger value="prehled">
+              <UserRound />
+              Přehled
+            </TabsTrigger>
+            <TabsTrigger value="eseje">
+              <BookOpen />
+              Eseje
+              <TabsTriggerCount count={essays.length} />
+            </TabsTrigger>
+            <TabsTrigger value="osobnostni-testy">
+              <Brain />
+              Osobnostní testy
+              <TabsTriggerCount count={personalityTests.length} />
+            </TabsTrigger>
+          </TabsList>
+
+          {/* Stats + contact */}
+          <TabsContent value="prehled">
+            <div className="flex flex-wrap items-center gap-x-6 gap-y-4 py-4">
+              {/* Stats */}
+              <div className="flex items-center gap-6">
+                {[
+                  { value: stats.approved_points, label: pts(stats.approved_points) },
+                  { value: stats.essay_count,    label: eseje(stats.essay_count) },
+                  { value: totalVotes,           label: hlasy(totalVotes) },
+                  { value: meetingCount,         label: schuzky(meetingCount) },
+                  { value: coachingSessionCount, label: koucovaniLabel },
+                ].map(({ value, label }) => (
+                  <div key={label} className="text-center">
+                    <p className="text-xl font-bold tabular-nums leading-none">{value}</p>
+                    <p className="text-xs text-muted-foreground mt-0.5">{label}</p>
+                  </div>
+                ))}
               </div>
-            ))}
-          </div>
 
-          {/* Divider */}
-          <div className="h-8 w-px bg-border hidden sm:block" />
+              {/* Divider */}
+              <div className="h-8 w-px bg-border hidden sm:block" />
 
-          {/* Contact */}
-          <div className="flex flex-wrap gap-x-5 gap-y-1.5 min-w-0">
-            <a href={`mailto:${profile.work_email}`} className="inline-flex items-center gap-1.5 text-xs text-muted-foreground hover:text-foreground transition-colors min-w-0">
-              <Mail className="size-3.5 shrink-0" /><span className="truncate">{profile.work_email}</span>
-            </a>
-            {profile.personal_email && (
-              <a href={`mailto:${profile.personal_email}`} className="inline-flex items-center gap-1.5 text-xs text-muted-foreground hover:text-foreground transition-colors min-w-0">
-                <Mail className="size-3.5 shrink-0" /><span className="truncate">{profile.personal_email}</span>
-              </a>
-            )}
-            {profile.phone_number && (
-              <a href={`tel:${profile.phone_number}`} className="inline-flex items-center gap-1.5 text-xs text-muted-foreground hover:text-foreground transition-colors">
-                <Phone className="size-3.5" />{profile.phone_number}
-              </a>
-            )}
-            {profile.date_of_birth && (
-              <span className="inline-flex items-center gap-1.5 text-xs text-muted-foreground">
-                <Cake className="size-3.5" />
-                {new Date(profile.date_of_birth).toLocaleDateString('cs-CZ', { day: 'numeric', month: 'long', year: 'numeric' })}
-              </span>
-            )}
-          </div>
-        </div>
+              {/* Contact */}
+              <div className="flex flex-wrap gap-x-5 gap-y-1.5 min-w-0">
+                <a href={`mailto:${profile.work_email}`} className="inline-flex items-center gap-1.5 text-xs text-muted-foreground hover:text-foreground transition-colors min-w-0">
+                  <Mail className="size-3.5 shrink-0" /><span className="truncate">{profile.work_email}</span>
+                </a>
+                {profile.personal_email && (
+                  <a href={`mailto:${profile.personal_email}`} className="inline-flex items-center gap-1.5 text-xs text-muted-foreground hover:text-foreground transition-colors min-w-0">
+                    <Mail className="size-3.5 shrink-0" /><span className="truncate">{profile.personal_email}</span>
+                  </a>
+                )}
+                {profile.phone_number && (
+                  <a href={`tel:${profile.phone_number}`} className="inline-flex items-center gap-1.5 text-xs text-muted-foreground hover:text-foreground transition-colors">
+                    <Phone className="size-3.5" />{profile.phone_number}
+                  </a>
+                )}
+                {profile.date_of_birth && (
+                  <span className="inline-flex items-center gap-1.5 text-xs text-muted-foreground">
+                    <Cake className="size-3.5" />
+                    {new Date(profile.date_of_birth).toLocaleDateString('cs-CZ', { day: 'numeric', month: 'long', year: 'numeric' })}
+                  </span>
+                )}
+              </div>
+            </div>
+          </TabsContent>
 
-        {/* ── Essays ── */}
-        <div className="py-8 space-y-4">
+          {/* Essays */}
+          <TabsContent value="eseje" className="mt-4">
+            <div className="space-y-4">
           <h2 className="font-semibold text-base">
             Eseje
             {essays.length > 0 && <span className="ml-2 font-normal text-muted-foreground text-sm">{essays.length}</span>}
@@ -261,7 +288,19 @@ export default async function ProfilePage({ params, searchParams }: PageProps) {
               )}
             </>
           )}
-        </div>
+            </div>
+          </TabsContent>
+
+          {/* Personality tests */}
+          <TabsContent value="osobnostni-testy" className="mt-4 space-y-4">
+            <InfoCard />
+            <PersonalityTestTimeline
+              initialTests={personalityTests}
+              profileId={profile.id}
+              isOwnProfile={isOwnProfile}
+            />
+          </TabsContent>
+        </Tabs>
       </PageShell>
     </>
   );

--- a/src/app/(main)/komunita/profil/[id]/page.tsx
+++ b/src/app/(main)/komunita/profil/[id]/page.tsx
@@ -44,7 +44,7 @@ export default async function ProfilePage({ params, searchParams }: PageProps) {
     getUserBookPointsStats(supabase, id),
     countCustomerMeetings(supabase, id).catch(() => 0),
     countIndividualCoachingSessions(supabase, id).catch(() => 0),
-    listPersonalityTests(supabase, id),
+    listPersonalityTests(supabase, id).catch(() => []),
   ]);
 
   const votedIds = new Set<string>();

--- a/src/app/api/personality-tests/[id]/open/route.ts
+++ b/src/app/api/personality-tests/[id]/open/route.ts
@@ -1,0 +1,32 @@
+import { NextRequest, NextResponse } from "next/server";
+import { createClient } from "@/lib/supabase/server";
+import { getSignedStorageUrl } from "@/lib/storage/service";
+
+export async function GET(request: NextRequest, { params }: { params: Promise<{ id: string }> }) {
+  try {
+    const { id } = await params;
+    const supabase = await createClient();
+    const { data: { user } } = await supabase.auth.getUser();
+
+    if (!user) {
+      return NextResponse.json({ error: "Neautorizováno" }, { status: 401 });
+    }
+
+    const { data, error } = await supabase
+      .from("personality_tests")
+      .select("file_path")
+      .eq("id", id)
+      .is("removed_at", null)
+      .maybeSingle();
+
+    if (error || !data) {
+      return NextResponse.json({ error: "Test nenalezen" }, { status: 404 });
+    }
+
+    const url = await getSignedStorageUrl("documents", data.file_path);
+    return NextResponse.redirect(url, 307);
+  } catch (error) {
+    console.error("GET /api/personality-tests/[id]/open error:", error);
+    return NextResponse.json({ error: "Nepodařilo se otevřít soubor" }, { status: 500 });
+  }
+}

--- a/src/app/api/personality-tests/[id]/route.ts
+++ b/src/app/api/personality-tests/[id]/route.ts
@@ -1,0 +1,158 @@
+import { NextRequest, NextResponse } from "next/server";
+import { createClient } from "@/lib/supabase/server";
+import { getCurrentUserProfile } from "@/lib/auth-helpers";
+import { deleteFile } from "@/lib/storage/service";
+import { MAX_DOCUMENT_SIZE } from "@/lib/storage/validation";
+import { PERSONALITY_TEST_TYPES } from "@/lib/personality-tests/types";
+import type { Updatable } from "@/lib/supabase/tables";
+
+interface UpdatePersonalityTestRequest {
+  testType?: string;
+  testTypeOther?: string;
+  testedOn?: string;
+  newKey?: string;
+  fileName?: string;
+  fileSize?: number;
+}
+
+const DATE_RE = /^\d{4}-\d{2}-\d{2}$/;
+
+export async function PATCH(request: NextRequest, { params }: { params: Promise<{ id: string }> }) {
+  try {
+    const { id } = await params;
+    const supabase = await createClient();
+    const { data: { user } } = await supabase.auth.getUser();
+
+    if (!user) {
+      return NextResponse.json({ error: "Neautorizováno" }, { status: 401 });
+    }
+
+    const profile = await getCurrentUserProfile(supabase, { user });
+    if (!profile) {
+      return NextResponse.json({ error: "Profil nenalezen" }, { status: 403 });
+    }
+
+    const body: UpdatePersonalityTestRequest = await request.json();
+    const { testType, testTypeOther, testedOn, newKey, fileName, fileSize } = body;
+
+    const existing = await supabase
+      .from("personality_tests")
+      .select("id, profile_id, file_path, removed_at")
+      .eq("id", id)
+      .is("removed_at", null)
+      .maybeSingle();
+
+    if (existing.error || !existing.data) {
+      return NextResponse.json({ error: "Test nenalezen" }, { status: 404 });
+    }
+
+    if (testType !== undefined && !(PERSONALITY_TEST_TYPES as readonly string[]).includes(testType)) {
+      return NextResponse.json({ error: "Neplatný typ testu" }, { status: 400 });
+    }
+    if (testType === "other" && !testTypeOther?.trim()) {
+      return NextResponse.json({ error: "Zadej název testu" }, { status: 400 });
+    }
+    if (testedOn !== undefined && !DATE_RE.test(testedOn)) {
+      return NextResponse.json({ error: "Neplatné datum" }, { status: 400 });
+    }
+    if (newKey !== undefined) {
+      if (!newKey.startsWith(`personality-test/${existing.data.profile_id}/`)) {
+        return NextResponse.json({ error: "Neplatný klíč souboru" }, { status: 400 });
+      }
+      if (!fileName?.trim() || fileName.length > 255) {
+        return NextResponse.json({ error: "Neplatný název souboru" }, { status: 400 });
+      }
+      if (typeof fileSize !== "number" || !Number.isFinite(fileSize) || fileSize <= 0 || fileSize > MAX_DOCUMENT_SIZE) {
+        return NextResponse.json({ error: "Neplatná velikost souboru" }, { status: 400 });
+      }
+    }
+
+    const update: Updatable<"personality_tests"> = { updated_by_profile_id: profile.id };
+    if (testType !== undefined) {
+      update.test_type = testType as Updatable<"personality_tests">["test_type"];
+      update.test_type_other = testType === "other" ? testTypeOther!.trim() : null;
+    }
+    if (testedOn !== undefined) {
+      update.tested_on = testedOn;
+    }
+    if (newKey !== undefined) {
+      update.file_path = newKey;
+      update.file_name = fileName!.trim();
+      update.file_size = fileSize;
+    }
+
+    const { data: updated, error: updateError } = await supabase
+      .from("personality_tests")
+      .update(update)
+      .eq("id", id)
+      .select()
+      .maybeSingle();
+
+    if (updateError || !updated) {
+      return NextResponse.json({ error: "Nepodařilo se uložit změny" }, { status: 403 });
+    }
+
+    if (newKey !== undefined && newKey !== existing.data.file_path) {
+      try {
+        await deleteFile("documents", existing.data.file_path);
+      } catch (error) {
+        console.error("Error deleting old personality test file:", error);
+      }
+    }
+
+    return NextResponse.json({ success: true, data: updated });
+  } catch (error) {
+    console.error("PATCH /api/personality-tests/[id] error:", error);
+    return NextResponse.json({ error: "Nepodařilo se uložit změny" }, { status: 500 });
+  }
+}
+
+export async function DELETE(request: NextRequest, { params }: { params: Promise<{ id: string }> }) {
+  try {
+    const { id } = await params;
+    const supabase = await createClient();
+    const { data: { user } } = await supabase.auth.getUser();
+
+    if (!user) {
+      return NextResponse.json({ error: "Neautorizováno" }, { status: 401 });
+    }
+
+    const profile = await getCurrentUserProfile(supabase, { user });
+    if (!profile) {
+      return NextResponse.json({ error: "Profil nenalezen" }, { status: 403 });
+    }
+
+    const existing = await supabase
+      .from("personality_tests")
+      .select("id, file_path")
+      .eq("id", id)
+      .is("removed_at", null)
+      .maybeSingle();
+
+    if (existing.error || !existing.data) {
+      return NextResponse.json({ error: "Test nenalezen" }, { status: 404 });
+    }
+
+    const { data: removed, error: updateError } = await supabase
+      .from("personality_tests")
+      .update({ removed_at: new Date().toISOString(), updated_by_profile_id: profile.id })
+      .eq("id", id)
+      .select("id")
+      .maybeSingle();
+
+    if (updateError || !removed) {
+      return NextResponse.json({ error: "Nepodařilo se odstranit test" }, { status: 403 });
+    }
+
+    try {
+      await deleteFile("documents", existing.data.file_path);
+    } catch (error) {
+      console.error("Error deleting personality test file:", error);
+    }
+
+    return NextResponse.json({ success: true });
+  } catch (error) {
+    console.error("DELETE /api/personality-tests/[id] error:", error);
+    return NextResponse.json({ error: "Nepodařilo se odstranit test" }, { status: 500 });
+  }
+}

--- a/src/app/api/personality-tests/route.ts
+++ b/src/app/api/personality-tests/route.ts
@@ -1,0 +1,87 @@
+import { NextRequest, NextResponse } from "next/server";
+import { createClient } from "@/lib/supabase/server";
+import { getCurrentUserProfile } from "@/lib/auth-helpers";
+import { MAX_DOCUMENT_SIZE } from "@/lib/storage/validation";
+import { PERSONALITY_TEST_TYPES } from "@/lib/personality-tests/types";
+import type { Insertable } from "@/lib/supabase/tables";
+
+interface CreatePersonalityTestRequest {
+  profileId: string;
+  key: string;
+  testType: string;
+  testTypeOther?: string;
+  testedOn: string;
+  fileName: string;
+  fileSize: number;
+}
+
+const DATE_RE = /^\d{4}-\d{2}-\d{2}$/;
+
+export async function POST(request: NextRequest) {
+  try {
+    const supabase = await createClient();
+    const { data: { user } } = await supabase.auth.getUser();
+
+    if (!user) {
+      return NextResponse.json({ error: "Neautorizováno" }, { status: 401 });
+    }
+
+    const profile = await getCurrentUserProfile(supabase, { user });
+    if (!profile) {
+      return NextResponse.json({ error: "Profil nenalezen" }, { status: 403 });
+    }
+
+    const body: CreatePersonalityTestRequest = await request.json();
+    const { profileId, key, testType, testTypeOther, testedOn, fileName, fileSize } = body;
+
+    if (profileId !== profile.id) {
+      return NextResponse.json({ error: "Nemůžeš nahrát test pro jinou osobu" }, { status: 403 });
+    }
+    if (!(PERSONALITY_TEST_TYPES as readonly string[]).includes(testType)) {
+      return NextResponse.json({ error: "Neplatný typ testu" }, { status: 400 });
+    }
+    if (testType === "other" && !testTypeOther?.trim()) {
+      return NextResponse.json({ error: "Zadej název testu" }, { status: 400 });
+    }
+    if (!DATE_RE.test(testedOn)) {
+      return NextResponse.json({ error: "Neplatné datum" }, { status: 400 });
+    }
+    if (!fileName?.trim() || fileName.length > 255) {
+      return NextResponse.json({ error: "Neplatný název souboru" }, { status: 400 });
+    }
+    if (!Number.isFinite(fileSize) || fileSize <= 0 || fileSize > MAX_DOCUMENT_SIZE) {
+      return NextResponse.json({ error: "Neplatná velikost souboru" }, { status: 400 });
+    }
+    if (!key.startsWith(`personality-test/${profileId}/`)) {
+      return NextResponse.json({ error: "Neplatný klíč souboru" }, { status: 400 });
+    }
+
+    const payload: Insertable<"personality_tests"> = {
+      profile_id: profileId,
+      test_type: testType as Insertable<"personality_tests">["test_type"],
+      test_type_other: testType === "other" ? testTypeOther!.trim() : null,
+      tested_on: testedOn,
+      file_path: key,
+      file_name: fileName.trim(),
+      file_size: fileSize,
+      created_by_profile_id: profile.id,
+      updated_by_profile_id: profile.id,
+    };
+
+    const { data, error } = await supabase
+      .from("personality_tests")
+      .insert(payload)
+      .select()
+      .single();
+
+    if (error) {
+      console.error("POST /api/personality-tests insert error:", error);
+      return NextResponse.json({ error: "Nepodařilo se uložit test" }, { status: 500 });
+    }
+
+    return NextResponse.json({ success: true, data });
+  } catch (error) {
+    console.error("POST /api/personality-tests error:", error);
+    return NextResponse.json({ error: "Nepodařilo se uložit test" }, { status: 500 });
+  }
+}

--- a/src/app/api/storage/presign-upload/route.ts
+++ b/src/app/api/storage/presign-upload/route.ts
@@ -12,6 +12,7 @@ import { getCurrentUserProfile } from "@/lib/auth-helpers";
 import { generatePresignedUpload } from "@/lib/storage/service";
 import {
   validateImageUpload,
+  validatePersonalityTestUpload,
   getFileExtension,
 } from "@/lib/storage/validation";
 import type { StorageContext } from "@/lib/storage/types";
@@ -46,7 +47,10 @@ export async function POST(request: NextRequest) {
     }
 
     // Validate file type and size
-    const validationError = validateImageUpload(contentType, fileSize);
+    const validationError =
+      context === "personality-test"
+        ? validatePersonalityTestUpload(contentType, fileSize)
+        : validateImageUpload(contentType, fileSize);
     if (validationError) {
       return NextResponse.json(
         { error: validationError.message },
@@ -64,7 +68,15 @@ export async function POST(request: NextRequest) {
     }
 
     // Authorization checks
-    if (context === "profile") {
+    if (context === "personality-test") {
+      // Users can only upload to their own profile
+      if (entityId !== profile.id) {
+        return NextResponse.json(
+          { error: "Nemůžeš nahrát soubor pro jinou osobu" },
+          { status: 403 }
+        );
+      }
+    } else if (context === "profile") {
       // Users can only upload to their own profile
       if (entityId !== profile.id) {
         return NextResponse.json(

--- a/src/components/app-sidebar.tsx
+++ b/src/components/app-sidebar.tsx
@@ -2,7 +2,7 @@
 
 import * as React from "react"
 import Link from "next/link"
-import { usePathname } from "next/navigation"
+import { usePathname, useSearchParams } from "next/navigation"
 import {
   LayoutDashboard,
   CalendarDays,
@@ -17,6 +17,7 @@ import {
   NotebookPen,
   Activity,
   Wrench,
+  Brain,
 } from "lucide-react"
 
 import { cn } from "@/lib/utils"
@@ -109,6 +110,11 @@ const getNavData = (isDevelopment: boolean, _isCoachOrAdmin: boolean, _reviewCou
           icon: Wrench,
         },
         {
+          title: "Osobnostní testy",
+          url: "/komunita/profil",
+          icon: Brain,
+        },
+        {
           title: "Čtení",
           url: "/cteni/prehled",
           icon: BookOpen,
@@ -152,6 +158,7 @@ interface AppSidebarProps extends React.ComponentProps<typeof Sidebar> {
 
 function AppSidebarContent({ user, reviewCount = 0 }: { user?: AppSidebarProps["user"]; reviewCount?: number }) {
   const pathname = usePathname()
+  const searchParams = useSearchParams()
   const { setOpenMobile } = useSidebar()
   const isCoachOrAdmin = user?.role === "coach" || user?.role === "admin"
   const isBeta = user?.beta_access ?? false
@@ -363,6 +370,38 @@ function AppSidebarContent({ user, reviewCount = 0 }: { user?: AppSidebarProps["
                           tooltip={item.title}
                         >
                           <Link href={item.url} onClick={closeSidebarOnMobile}>
+                            <item.icon className="size-4" />
+                            <span>{item.title}</span>
+                            <Badge
+                              variant="secondary"
+                              className="ml-auto h-5 text-[10px] px-1.5"
+                            >
+                              Beta
+                            </Badge>
+                          </Link>
+                        </SidebarMenuButton>
+                      </SidebarMenuItem>
+                    )
+                  }
+
+                  // Osobnostní testy — own profile tests tab, beta-only
+                  if (item.title === "Osobnostní testy") {
+                    if (!isBeta || !user) return null
+
+                    return (
+                      <SidebarMenuItem key={item.title}>
+                        <SidebarMenuButton
+                          asChild
+                          isActive={
+                            pathname.startsWith("/komunita/profil/") &&
+                            searchParams.get("tab") === "osobnostni-testy"
+                          }
+                          tooltip={item.title}
+                        >
+                          <Link
+                            href={`/komunita/profil/${user.id}?tab=osobnostni-testy`}
+                            onClick={closeSidebarOnMobile}
+                          >
                             <item.icon className="size-4" />
                             <span>{item.title}</span>
                             <Badge

--- a/src/components/personality-tests/info-card.tsx
+++ b/src/components/personality-tests/info-card.tsx
@@ -1,0 +1,20 @@
+import { Info } from "lucide-react"
+
+export function InfoCard() {
+  return (
+    <div className="flex gap-2 rounded-lg border border-border/50 bg-muted/30 p-3 text-xs leading-relaxed text-muted-foreground">
+      <Info className="mt-0.5 size-4 shrink-0 text-muted-foreground/50" />
+      <div className="space-y-1">
+        <p>
+          <strong>Osobnostní test</strong> slouží k hodnocení a pochopení charakterových rysů,
+          chování a preferencí téček. Pomáhá identifikovat silné a slabé stránky, motivace
+          a způsob interakce s okolím.
+        </p>
+        <p>
+          Osobnostní test si každé téčko dělá v 1. semestru. Následně ho zkonzultuje
+          s některým z koučů. Slouží jako podklad pro Learning contract.
+        </p>
+      </div>
+    </div>
+  )
+}

--- a/src/components/personality-tests/personality-test-form.tsx
+++ b/src/components/personality-tests/personality-test-form.tsx
@@ -155,9 +155,9 @@ export function PersonalityTestForm({ profileId, initial, onSuccess, onCancel }:
       )}
 
       <div className="space-y-2">
-        <Label>Typ testu</Label>
+        <Label htmlFor="test-type">Typ testu</Label>
         <Select value={testType} onValueChange={setTestType}>
-          <SelectTrigger className="w-full">
+          <SelectTrigger id="test-type" className="w-full">
             <SelectValue placeholder="Vyberte typ testu" />
           </SelectTrigger>
           <SelectContent>
@@ -203,7 +203,7 @@ export function PersonalityTestForm({ profileId, initial, onSuccess, onCancel }:
         <p className="text-xs text-muted-foreground">
           {initial?.file_name
             ? `Aktuální soubor: ${initial.file_name} — nový soubor ho nahradí.`
-            : "PDF, PNG, JPEG nebo WebP · max 20 MB"}
+            : `PDF, PNG, JPEG nebo WebP · max ${MAX_DOCUMENT_SIZE / 1024 / 1024} MB`}
         </p>
       </div>
 

--- a/src/components/personality-tests/personality-test-form.tsx
+++ b/src/components/personality-tests/personality-test-form.tsx
@@ -1,0 +1,221 @@
+"use client"
+
+import { useState } from "react"
+import { Loader2 } from "lucide-react"
+import { Button } from "@/components/ui/button"
+import { Input } from "@/components/ui/input"
+import { Label } from "@/components/ui/label"
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select"
+import { toast } from "sonner"
+import { ALLOWED_DOCUMENT_TYPES, MAX_DOCUMENT_SIZE } from "@/lib/storage/validation"
+import type { PersonalityTest } from "@/lib/personality-tests/types"
+import { PERSONALITY_TEST_TYPES, PERSONALITY_TEST_TYPE_LABELS } from "@/lib/personality-tests/types"
+
+function today(): string {
+  const now = new Date()
+  return `${now.getFullYear()}-${String(now.getMonth() + 1).padStart(2, "0")}-${String(now.getDate()).padStart(2, "0")}`
+}
+
+interface PersonalityTestFormProps {
+  profileId: string
+  initial?: PersonalityTest
+  onSuccess: (test: PersonalityTest) => void
+  onCancel: () => void
+}
+
+export function PersonalityTestForm({ profileId, initial, onSuccess, onCancel }: PersonalityTestFormProps) {
+  const [loading, setLoading] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+  const [testType, setTestType] = useState<string>(initial?.test_type ?? "")
+  const [testTypeOther, setTestTypeOther] = useState(initial?.test_type_other ?? "")
+  const [testedOn, setTestedOn] = useState(initial?.tested_on ?? today())
+  const [file, setFile] = useState<File | null>(null)
+
+  async function handleSubmit(e: React.FormEvent) {
+    e.preventDefault()
+    setError(null)
+
+    if (!(PERSONALITY_TEST_TYPES as readonly string[]).includes(testType)) {
+      setError("Vyberte typ testu.")
+      return
+    }
+    if (testType === "other" && !testTypeOther.trim()) {
+      setError("Zadejte název testu.")
+      return
+    }
+    if (!testedOn) {
+      setError("Zadejte datum testu.")
+      return
+    }
+    if (!initial && !file) {
+      setError("Nahrajte soubor s výsledky.")
+      return
+    }
+    if (file && !(ALLOWED_DOCUMENT_TYPES as readonly string[]).includes(file.type)) {
+      setError("Povolené formáty: PDF, PNG, JPEG, WebP.")
+      return
+    }
+    if (file && file.size > MAX_DOCUMENT_SIZE) {
+      setError(`Maximální velikost souboru je ${MAX_DOCUMENT_SIZE / 1024 / 1024}MB.`)
+      return
+    }
+
+    setLoading(true)
+    try {
+      let newKey: string | null = null
+      let fileName: string | null = null
+      let fileSize: number | null = null
+
+      if (file) {
+        const presignRes = await fetch("/api/storage/presign-upload", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({
+            context: "personality-test",
+            entityId: profileId,
+            contentType: file.type,
+            fileSize: file.size,
+          }),
+        })
+        const presignJson = await presignRes.json()
+        if (!presignRes.ok || !presignJson.data) {
+          throw new Error(presignJson.error ?? "Nepodařilo se připravit nahrávání")
+        }
+        const { url, key } = presignJson.data as { url: string; key: string }
+
+        const putRes = await fetch(url, {
+          method: "PUT",
+          headers: { "Content-Type": file.type },
+          body: file,
+        })
+        if (!putRes.ok) throw new Error("Nepodařilo se nahrát soubor")
+
+        newKey = key
+        fileName = file.name
+        fileSize = file.size
+      }
+
+      let result: PersonalityTest
+      if (initial?.id) {
+        const patchRes = await fetch(`/api/personality-tests/${initial.id}`, {
+          method: "PATCH",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({
+            testType,
+            testTypeOther: testType === "other" ? testTypeOther.trim() : null,
+            testedOn,
+            ...(newKey ? { newKey, fileName, fileSize } : {}),
+          }),
+        })
+        const patchJson = await patchRes.json()
+        if (!patchRes.ok) throw new Error(patchJson.error ?? "Nepodařilo se uložit změny")
+        result = patchJson.data as PersonalityTest
+        toast.success("Test aktualizován")
+      } else {
+        const createRes = await fetch("/api/personality-tests", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({
+            profileId,
+            key: newKey!,
+            testType,
+            testTypeOther: testType === "other" ? testTypeOther.trim() : null,
+            testedOn,
+            fileName,
+            fileSize,
+          }),
+        })
+        const createJson = await createRes.json()
+        if (!createRes.ok) throw new Error(createJson.error ?? "Nepodařilo se uložit test")
+        result = createJson.data as PersonalityTest
+        toast.success("Test nahrán")
+      }
+
+      onSuccess(result)
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Neznámá chyba")
+      toast.error("Nepodařilo se uložit test")
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  return (
+    <form onSubmit={handleSubmit} className="space-y-4">
+      {error && (
+        <div className="rounded-md bg-destructive/10 p-3 text-sm text-destructive">
+          {error}
+        </div>
+      )}
+
+      <div className="space-y-2">
+        <Label>Typ testu</Label>
+        <Select value={testType} onValueChange={setTestType}>
+          <SelectTrigger className="w-full">
+            <SelectValue placeholder="Vyberte typ testu" />
+          </SelectTrigger>
+          <SelectContent>
+            {PERSONALITY_TEST_TYPES.map((type) => (
+              <SelectItem key={type} value={type}>
+                {PERSONALITY_TEST_TYPE_LABELS[type]}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+      </div>
+
+      {testType === "other" && (
+        <div className="space-y-2">
+          <Label htmlFor="test-type-other">Název testu</Label>
+          <Input
+            id="test-type-other"
+            value={testTypeOther}
+            onChange={(e) => setTestTypeOther(e.target.value)}
+            placeholder="Např. Hogan Assessment"
+          />
+        </div>
+      )}
+
+      <div className="space-y-2">
+        <Label htmlFor="tested-on">Datum testu</Label>
+        <Input
+          id="tested-on"
+          type="date"
+          value={testedOn}
+          onChange={(e) => setTestedOn(e.target.value)}
+        />
+      </div>
+
+      <div className="space-y-2">
+        <Label htmlFor="test-file">Soubor s výsledky</Label>
+        <Input
+          id="test-file"
+          type="file"
+          accept=".pdf,image/png,image/jpeg,image/webp"
+          onChange={(e) => setFile(e.target.files?.[0] ?? null)}
+        />
+        <p className="text-xs text-muted-foreground">
+          {initial?.file_name
+            ? `Aktuální soubor: ${initial.file_name} — nový soubor ho nahradí.`
+            : "PDF, PNG, JPEG nebo WebP · max 20 MB"}
+        </p>
+      </div>
+
+      <div className="flex items-center justify-end gap-2">
+        <Button type="button" variant="outline" onClick={onCancel} disabled={loading}>
+          Zrušit
+        </Button>
+        <Button type="submit" disabled={loading}>
+          {loading && <Loader2 className="size-4 animate-spin" />}
+          {initial?.id ? "Uložit změny" : "Nahrát test"}
+        </Button>
+      </div>
+    </form>
+  )
+}

--- a/src/components/personality-tests/personality-test-timeline.test.tsx
+++ b/src/components/personality-tests/personality-test-timeline.test.tsx
@@ -18,7 +18,7 @@ function testRow(overrides: Partial<PersonalityTest> = {}): PersonalityTest {
     test_type: 'mbti',
     test_type_other: null,
     tested_on: '2026-03-15',
-    file_path: 'personality-tests/test-1/report.pdf',
+    file_path: 'personality-test/test-1/report.pdf',
     file_name: 'mbti-report.pdf',
     file_size: 1_500_000,
     created_at: '2026-03-16T10:00:00Z',

--- a/src/components/personality-tests/personality-test-timeline.test.tsx
+++ b/src/components/personality-tests/personality-test-timeline.test.tsx
@@ -1,0 +1,144 @@
+import { describe, expect, it, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { PersonalityTestTimeline } from '@/components/personality-tests/personality-test-timeline';
+import type { PersonalityTest } from '@/lib/personality-tests/types';
+
+const { error, success } = vi.hoisted(() => ({
+  error: vi.fn(),
+  success: vi.fn(),
+}));
+
+vi.mock('sonner', () => ({ toast: { error, success } }));
+
+function testRow(overrides: Partial<PersonalityTest> = {}): PersonalityTest {
+  return {
+    id: 'test-1',
+    profile_id: 'profile-1',
+    test_type: 'mbti',
+    test_type_other: null,
+    tested_on: '2026-03-15',
+    file_path: 'personality-tests/test-1/report.pdf',
+    file_name: 'mbti-report.pdf',
+    file_size: 1_500_000,
+    created_at: '2026-03-16T10:00:00Z',
+    updated_at: '2026-03-16T10:00:00Z',
+    created_by_profile_id: 'profile-1',
+    updated_by_profile_id: 'profile-1',
+    removed_at: null,
+    ...overrides,
+  };
+}
+
+const fetchMock = vi.fn();
+
+beforeEach(() => {
+  vi.stubGlobal('fetch', fetchMock);
+  fetchMock.mockReset();
+  error.mockReset();
+  success.mockReset();
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe('PersonalityTestTimeline', () => {
+  it('renders the owner empty state with the upload CTA and no viewer copy', () => {
+    render(<PersonalityTestTimeline initialTests={[]} profileId="profile-1" isOwnProfile />);
+
+    expect(screen.getByText('Zatím nemáš nahraný žádný osobnostní test')).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        'Nahraj výsledky svého osobnostního testu jako soubor PDF nebo obrázek. Timeline ukáže, jak se v průběhu studia vyvíjíš.',
+      ),
+    ).toBeInTheDocument();
+    expect(screen.getAllByRole('button', { name: 'Nahrát test' }).length).toBeGreaterThan(0);
+    expect(screen.queryByText('Zatím žádné osobnostní testy')).not.toBeInTheDocument();
+    expect(screen.queryByText('Tato osoba zatím nenahrála žádné osobnostní testy.')).not.toBeInTheDocument();
+  });
+
+  it('renders the viewer empty state without any action buttons', () => {
+    render(<PersonalityTestTimeline initialTests={[]} profileId="profile-1" isOwnProfile={false} />);
+
+    expect(screen.getByText('Zatím žádné osobnostní testy')).toBeInTheDocument();
+    expect(screen.getByText('Tato osoba zatím nenahrála žádné osobnostní testy.')).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: 'Nahrát test' })).not.toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: 'Upravit test' })).not.toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: 'Smazat test' })).not.toBeInTheDocument();
+  });
+
+  it('lists tests newest first with type, date, file name and size; owner gets full actions', () => {
+    const newest = testRow({ id: 'test-2', test_type: 'mbti' });
+    const older = testRow({ id: 'test-1', test_type: 'gallup', tested_on: '2025-11-02' });
+    render(
+      <PersonalityTestTimeline initialTests={[older, newest]} profileId="profile-1" isOwnProfile />,
+    );
+
+    const items = screen.getAllByRole('listitem');
+    expect(items).toHaveLength(2);
+
+    const first = items[0].textContent ?? '';
+    expect(first).toContain('MBTI');
+    expect(first).toContain('15. 3. 2026');
+    expect(first).toContain('mbti-report.pdf');
+    expect(first).toContain('1,4 MB');
+    expect(items[1].textContent).toContain('Gallup');
+    expect(items[1].textContent).toContain('2. 11. 2025');
+
+    expect(screen.getAllByRole('link', { name: 'Otevřít' })).toHaveLength(2);
+    expect(screen.getAllByRole('button', { name: 'Upravit test' })).toHaveLength(2);
+    expect(screen.getAllByRole('button', { name: 'Smazat test' })).toHaveLength(2);
+  });
+
+  it('gives a viewer only the open link', () => {
+    render(<PersonalityTestTimeline initialTests={[testRow()]} profileId="profile-1" isOwnProfile={false} />);
+
+    expect(screen.getByRole('link', { name: 'Otevřít' })).toHaveAttribute(
+      'href',
+      '/api/personality-tests/test-1/open',
+    );
+    expect(screen.queryByRole('button', { name: 'Upravit test' })).not.toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: 'Smazat test' })).not.toBeInTheDocument();
+  });
+
+  it('deletes a test after confirming and removes it from the timeline', async () => {
+    const row = testRow();
+    fetchMock.mockResolvedValue({ ok: true, json: async () => ({ success: true }) });
+    const user = userEvent.setup();
+    render(<PersonalityTestTimeline initialTests={[row]} profileId="profile-1" isOwnProfile />);
+
+    await user.click(screen.getByRole('button', { name: 'Smazat test' }));
+    expect(screen.getByText('Odstranit test?')).toBeInTheDocument();
+
+    await user.click(screen.getByRole('button', { name: 'Odstranit' }));
+
+    await waitFor(() =>
+      expect(fetchMock).toHaveBeenCalledWith(`/api/personality-tests/${row.id}`, { method: 'DELETE' }),
+    );
+    await waitFor(() => expect(success).toHaveBeenCalledWith('Test odstraněn'));
+    await waitFor(() => expect(screen.queryByRole('listitem')).not.toBeInTheDocument());
+    await waitFor(() => expect(screen.queryByText('Odstranit test?')).not.toBeInTheDocument());
+  });
+
+  it('keeps the dialog open and the test listed when deletion fails', async () => {
+    const row = testRow();
+    fetchMock.mockResolvedValue({
+      ok: false,
+      json: async () => ({ error: 'Nepodařilo se odstranit test' }),
+    });
+    const user = userEvent.setup();
+    render(<PersonalityTestTimeline initialTests={[row]} profileId="profile-1" isOwnProfile />);
+
+    await user.click(screen.getByRole('button', { name: 'Smazat test' }));
+    expect(screen.getByText('Odstranit test?')).toBeInTheDocument();
+
+    await user.click(screen.getByRole('button', { name: 'Odstranit' }));
+
+    await waitFor(() => expect(error).toHaveBeenCalledWith('Nepodařilo se odstranit test'));
+    expect(screen.getByText('Odstranit test?')).toBeInTheDocument();
+    // Radix marks DOM outside the open modal dialog aria-hidden, which hides it
+    // from role queries but not text queries — the test is still there.
+    expect(screen.getByText(/mbti-report\.pdf/)).toBeInTheDocument();
+  });
+});

--- a/src/components/personality-tests/personality-test-timeline.tsx
+++ b/src/components/personality-tests/personality-test-timeline.tsx
@@ -217,7 +217,7 @@ export function PersonalityTestTimeline({ initialTests, profileId, isOwnProfile 
       <AlertDialog
         open={deleting !== null}
         onOpenChange={(open) => {
-          if (!open) setDeleting(null)
+          if (!open && deletingId === null) setDeleting(null)
         }}
       >
         <AlertDialogContent>

--- a/src/components/personality-tests/personality-test-timeline.tsx
+++ b/src/components/personality-tests/personality-test-timeline.tsx
@@ -235,7 +235,10 @@ export function PersonalityTestTimeline({ initialTests, profileId, isOwnProfile 
           <AlertDialogFooter>
             <AlertDialogCancel disabled={deletingId !== null}>Zrušit</AlertDialogCancel>
             <AlertDialogAction
-              onClick={handleDelete}
+              onClick={(e) => {
+                e.preventDefault()
+                void handleDelete()
+              }}
               disabled={deletingId !== null}
               className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
             >

--- a/src/components/personality-tests/personality-test-timeline.tsx
+++ b/src/components/personality-tests/personality-test-timeline.tsx
@@ -19,7 +19,7 @@ import {
   AlertDialogFooter,
   AlertDialogHeader,
   AlertDialogTitle,
-} from "@/components/ui/alert-dialog"
+} from "@/components/ui/responsive-alert-dialog"
 import {
   Empty,
   EmptyMedia,

--- a/src/components/personality-tests/personality-test-timeline.tsx
+++ b/src/components/personality-tests/personality-test-timeline.tsx
@@ -1,0 +1,250 @@
+"use client"
+
+import { useMemo, useState } from "react"
+import { ExternalLink, FileText, Loader2, Pencil, Trash2, Upload } from "lucide-react"
+import { Button } from "@/components/ui/button"
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from "@/components/ui/responsive-dialog"
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from "@/components/ui/alert-dialog"
+import {
+  Empty,
+  EmptyMedia,
+  EmptyHeader,
+  EmptyTitle,
+  EmptyDescription,
+  EmptyContent,
+} from "@/components/ui/empty"
+import { toast } from "sonner"
+import { PersonalityTestForm } from "./personality-test-form"
+import { formatFileSize, formatTestDate } from "@/lib/personality-tests/format"
+import { getTestTypeLabel } from "@/lib/personality-tests/types"
+import type { PersonalityTest } from "@/lib/personality-tests/types"
+
+interface PersonalityTestTimelineProps {
+  initialTests: PersonalityTest[]
+  profileId: string
+  isOwnProfile: boolean
+}
+
+export function PersonalityTestTimeline({ initialTests, profileId, isOwnProfile }: PersonalityTestTimelineProps) {
+  const [items, setItems] = useState(initialTests)
+  const [createOpen, setCreateOpen] = useState(false)
+  const [editing, setEditing] = useState<PersonalityTest | null>(null)
+  const [deleting, setDeleting] = useState<PersonalityTest | null>(null)
+  const [deletingId, setDeletingId] = useState<string | null>(null)
+
+  const sorted = useMemo(
+    () => [...items].sort((a, b) => b.tested_on.localeCompare(a.tested_on)),
+    [items],
+  )
+
+  function handleCreated(test: PersonalityTest) {
+    setItems((prev) => [...prev, test])
+    setCreateOpen(false)
+  }
+
+  function handleUpdated(test: PersonalityTest) {
+    setItems((prev) => prev.map((t) => (t.id === test.id ? test : t)))
+    setEditing(null)
+  }
+
+  async function handleDelete() {
+    if (!deleting) return
+    setDeletingId(deleting.id)
+    try {
+      const res = await fetch(`/api/personality-tests/${deleting.id}`, { method: "DELETE" })
+      const json = await res.json()
+      if (!res.ok) throw new Error(json.error ?? "Nepodařilo se odstranit test")
+      setItems((prev) => prev.filter((t) => t.id !== deleting.id))
+      toast.success("Test odstraněn")
+      setDeleting(null)
+    } catch (err) {
+      toast.error(err instanceof Error ? err.message : "Nepodařilo se odstranit test")
+    } finally {
+      setDeletingId(null)
+    }
+  }
+
+  return (
+    <div className="space-y-4 sm:space-y-6">
+      {isOwnProfile && (
+        <div className="flex items-center justify-end">
+          <Dialog open={createOpen} onOpenChange={setCreateOpen}>
+            <DialogTrigger asChild>
+              <Button size="sm">
+                <Upload className="size-4" />
+                Nahrát test
+              </Button>
+            </DialogTrigger>
+            <DialogContent className="sm:max-w-lg">
+              <DialogHeader>
+                <DialogTitle>Nový osobnostní test</DialogTitle>
+              </DialogHeader>
+              <PersonalityTestForm
+                profileId={profileId}
+                onSuccess={handleCreated}
+                onCancel={() => setCreateOpen(false)}
+              />
+            </DialogContent>
+          </Dialog>
+        </div>
+      )}
+
+      {sorted.length === 0 ? (
+        <Empty>
+          <EmptyMedia variant="icon">
+            <FileText className="size-6" />
+          </EmptyMedia>
+          <EmptyHeader>
+            <EmptyTitle>
+              {isOwnProfile ? "Zatím nemáš nahraný žádný osobnostní test" : "Zatím žádné osobnostní testy"}
+            </EmptyTitle>
+            <EmptyDescription>
+              {isOwnProfile
+                ? "Nahraj výsledky svého osobnostního testu jako soubor PDF nebo obrázek. Timeline ukáže, jak se v průběhu studia vyvíjíš."
+                : "Tato osoba zatím nenahrála žádné osobnostní testy."}
+            </EmptyDescription>
+          </EmptyHeader>
+          {isOwnProfile && (
+            <EmptyContent>
+              <Button size="sm" onClick={() => setCreateOpen(true)}>
+                <Upload className="size-4" />
+                Nahrát test
+              </Button>
+            </EmptyContent>
+          )}
+        </Empty>
+      ) : (
+        <ol className="space-y-6">
+          {sorted.map((test, index) => (
+            <li key={test.id} className="relative pl-6 sm:pl-8">
+              {index < sorted.length - 1 && (
+                <span
+                  aria-hidden
+                  className="absolute left-0 top-5 bottom-[-32px] w-px bg-border"
+                />
+              )}
+              <span
+                aria-hidden
+                className="absolute left-0 top-2 size-3 -translate-x-1/2 rounded-full bg-primary ring-4 ring-background"
+              />
+              <div className="flex items-center gap-3 rounded-xl border bg-card px-3.5 py-3">
+                <div className="flex size-10 shrink-0 items-center justify-center rounded-lg bg-primary/10 text-primary">
+                  <FileText className="size-5" />
+                </div>
+                <div className="min-w-0 flex-1">
+                  <p className="truncate text-sm font-semibold">{getTestTypeLabel(test)}</p>
+                  <p className="truncate text-xs text-muted-foreground">
+                    {formatTestDate(test.tested_on)} · {test.file_name} · {formatFileSize(test.file_size)}
+                  </p>
+                </div>
+                <div className="flex shrink-0 items-center gap-1">
+                  <Button asChild variant="outline" size="sm">
+                    <a
+                      href={`/api/personality-tests/${test.id}/open`}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                    >
+                      <ExternalLink className="size-3.5" />
+                      <span className="sr-only sm:not-sr-only sm:inline">Otevřít</span>
+                    </a>
+                  </Button>
+                  {isOwnProfile && (
+                    <>
+                      <Button
+                        variant="outline"
+                        size="sm"
+                        aria-label="Upravit test"
+                        onClick={() => setEditing(test)}
+                      >
+                        <Pencil className="size-4" />
+                        <span className="sr-only sm:not-sr-only sm:inline">Upravit</span>
+                      </Button>
+                      <Button
+                        variant="outline"
+                        size="sm"
+                        className="text-destructive"
+                        aria-label="Smazat test"
+                        onClick={() => setDeleting(test)}
+                      >
+                        <Trash2 className="size-4" />
+                        <span className="sr-only sm:not-sr-only sm:inline">Smazat</span>
+                      </Button>
+                    </>
+                  )}
+                </div>
+              </div>
+            </li>
+          ))}
+        </ol>
+      )}
+
+      <Dialog
+        open={editing !== null}
+        onOpenChange={(open) => {
+          if (!open) setEditing(null)
+        }}
+      >
+        <DialogContent className="sm:max-w-lg">
+          <DialogHeader>
+            <DialogTitle>Upravit test</DialogTitle>
+          </DialogHeader>
+          {editing && (
+            <PersonalityTestForm
+              profileId={profileId}
+              initial={editing}
+              onSuccess={handleUpdated}
+              onCancel={() => setEditing(null)}
+            />
+          )}
+        </DialogContent>
+      </Dialog>
+
+      <AlertDialog
+        open={deleting !== null}
+        onOpenChange={(open) => {
+          if (!open) setDeleting(null)
+        }}
+      >
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>Odstranit test?</AlertDialogTitle>
+            <AlertDialogDescription>
+              {deleting && (
+                <>
+                  Test <strong>{getTestTypeLabel(deleting)}</strong> ({formatTestDate(deleting.tested_on)}){" "}
+                  odebereš ze svého profilu. Nahraný soubor bude smazán.
+                </>
+              )}
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel disabled={deletingId !== null}>Zrušit</AlertDialogCancel>
+            <AlertDialogAction
+              onClick={handleDelete}
+              disabled={deletingId !== null}
+              className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
+            >
+              {deletingId !== null && <Loader2 className="size-4 animate-spin" />}
+              Odstranit
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+    </div>
+  )
+}

--- a/src/lib/personality-tests/format.test.ts
+++ b/src/lib/personality-tests/format.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from "vitest"
+import { formatTestDate, formatFileSize } from "./format"
+import { getTestTypeLabel } from "./types"
+
+describe("personality test format helpers", () => {
+  it("formats a date as day. month. year", () => {
+    expect(formatTestDate("2026-03-12")).toBe("12. 3. 2026")
+  })
+
+  it("formats file sizes in B, KB and MB with a Czech decimal comma", () => {
+    expect(formatFileSize(512)).toBe("512 B")
+    expect(formatFileSize(2048)).toBe("2 KB")
+    expect(formatFileSize(2 * 1024 * 1024 + 512 * 1024)).toBe("2,5 MB")
+  })
+})
+
+describe("personality test type labels", () => {
+  it("labels known types from the enum", () => {
+    expect(getTestTypeLabel({ test_type: "mbti", test_type_other: null })).toBe("MBTI")
+    expect(getTestTypeLabel({ test_type: "disc", test_type_other: null })).toBe("DISC")
+  })
+
+  it("uses the custom name for other", () => {
+    expect(
+      getTestTypeLabel({ test_type: "other", test_type_other: "Hogan Assessment" }),
+    ).toBe("Hogan Assessment")
+  })
+})

--- a/src/lib/personality-tests/format.ts
+++ b/src/lib/personality-tests/format.ts
@@ -1,0 +1,10 @@
+export function formatTestDate(dateStr: string): string {
+  const [year, month, day] = dateStr.split("-")
+  return `${Number(day)}. ${Number(month)}. ${year}`
+}
+
+export function formatFileSize(bytes: number): string {
+  if (bytes < 1024) return `${bytes} B`
+  if (bytes < 1024 * 1024) return `${Math.round(bytes / 1024)} KB`
+  return `${(bytes / 1024 / 1024).toFixed(1).replace(".", ",")} MB`
+}

--- a/src/lib/personality-tests/queries.ts
+++ b/src/lib/personality-tests/queries.ts
@@ -1,0 +1,18 @@
+import type { SupabaseClient } from "@supabase/supabase-js"
+import type { Database } from "@/lib/supabase/database.types"
+import type { PersonalityTest } from "./types"
+
+export async function listPersonalityTests(
+  supabase: SupabaseClient<Database>,
+  profileId: string,
+): Promise<PersonalityTest[]> {
+  const { data, error } = await supabase
+    .from("personality_tests")
+    .select("*")
+    .is("removed_at", null)
+    .eq("profile_id", profileId)
+    .order("tested_on", { ascending: false })
+
+  if (error) throw error
+  return (data ?? []) as PersonalityTest[]
+}

--- a/src/lib/personality-tests/types.ts
+++ b/src/lib/personality-tests/types.ts
@@ -1,0 +1,33 @@
+import type { Tables } from "@/lib/supabase/tables"
+
+export type PersonalityTest = Tables<"personality_tests">
+
+export const PERSONALITY_TEST_TYPES = [
+  "gallup",
+  "mbti",
+  "disc",
+  "big_five",
+  "enneagram",
+  "belbin",
+  "other",
+] as const
+
+export type PersonalityTestType = (typeof PERSONALITY_TEST_TYPES)[number]
+
+export const PERSONALITY_TEST_TYPE_LABELS: Record<PersonalityTestType, string> = {
+  gallup: "Gallup",
+  mbti: "MBTI",
+  disc: "DISC",
+  big_five: "Big Five",
+  enneagram: "Enneagram",
+  belbin: "Belbin",
+  other: "Jiný test",
+}
+
+export function getTestTypeLabel(
+  test: Pick<PersonalityTest, "test_type" | "test_type_other">,
+): string {
+  return test.test_type === "other"
+    ? test.test_type_other ?? PERSONALITY_TEST_TYPE_LABELS.other
+    : PERSONALITY_TEST_TYPE_LABELS[test.test_type]
+}

--- a/src/lib/storage/authorization.ts
+++ b/src/lib/storage/authorization.ts
@@ -13,6 +13,13 @@ export function authorizeAction(
   entityId: string,
   profile: AuthProfile,
 ): string | null {
+  if (context === "personality-test") {
+    if (entityId !== profile.id) {
+      return "Nemůžeš nahrát soubor pro jinou osobu";
+    }
+    return null;
+  }
+
   if (context === "profile") {
     if (entityId !== profile.id) {
       return "Nemáš oprávnění provést tuto akci";

--- a/src/lib/storage/buckets.ts
+++ b/src/lib/storage/buckets.ts
@@ -37,5 +37,7 @@ export function contextToBucket(context: StorageContext): BucketId {
       return "avatars";
     case "book":
       return "images";
+    case "personality-test":
+      return "documents";
   }
 }

--- a/src/lib/storage/types.ts
+++ b/src/lib/storage/types.ts
@@ -2,7 +2,7 @@
  * Storage Types for Supabase Storage S3 Integration
  */
 
-export type StorageContext = "profile" | "team" | "book";
+export type StorageContext = "profile" | "team" | "book" | "personality-test";
 
 export interface UploadOptions {
   context: StorageContext;

--- a/src/lib/storage/validation.test.ts
+++ b/src/lib/storage/validation.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from "vitest"
+import {
+  ALLOWED_DOCUMENT_TYPES,
+  MAX_DOCUMENT_SIZE,
+  validatePersonalityTestUpload,
+} from "./validation"
+
+describe("validatePersonalityTestUpload", () => {
+  it("accepts PDF and common image types within the size limit", () => {
+    for (const type of ALLOWED_DOCUMENT_TYPES) {
+      expect(validatePersonalityTestUpload(type, MAX_DOCUMENT_SIZE)).toBeNull()
+    }
+  })
+
+  it("rejects unsupported content types", () => {
+    expect(validatePersonalityTestUpload("application/zip", 1024)).toMatchObject({
+      field: "contentType",
+    })
+  })
+
+  it("rejects files over the size limit", () => {
+    expect(validatePersonalityTestUpload("application/pdf", MAX_DOCUMENT_SIZE + 1)).toMatchObject({
+      field: "fileSize",
+    })
+  })
+})

--- a/src/lib/storage/validation.ts
+++ b/src/lib/storage/validation.ts
@@ -15,6 +15,16 @@ export const MAX_FILE_SIZE = 10 * 1024 * 1024; // 10MB
 // Typically 50-200KB depending on image complexity
 export const EXPECTED_OPTIMIZED_SIZE = 200 * 1024; // 200KB
 
+export const ALLOWED_DOCUMENT_TYPES = [
+  "application/pdf",
+  "image/png",
+  "image/jpeg",
+  "image/webp",
+] as const;
+
+// Max size for personality test uploads (PDF reports with graphics)
+export const MAX_DOCUMENT_SIZE = 20 * 1024 * 1024; // 20MB
+
 export interface ValidationError {
   field: string;
   message: string;
@@ -45,6 +55,30 @@ export function validateImageUpload(
 }
 
 /**
+ * Validate personality test upload constraints
+ */
+export function validatePersonalityTestUpload(
+  contentType: string,
+  fileSize: number
+): ValidationError | null {
+  if (!(ALLOWED_DOCUMENT_TYPES as readonly string[]).includes(contentType)) {
+    return {
+      field: "contentType",
+      message: "Povolené formáty: PDF, PNG, JPEG, WebP",
+    };
+  }
+
+  if (fileSize > MAX_DOCUMENT_SIZE) {
+    return {
+      field: "fileSize",
+      message: `Maximální velikost souboru je ${MAX_DOCUMENT_SIZE / 1024 / 1024}MB`,
+    };
+  }
+
+  return null;
+}
+
+/**
  * Get file extension from MIME type
  */
 export function getFileExtension(contentType: string): string {
@@ -52,6 +86,7 @@ export function getFileExtension(contentType: string): string {
     "image/jpeg": "jpg",
     "image/png": "png",
     "image/webp": "webp",
+    "application/pdf": "pdf",
   };
   return map[contentType] || "jpg";
 }

--- a/src/lib/supabase/database.types.ts
+++ b/src/lib/supabase/database.types.ts
@@ -1035,6 +1035,76 @@ export type Database = {
           },
         ]
       }
+      personality_tests: {
+        Row: {
+          created_at: string
+          created_by_profile_id: string
+          file_name: string
+          file_path: string
+          file_size: number
+          id: string
+          profile_id: string
+          removed_at: string | null
+          test_type: Database["public"]["Enums"]["personality_test_type"]
+          test_type_other: string | null
+          tested_on: string
+          updated_at: string
+          updated_by_profile_id: string
+        }
+        Insert: {
+          created_at?: string
+          created_by_profile_id: string
+          file_name: string
+          file_path: string
+          file_size: number
+          id?: string
+          profile_id: string
+          removed_at?: string | null
+          test_type: Database["public"]["Enums"]["personality_test_type"]
+          test_type_other?: string | null
+          tested_on: string
+          updated_at?: string
+          updated_by_profile_id: string
+        }
+        Update: {
+          created_at?: string
+          created_by_profile_id?: string
+          file_name?: string
+          file_path?: string
+          file_size?: number
+          id?: string
+          profile_id?: string
+          removed_at?: string | null
+          test_type?: Database["public"]["Enums"]["personality_test_type"]
+          test_type_other?: string | null
+          tested_on?: string
+          updated_at?: string
+          updated_by_profile_id?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "personality_tests_created_by_profile_id_fkey"
+            columns: ["created_by_profile_id"]
+            isOneToOne: false
+            referencedRelation: "profiles"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "personality_tests_profile_id_fkey"
+            columns: ["profile_id"]
+            isOneToOne: false
+            referencedRelation: "profiles"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "personality_tests_updated_by_profile_id_fkey"
+            columns: ["updated_by_profile_id"]
+            isOneToOne: false
+            referencedRelation: "profiles"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
       profiles: {
         Row: {
           access_removed_at: string | null
@@ -1935,6 +2005,14 @@ export type Database = {
     Enums: {
       book_list_status: "processing" | "shortlist" | "longlist" | "archived"
       book_source: "manual" | "google_books" | "open_library"
+      personality_test_type:
+        | "gallup"
+        | "mbti"
+        | "disc"
+        | "big_five"
+        | "enneagram"
+        | "belbin"
+        | "other"
       profile_role: "student" | "mentor" | "coach" | "admin"
       schedule_type: "training_session" | "houston_calling"
       semester_reflection_topic:
@@ -2079,6 +2157,15 @@ export const Constants = {
     Enums: {
       book_list_status: ["processing", "shortlist", "longlist", "archived"],
       book_source: ["manual", "google_books", "open_library"],
+      personality_test_type: [
+        "gallup",
+        "mbti",
+        "disc",
+        "big_five",
+        "enneagram",
+        "belbin",
+        "other",
+      ],
       profile_role: ["student", "mentor", "coach", "admin"],
       schedule_type: ["training_session", "houston_calling"],
       semester_reflection_topic: [

--- a/supabase/migrations/20260818181631_broad_angel.sql
+++ b/supabase/migrations/20260818181631_broad_angel.sql
@@ -1,0 +1,27 @@
+CREATE TYPE "public"."personality_test_type" AS ENUM('gallup', 'mbti', 'disc', 'big_five', 'enneagram', 'belbin', 'other');--> statement-breakpoint
+CREATE TABLE "personality_tests" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"profile_id" uuid NOT NULL,
+	"test_type" "personality_test_type" NOT NULL,
+	"test_type_other" text,
+	"tested_on" date NOT NULL,
+	"file_path" text NOT NULL,
+	"file_name" text NOT NULL,
+	"file_size" integer NOT NULL,
+	"removed_at" timestamp with time zone,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"updated_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"created_by_profile_id" uuid NOT NULL,
+	"updated_by_profile_id" uuid NOT NULL,
+	CONSTRAINT "personality_tests_other_type_required" CHECK ((test_type <> 'other' OR (test_type_other IS NOT NULL AND length(trim(test_type_other)) > 0)))
+);
+--> statement-breakpoint
+ALTER TABLE "personality_tests" ENABLE ROW LEVEL SECURITY;--> statement-breakpoint
+ALTER TABLE "personality_tests" ADD CONSTRAINT "personality_tests_profile_id_fkey" FOREIGN KEY ("profile_id") REFERENCES "public"."profiles"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "personality_tests" ADD CONSTRAINT "personality_tests_created_by_profile_id_fkey" FOREIGN KEY ("created_by_profile_id") REFERENCES "public"."profiles"("id") ON DELETE restrict ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "personality_tests" ADD CONSTRAINT "personality_tests_updated_by_profile_id_fkey" FOREIGN KEY ("updated_by_profile_id") REFERENCES "public"."profiles"("id") ON DELETE restrict ON UPDATE no action;--> statement-breakpoint
+CREATE INDEX "personality_tests_profile_tested_on_idx" ON "personality_tests" USING btree ("profile_id" uuid_ops,"tested_on" date_ops);--> statement-breakpoint
+CREATE POLICY "Verified users can view personality tests" ON "personality_tests" AS PERMISSIVE FOR SELECT TO "authenticated" USING ((removed_at IS NULL) AND (EXISTS (SELECT 1 FROM users WHERE (users.auth_user_id = (SELECT auth.uid()) AND users.verified_work_email IS NOT NULL))));--> statement-breakpoint
+CREATE POLICY "Users can create their own personality tests" ON "personality_tests" AS PERMISSIVE FOR INSERT TO "authenticated" WITH CHECK ((profile_id = current_profile_id()));--> statement-breakpoint
+CREATE POLICY "Users can update their own personality tests" ON "personality_tests" AS PERMISSIVE FOR UPDATE TO "authenticated" USING ((profile_id = current_profile_id())) WITH CHECK ((profile_id = current_profile_id()));--> statement-breakpoint
+CREATE POLICY "Users can delete their own personality tests" ON "personality_tests" AS PERMISSIVE FOR DELETE TO "authenticated" USING ((profile_id = current_profile_id()));

--- a/supabase/migrations/20260818181637_lazy_preak.sql
+++ b/supabase/migrations/20260818181637_lazy_preak.sql
@@ -1,0 +1,12 @@
+-- Custom SQL migration file, put your code below! --
+
+-- Migration: updated_at trigger for personality_tests.
+-- Mirrors the team_activities trigger (20260818075419_wealthy_bloodscream.sql):
+-- without it, updated_at never changes on UPDATE.
+
+drop trigger if exists personality_tests_updated_at_trigger on public.personality_tests;
+
+create trigger personality_tests_updated_at_trigger
+before update on public.personality_tests
+for each row
+execute function public.handle_updated_at();

--- a/supabase/migrations/20260818191117_gorgeous_cammi.sql
+++ b/supabase/migrations/20260818191117_gorgeous_cammi.sql
@@ -1,0 +1,1 @@
+ALTER POLICY "Verified users can view personality tests" ON "personality_tests" TO authenticated USING ((EXISTS (SELECT 1 FROM users WHERE (users.auth_user_id = (SELECT auth.uid()) AND users.verified_work_email IS NOT NULL))));

--- a/supabase/migrations/meta/20260818181631_snapshot.json
+++ b/supabase/migrations/meta/20260818181631_snapshot.json
@@ -1,0 +1,5831 @@
+{
+  "id": "30f83aae-8ffe-4311-80a9-3fbc4700454b",
+  "prevId": "b20c3f2e-cb28-4f6b-ba44-67db97ae5544",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.book_loans": {
+      "name": "book_loans",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "library_book_id": {
+          "name": "library_book_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "borrower_id": {
+          "name": "borrower_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "borrowed_at": {
+          "name": "borrowed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "due_at": {
+          "name": "due_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "returned_at": {
+          "name": "returned_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "book_loans_library_book_id_idx": {
+          "name": "book_loans_library_book_id_idx",
+          "columns": [
+            {
+              "expression": "library_book_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "uuid_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "book_loans_borrower_id_idx": {
+          "name": "book_loans_borrower_id_idx",
+          "columns": [
+            {
+              "expression": "borrower_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "uuid_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "book_loans_active_idx": {
+          "name": "book_loans_active_idx",
+          "columns": [
+            {
+              "expression": "library_book_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "uuid_ops"
+            }
+          ],
+          "isUnique": false,
+          "where": "(returned_at IS NULL)",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "book_loans_library_book_id_fkey": {
+          "name": "book_loans_library_book_id_fkey",
+          "tableFrom": "book_loans",
+          "tableTo": "library_books",
+          "columnsFrom": [
+            "library_book_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "book_loans_borrower_id_fkey": {
+          "name": "book_loans_borrower_id_fkey",
+          "tableFrom": "book_loans",
+          "tableTo": "profiles",
+          "columnsFrom": [
+            "borrower_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {
+        "Authenticated users can view loans": {
+          "name": "Authenticated users can view loans",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": [
+            "authenticated"
+          ],
+          "using": "true"
+        },
+        "Users can borrow for themselves": {
+          "name": "Users can borrow for themselves",
+          "as": "PERMISSIVE",
+          "for": "INSERT",
+          "to": [
+            "authenticated"
+          ],
+          "withCheck": "(borrower_id = current_profile_id())"
+        },
+        "Borrower can return their own loan": {
+          "name": "Borrower can return their own loan",
+          "as": "PERMISSIVE",
+          "for": "UPDATE",
+          "to": [
+            "authenticated"
+          ],
+          "using": "(borrower_id = current_profile_id())",
+          "withCheck": "(borrower_id = current_profile_id())"
+        }
+      },
+      "checkConstraints": {},
+      "isRLSEnabled": true
+    },
+    "public.book_tags": {
+      "name": "book_tags",
+      "schema": "",
+      "columns": {
+        "book_id": {
+          "name": "book_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tag_id": {
+          "name": "tag_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_by_profile_id": {
+          "name": "created_by_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_by_profile_id": {
+          "name": "updated_by_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "book_tags_tag_idx": {
+          "name": "book_tags_tag_idx",
+          "columns": [
+            {
+              "expression": "tag_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "uuid_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "book_tags_book_id_fkey": {
+          "name": "book_tags_book_id_fkey",
+          "tableFrom": "book_tags",
+          "tableTo": "books",
+          "columnsFrom": [
+            "book_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "book_tags_tag_id_fkey": {
+          "name": "book_tags_tag_id_fkey",
+          "tableFrom": "book_tags",
+          "tableTo": "tags",
+          "columnsFrom": [
+            "tag_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "book_tags_created_by_profile_id_fkey": {
+          "name": "book_tags_created_by_profile_id_fkey",
+          "tableFrom": "book_tags",
+          "tableTo": "profiles",
+          "columnsFrom": [
+            "created_by_profile_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "book_tags_updated_by_profile_id_fkey": {
+          "name": "book_tags_updated_by_profile_id_fkey",
+          "tableFrom": "book_tags",
+          "tableTo": "profiles",
+          "columnsFrom": [
+            "updated_by_profile_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "book_tags_pkey": {
+          "name": "book_tags_pkey",
+          "columns": [
+            "book_id",
+            "tag_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {
+        "Authenticated users can view book tags": {
+          "name": "Authenticated users can view book tags",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": [
+            "authenticated"
+          ],
+          "using": "true"
+        },
+        "Authenticated users can assign book tags": {
+          "name": "Authenticated users can assign book tags",
+          "as": "PERMISSIVE",
+          "for": "INSERT",
+          "to": [
+            "authenticated"
+          ],
+          "withCheck": "(created_by_profile_id = current_profile_id())"
+        },
+        "Coaches and admins can update book tags": {
+          "name": "Coaches and admins can update book tags",
+          "as": "PERMISSIVE",
+          "for": "UPDATE",
+          "to": [
+            "authenticated"
+          ],
+          "using": "is_coach_or_admin()",
+          "withCheck": "is_coach_or_admin()"
+        },
+        "Coaches and admins can remove book tags": {
+          "name": "Coaches and admins can remove book tags",
+          "as": "PERMISSIVE",
+          "for": "DELETE",
+          "to": [
+            "authenticated"
+          ],
+          "using": "is_coach_or_admin()"
+        }
+      },
+      "checkConstraints": {},
+      "isRLSEnabled": true
+    },
+    "public.books": {
+      "name": "books",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "title_cs": {
+          "name": "title_cs",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title_en": {
+          "name": "title_en",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "author": {
+          "name": "author",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "isbn_13": {
+          "name": "isbn_13",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "google_books_cover_url": {
+          "name": "google_books_cover_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "book_points": {
+          "name": "book_points",
+          "type": "numeric(3, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "page_count": {
+          "name": "page_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "preview_link": {
+          "name": "preview_link",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source": {
+          "name": "source",
+          "type": "book_source",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'manual'"
+        },
+        "external_id": {
+          "name": "external_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "list_status": {
+          "name": "list_status",
+          "type": "book_list_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'processing'"
+        },
+        "list_status_changed_at": {
+          "name": "list_status_changed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "list_status_changed_by_profile_id": {
+          "name": "list_status_changed_by_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "list_status_reason": {
+          "name": "list_status_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "highlight_category_id": {
+          "name": "highlight_category_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_rocket_model": {
+          "name": "is_rocket_model",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_by_profile_id": {
+          "name": "created_by_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_by_profile_id": {
+          "name": "updated_by_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "books_created_by_idx": {
+          "name": "books_created_by_idx",
+          "columns": [
+            {
+              "expression": "created_by_profile_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "uuid_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "books_author_trgm_idx": {
+          "name": "books_author_trgm_idx",
+          "columns": [
+            {
+              "expression": "author",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "gin_trgm_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        },
+        "books_created_desc_idx": {
+          "name": "books_created_desc_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "first",
+              "opclass": "timestamptz_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "books_isbn_13_idx": {
+          "name": "books_isbn_13_idx",
+          "columns": [
+            {
+              "expression": "isbn_13",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "text_ops"
+            }
+          ],
+          "isUnique": false,
+          "where": "(isbn_13 IS NOT NULL)",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "books_list_status_idx": {
+          "name": "books_list_status_idx",
+          "columns": [
+            {
+              "expression": "list_status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "enum_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "books_title_cs_trgm_idx": {
+          "name": "books_title_cs_trgm_idx",
+          "columns": [
+            {
+              "expression": "title_cs",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "gin_trgm_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "books_created_by_profile_id_fkey": {
+          "name": "books_created_by_profile_id_fkey",
+          "tableFrom": "books",
+          "tableTo": "profiles",
+          "columnsFrom": [
+            "created_by_profile_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "books_updated_by_profile_id_fkey": {
+          "name": "books_updated_by_profile_id_fkey",
+          "tableFrom": "books",
+          "tableTo": "profiles",
+          "columnsFrom": [
+            "updated_by_profile_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "books_list_status_changed_by_profile_id_fkey": {
+          "name": "books_list_status_changed_by_profile_id_fkey",
+          "tableFrom": "books",
+          "tableTo": "profiles",
+          "columnsFrom": [
+            "list_status_changed_by_profile_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "books_highlight_category_id_fkey": {
+          "name": "books_highlight_category_id_fkey",
+          "tableFrom": "books",
+          "tableTo": "highlight_categories",
+          "columnsFrom": [
+            "highlight_category_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {
+        "Coaches and admins can delete books": {
+          "name": "Coaches and admins can delete books",
+          "as": "PERMISSIVE",
+          "for": "DELETE",
+          "to": [
+            "public"
+          ],
+          "using": "is_coach_or_admin()"
+        },
+        "Coaches and admins can update books": {
+          "name": "Coaches and admins can update books",
+          "as": "PERMISSIVE",
+          "for": "UPDATE",
+          "to": [
+            "authenticated"
+          ],
+          "using": "is_coach_or_admin()",
+          "withCheck": "is_coach_or_admin()"
+        },
+        "Authenticated users can add books": {
+          "name": "Authenticated users can add books",
+          "as": "PERMISSIVE",
+          "for": "INSERT",
+          "to": [
+            "authenticated"
+          ],
+          "withCheck": "(created_by_profile_id = current_profile_id())"
+        },
+        "Authenticated users can view all books": {
+          "name": "Authenticated users can view all books",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": [
+            "authenticated"
+          ],
+          "using": "true"
+        }
+      },
+      "checkConstraints": {
+        "books_book_points_check": {
+          "name": "books_book_points_check",
+          "value": "(book_points IS NULL) OR ((book_points >= (0)::numeric) AND (book_points <= (3)::numeric))"
+        },
+        "books_archived_points_check": {
+          "name": "books_archived_points_check",
+          "value": "(list_status <> 'archived') OR (book_points = (0)::numeric)"
+        }
+      },
+      "isRLSEnabled": true
+    },
+    "public.highlight_categories": {
+      "name": "highlight_categories",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_by_profile_id": {
+          "name": "created_by_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_by_profile_id": {
+          "name": "updated_by_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "highlight_categories_created_by_profile_id_fkey": {
+          "name": "highlight_categories_created_by_profile_id_fkey",
+          "tableFrom": "highlight_categories",
+          "tableTo": "profiles",
+          "columnsFrom": [
+            "created_by_profile_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "highlight_categories_updated_by_profile_id_fkey": {
+          "name": "highlight_categories_updated_by_profile_id_fkey",
+          "tableFrom": "highlight_categories",
+          "tableTo": "profiles",
+          "columnsFrom": [
+            "updated_by_profile_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {
+        "Authenticated users can view highlight categories": {
+          "name": "Authenticated users can view highlight categories",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": [
+            "authenticated"
+          ],
+          "using": "true"
+        },
+        "Coaches and admins can add highlight categories": {
+          "name": "Coaches and admins can add highlight categories",
+          "as": "PERMISSIVE",
+          "for": "INSERT",
+          "to": [
+            "authenticated"
+          ],
+          "withCheck": "is_coach_or_admin()"
+        },
+        "Coaches and admins can update highlight categories": {
+          "name": "Coaches and admins can update highlight categories",
+          "as": "PERMISSIVE",
+          "for": "UPDATE",
+          "to": [
+            "authenticated"
+          ],
+          "using": "is_coach_or_admin()",
+          "withCheck": "is_coach_or_admin()"
+        },
+        "Coaches and admins can delete highlight categories": {
+          "name": "Coaches and admins can delete highlight categories",
+          "as": "PERMISSIVE",
+          "for": "DELETE",
+          "to": [
+            "authenticated"
+          ],
+          "using": "is_coach_or_admin()"
+        }
+      },
+      "checkConstraints": {},
+      "isRLSEnabled": true
+    },
+    "public.library_books": {
+      "name": "library_books",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "book_id": {
+          "name": "book_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "isbn_13": {
+          "name": "isbn_13",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_by_profile_id": {
+          "name": "created_by_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_by_profile_id": {
+          "name": "updated_by_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "library_books_book_id_idx": {
+          "name": "library_books_book_id_idx",
+          "columns": [
+            {
+              "expression": "book_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "uuid_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "library_books_isbn_13_idx": {
+          "name": "library_books_isbn_13_idx",
+          "columns": [
+            {
+              "expression": "isbn_13",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "text_ops"
+            }
+          ],
+          "isUnique": false,
+          "where": "(isbn_13 IS NOT NULL)",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "library_books_book_id_fkey": {
+          "name": "library_books_book_id_fkey",
+          "tableFrom": "library_books",
+          "tableTo": "books",
+          "columnsFrom": [
+            "book_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "library_books_created_by_profile_id_fkey": {
+          "name": "library_books_created_by_profile_id_fkey",
+          "tableFrom": "library_books",
+          "tableTo": "profiles",
+          "columnsFrom": [
+            "created_by_profile_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "library_books_updated_by_profile_id_fkey": {
+          "name": "library_books_updated_by_profile_id_fkey",
+          "tableFrom": "library_books",
+          "tableTo": "profiles",
+          "columnsFrom": [
+            "updated_by_profile_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {
+        "Authenticated users can view library books": {
+          "name": "Authenticated users can view library books",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": [
+            "authenticated"
+          ],
+          "using": "true"
+        },
+        "Coaches and admins can add library books": {
+          "name": "Coaches and admins can add library books",
+          "as": "PERMISSIVE",
+          "for": "INSERT",
+          "to": [
+            "authenticated"
+          ],
+          "withCheck": "is_coach_or_admin()"
+        },
+        "Coaches and admins can update library books": {
+          "name": "Coaches and admins can update library books",
+          "as": "PERMISSIVE",
+          "for": "UPDATE",
+          "to": [
+            "authenticated"
+          ],
+          "using": "is_coach_or_admin()",
+          "withCheck": "is_coach_or_admin()"
+        },
+        "Coaches and admins can delete library books": {
+          "name": "Coaches and admins can delete library books",
+          "as": "PERMISSIVE",
+          "for": "DELETE",
+          "to": [
+            "authenticated"
+          ],
+          "using": "is_coach_or_admin()"
+        }
+      },
+      "checkConstraints": {},
+      "isRLSEnabled": true
+    },
+    "public.tags": {
+      "name": "tags",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_by_profile_id": {
+          "name": "created_by_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_by_profile_id": {
+          "name": "updated_by_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "tags_created_by_profile_id_fkey": {
+          "name": "tags_created_by_profile_id_fkey",
+          "tableFrom": "tags",
+          "tableTo": "profiles",
+          "columnsFrom": [
+            "created_by_profile_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "tags_updated_by_profile_id_fkey": {
+          "name": "tags_updated_by_profile_id_fkey",
+          "tableFrom": "tags",
+          "tableTo": "profiles",
+          "columnsFrom": [
+            "updated_by_profile_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "tags_name_key": {
+          "name": "tags_name_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "name"
+          ]
+        }
+      },
+      "policies": {
+        "Authenticated users can view tags": {
+          "name": "Authenticated users can view tags",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": [
+            "authenticated"
+          ],
+          "using": "true"
+        },
+        "Coaches and admins can add tags": {
+          "name": "Coaches and admins can add tags",
+          "as": "PERMISSIVE",
+          "for": "INSERT",
+          "to": [
+            "authenticated"
+          ],
+          "withCheck": "is_coach_or_admin()"
+        },
+        "Coaches and admins can update tags": {
+          "name": "Coaches and admins can update tags",
+          "as": "PERMISSIVE",
+          "for": "UPDATE",
+          "to": [
+            "authenticated"
+          ],
+          "using": "is_coach_or_admin()",
+          "withCheck": "is_coach_or_admin()"
+        },
+        "Coaches and admins can delete tags": {
+          "name": "Coaches and admins can delete tags",
+          "as": "PERMISSIVE",
+          "for": "DELETE",
+          "to": [
+            "authenticated"
+          ],
+          "using": "is_coach_or_admin()"
+        }
+      },
+      "checkConstraints": {},
+      "isRLSEnabled": true
+    },
+    "public.customer_meetings": {
+      "name": "customer_meetings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "profile_id": {
+          "name": "profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "meeting_at": {
+          "name": "meeting_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "company": {
+          "name": "company",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "contact_person": {
+          "name": "contact_person",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "position": {
+          "name": "position",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "objective": {
+          "name": "objective",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "post_mortem": {
+          "name": "post_mortem",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "team_share": {
+          "name": "team_share",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "removed_at": {
+          "name": "removed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_by_profile_id": {
+          "name": "created_by_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_by_profile_id": {
+          "name": "updated_by_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "customer_meetings_profile_idx": {
+          "name": "customer_meetings_profile_idx",
+          "columns": [
+            {
+              "expression": "profile_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "uuid_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "customer_meetings_created_desc_idx": {
+          "name": "customer_meetings_created_desc_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "first",
+              "opclass": "timestamptz_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "customer_meetings_profile_id_fkey": {
+          "name": "customer_meetings_profile_id_fkey",
+          "tableFrom": "customer_meetings",
+          "tableTo": "profiles",
+          "columnsFrom": [
+            "profile_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "customer_meetings_created_by_profile_id_fkey": {
+          "name": "customer_meetings_created_by_profile_id_fkey",
+          "tableFrom": "customer_meetings",
+          "tableTo": "profiles",
+          "columnsFrom": [
+            "created_by_profile_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "customer_meetings_updated_by_profile_id_fkey": {
+          "name": "customer_meetings_updated_by_profile_id_fkey",
+          "tableFrom": "customer_meetings",
+          "tableTo": "profiles",
+          "columnsFrom": [
+            "updated_by_profile_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {
+        "Users can view their own customer meetings": {
+          "name": "Users can view their own customer meetings",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": [
+            "authenticated"
+          ],
+          "using": "(profile_id = current_profile_id())"
+        },
+        "Users can create their own customer meetings": {
+          "name": "Users can create their own customer meetings",
+          "as": "PERMISSIVE",
+          "for": "INSERT",
+          "to": [
+            "authenticated"
+          ],
+          "withCheck": "(profile_id = current_profile_id())"
+        },
+        "Users can update their own customer meetings": {
+          "name": "Users can update their own customer meetings",
+          "as": "PERMISSIVE",
+          "for": "UPDATE",
+          "to": [
+            "authenticated"
+          ],
+          "using": "(profile_id = current_profile_id())",
+          "withCheck": "(profile_id = current_profile_id())"
+        },
+        "Users can delete their own customer meetings": {
+          "name": "Users can delete their own customer meetings",
+          "as": "PERMISSIVE",
+          "for": "DELETE",
+          "to": [
+            "authenticated"
+          ],
+          "using": "(profile_id = current_profile_id())"
+        }
+      },
+      "checkConstraints": {},
+      "isRLSEnabled": true
+    },
+    "public.dashboard_layouts": {
+      "name": "dashboard_layouts",
+      "schema": "",
+      "columns": {
+        "profile_id": {
+          "name": "profile_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "widgets": {
+          "name": "widgets",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_by_profile_id": {
+          "name": "created_by_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_by_profile_id": {
+          "name": "updated_by_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "dashboard_layouts_profile_id_fkey": {
+          "name": "dashboard_layouts_profile_id_fkey",
+          "tableFrom": "dashboard_layouts",
+          "tableTo": "profiles",
+          "columnsFrom": [
+            "profile_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "dashboard_layouts_created_by_profile_id_fkey": {
+          "name": "dashboard_layouts_created_by_profile_id_fkey",
+          "tableFrom": "dashboard_layouts",
+          "tableTo": "profiles",
+          "columnsFrom": [
+            "created_by_profile_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "dashboard_layouts_updated_by_profile_id_fkey": {
+          "name": "dashboard_layouts_updated_by_profile_id_fkey",
+          "tableFrom": "dashboard_layouts",
+          "tableTo": "profiles",
+          "columnsFrom": [
+            "updated_by_profile_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {
+        "Users can delete their own dashboard layout": {
+          "name": "Users can delete their own dashboard layout",
+          "as": "PERMISSIVE",
+          "for": "DELETE",
+          "to": [
+            "public"
+          ],
+          "using": "(profile_id = current_profile_id())"
+        },
+        "Users can update their own dashboard layout": {
+          "name": "Users can update their own dashboard layout",
+          "as": "PERMISSIVE",
+          "for": "UPDATE",
+          "to": [
+            "public"
+          ],
+          "using": "(profile_id = current_profile_id())",
+          "withCheck": "(profile_id = current_profile_id())"
+        },
+        "Users can insert their own dashboard layout": {
+          "name": "Users can insert their own dashboard layout",
+          "as": "PERMISSIVE",
+          "for": "INSERT",
+          "to": [
+            "public"
+          ],
+          "withCheck": "(profile_id = current_profile_id())"
+        },
+        "Users can view their own dashboard layout": {
+          "name": "Users can view their own dashboard layout",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": [
+            "public"
+          ],
+          "using": "(profile_id = current_profile_id())"
+        }
+      },
+      "checkConstraints": {},
+      "isRLSEnabled": true
+    },
+    "public.essay_coach_reads": {
+      "name": "essay_coach_reads",
+      "schema": "",
+      "columns": {
+        "essay_id": {
+          "name": "essay_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "coach_profile_id": {
+          "name": "coach_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "read_at": {
+          "name": "read_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_by_profile_id": {
+          "name": "created_by_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_by_profile_id": {
+          "name": "updated_by_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "essay_coach_reads_coach_idx": {
+          "name": "essay_coach_reads_coach_idx",
+          "columns": [
+            {
+              "expression": "coach_profile_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "uuid_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "essay_coach_reads_essay_id_fkey": {
+          "name": "essay_coach_reads_essay_id_fkey",
+          "tableFrom": "essay_coach_reads",
+          "tableTo": "essays",
+          "columnsFrom": [
+            "essay_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "essay_coach_reads_coach_profile_id_fkey": {
+          "name": "essay_coach_reads_coach_profile_id_fkey",
+          "tableFrom": "essay_coach_reads",
+          "tableTo": "profiles",
+          "columnsFrom": [
+            "coach_profile_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "essay_coach_reads_created_by_profile_id_fkey": {
+          "name": "essay_coach_reads_created_by_profile_id_fkey",
+          "tableFrom": "essay_coach_reads",
+          "tableTo": "profiles",
+          "columnsFrom": [
+            "created_by_profile_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "essay_coach_reads_updated_by_profile_id_fkey": {
+          "name": "essay_coach_reads_updated_by_profile_id_fkey",
+          "tableFrom": "essay_coach_reads",
+          "tableTo": "profiles",
+          "columnsFrom": [
+            "updated_by_profile_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "essay_coach_reads_pkey": {
+          "name": "essay_coach_reads_pkey",
+          "columns": [
+            "essay_id",
+            "coach_profile_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {
+        "Coaches remove own reads": {
+          "name": "Coaches remove own reads",
+          "as": "PERMISSIVE",
+          "for": "DELETE",
+          "to": [
+            "authenticated"
+          ],
+          "using": "(coach_profile_id = current_profile_id())"
+        },
+        "Coaches mark own reads within their team": {
+          "name": "Coaches mark own reads within their team",
+          "as": "PERMISSIVE",
+          "for": "INSERT",
+          "to": [
+            "authenticated"
+          ],
+          "withCheck": "((coach_profile_id = current_profile_id()) AND coach_can_review_essay(essay_id))"
+        },
+        "Coach sees own reads; author sees reads of own essays": {
+          "name": "Coach sees own reads; author sees reads of own essays",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": [
+            "authenticated"
+          ],
+          "using": "((coach_profile_id = current_profile_id()) OR (EXISTS ( SELECT 1\n   FROM essays e\n  WHERE ((e.id = essay_coach_reads.essay_id) AND (e.author_profile_id = current_profile_id())))))"
+        }
+      },
+      "checkConstraints": {},
+      "isRLSEnabled": true
+    },
+    "public.essay_comments": {
+      "name": "essay_comments",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "essay_id": {
+          "name": "essay_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "author_profile_id": {
+          "name": "author_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "parent_id": {
+          "name": "parent_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "removed_at": {
+          "name": "removed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_by_profile_id": {
+          "name": "created_by_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_by_profile_id": {
+          "name": "updated_by_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "essay_comments_author_idx": {
+          "name": "essay_comments_author_idx",
+          "columns": [
+            {
+              "expression": "author_profile_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "uuid_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "essay_comments_essay_idx": {
+          "name": "essay_comments_essay_idx",
+          "columns": [
+            {
+              "expression": "essay_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "uuid_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "essay_comments_essay_id_fkey": {
+          "name": "essay_comments_essay_id_fkey",
+          "tableFrom": "essay_comments",
+          "tableTo": "essays",
+          "columnsFrom": [
+            "essay_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "essay_comments_author_profile_id_fkey": {
+          "name": "essay_comments_author_profile_id_fkey",
+          "tableFrom": "essay_comments",
+          "tableTo": "profiles",
+          "columnsFrom": [
+            "author_profile_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "essay_comments_created_by_profile_id_fkey": {
+          "name": "essay_comments_created_by_profile_id_fkey",
+          "tableFrom": "essay_comments",
+          "tableTo": "profiles",
+          "columnsFrom": [
+            "created_by_profile_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "essay_comments_updated_by_profile_id_fkey": {
+          "name": "essay_comments_updated_by_profile_id_fkey",
+          "tableFrom": "essay_comments",
+          "tableTo": "profiles",
+          "columnsFrom": [
+            "updated_by_profile_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "essay_comments_parent_id_fkey": {
+          "name": "essay_comments_parent_id_fkey",
+          "tableFrom": "essay_comments",
+          "tableTo": "essay_comments",
+          "columnsFrom": [
+            "parent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {
+        "Authors and admins can delete essay comments": {
+          "name": "Authors and admins can delete essay comments",
+          "as": "PERMISSIVE",
+          "for": "DELETE",
+          "to": [
+            "authenticated"
+          ],
+          "using": "((author_profile_id = current_profile_id()) OR is_admin())"
+        },
+        "Authors can update their own essay comments": {
+          "name": "Authors can update their own essay comments",
+          "as": "PERMISSIVE",
+          "for": "UPDATE",
+          "to": [
+            "authenticated"
+          ],
+          "using": "(author_profile_id = current_profile_id())",
+          "withCheck": "(author_profile_id = current_profile_id())"
+        },
+        "Authenticated users can add essay comments": {
+          "name": "Authenticated users can add essay comments",
+          "as": "PERMISSIVE",
+          "for": "INSERT",
+          "to": [
+            "authenticated"
+          ],
+          "withCheck": "(author_profile_id = current_profile_id())"
+        },
+        "Authenticated users can view essay comments": {
+          "name": "Authenticated users can view essay comments",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": [
+            "authenticated"
+          ],
+          "using": "true"
+        }
+      },
+      "checkConstraints": {
+        "essay_comments_body_check": {
+          "name": "essay_comments_body_check",
+          "value": "(char_length(body) >= 1) AND (char_length(body) <= 4000)"
+        }
+      },
+      "isRLSEnabled": true
+    },
+    "public.essay_revisions": {
+      "name": "essay_revisions",
+      "schema": "",
+      "columns": {
+        "essay_id": {
+          "name": "essay_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "revision_no": {
+          "name": "revision_no",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content_json": {
+          "name": "content_json",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "invalid_since": {
+          "name": "invalid_since",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_by_profile_id": {
+          "name": "created_by_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_by_profile_id": {
+          "name": "updated_by_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "essay_revisions_essay_id_fkey": {
+          "name": "essay_revisions_essay_id_fkey",
+          "tableFrom": "essay_revisions",
+          "tableTo": "essays",
+          "columnsFrom": [
+            "essay_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "essay_revisions_created_by_profile_id_fkey": {
+          "name": "essay_revisions_created_by_profile_id_fkey",
+          "tableFrom": "essay_revisions",
+          "tableTo": "profiles",
+          "columnsFrom": [
+            "created_by_profile_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "essay_revisions_updated_by_profile_id_fkey": {
+          "name": "essay_revisions_updated_by_profile_id_fkey",
+          "tableFrom": "essay_revisions",
+          "tableTo": "profiles",
+          "columnsFrom": [
+            "updated_by_profile_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "essay_revisions_pkey": {
+          "name": "essay_revisions_pkey",
+          "columns": [
+            "essay_id",
+            "revision_no"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {
+        "Authenticated users can view essay revisions": {
+          "name": "Authenticated users can view essay revisions",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": [
+            "authenticated"
+          ],
+          "using": "(EXISTS ( SELECT 1\n   FROM essays e\n  WHERE ((e.id = essay_revisions.essay_id) AND ((e.published_at IS NOT NULL) OR (e.author_profile_id = ( SELECT current_profile_id())) OR ( SELECT is_admin())))))"
+        },
+        "Authors can create essay revisions": {
+          "name": "Authors can create essay revisions",
+          "as": "PERMISSIVE",
+          "for": "INSERT",
+          "to": [
+            "authenticated"
+          ],
+          "withCheck": "(created_by_profile_id = current_profile_id())"
+        },
+        "Authors can update their newest recent essay revision": {
+          "name": "Authors can update their newest recent essay revision",
+          "as": "PERMISSIVE",
+          "for": "UPDATE",
+          "to": [
+            "authenticated"
+          ],
+          "using": "((created_by_profile_id = ( SELECT current_profile_id())) AND (created_at > (now() - '00:30:00'::interval)))",
+          "withCheck": "(created_by_profile_id = ( SELECT current_profile_id()))"
+        },
+        "Essay revisions cannot be deleted": {
+          "name": "Essay revisions cannot be deleted",
+          "as": "PERMISSIVE",
+          "for": "DELETE",
+          "to": [
+            "authenticated"
+          ],
+          "using": "false"
+        }
+      },
+      "checkConstraints": {},
+      "isRLSEnabled": true
+    },
+    "public.essay_views": {
+      "name": "essay_views",
+      "schema": "",
+      "columns": {
+        "essay_id": {
+          "name": "essay_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "viewer_profile_id": {
+          "name": "viewer_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "first_viewed_at": {
+          "name": "first_viewed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_viewed_at": {
+          "name": "last_viewed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_by_profile_id": {
+          "name": "created_by_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_by_profile_id": {
+          "name": "updated_by_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "essay_views_viewer_idx": {
+          "name": "essay_views_viewer_idx",
+          "columns": [
+            {
+              "expression": "viewer_profile_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "uuid_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "essay_views_essay_id_fkey": {
+          "name": "essay_views_essay_id_fkey",
+          "tableFrom": "essay_views",
+          "tableTo": "essays",
+          "columnsFrom": [
+            "essay_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "essay_views_viewer_profile_id_fkey": {
+          "name": "essay_views_viewer_profile_id_fkey",
+          "tableFrom": "essay_views",
+          "tableTo": "profiles",
+          "columnsFrom": [
+            "viewer_profile_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "essay_views_created_by_profile_id_fkey": {
+          "name": "essay_views_created_by_profile_id_fkey",
+          "tableFrom": "essay_views",
+          "tableTo": "profiles",
+          "columnsFrom": [
+            "created_by_profile_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "essay_views_updated_by_profile_id_fkey": {
+          "name": "essay_views_updated_by_profile_id_fkey",
+          "tableFrom": "essay_views",
+          "tableTo": "profiles",
+          "columnsFrom": [
+            "updated_by_profile_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "essay_views_pkey": {
+          "name": "essay_views_pkey",
+          "columns": [
+            "essay_id",
+            "viewer_profile_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {
+        "No direct inserts to essay_views": {
+          "name": "No direct inserts to essay_views",
+          "as": "PERMISSIVE",
+          "for": "INSERT",
+          "to": [
+            "authenticated"
+          ],
+          "withCheck": "false"
+        },
+        "Authors see all viewers; others see own row": {
+          "name": "Authors see all viewers; others see own row",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": [
+            "authenticated"
+          ],
+          "using": "((viewer_profile_id = current_profile_id()) OR (EXISTS ( SELECT 1\n   FROM essays e\n  WHERE ((e.id = essay_views.essay_id) AND (e.author_profile_id = current_profile_id())))))"
+        }
+      },
+      "checkConstraints": {},
+      "isRLSEnabled": true
+    },
+    "public.essay_votes": {
+      "name": "essay_votes",
+      "schema": "",
+      "columns": {
+        "essay_id": {
+          "name": "essay_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "voter_profile_id": {
+          "name": "voter_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_by_profile_id": {
+          "name": "created_by_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_by_profile_id": {
+          "name": "updated_by_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "essay_votes_voter_idx": {
+          "name": "essay_votes_voter_idx",
+          "columns": [
+            {
+              "expression": "voter_profile_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "uuid_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "essay_votes_essay_id_fkey": {
+          "name": "essay_votes_essay_id_fkey",
+          "tableFrom": "essay_votes",
+          "tableTo": "essays",
+          "columnsFrom": [
+            "essay_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "essay_votes_voter_profile_id_fkey": {
+          "name": "essay_votes_voter_profile_id_fkey",
+          "tableFrom": "essay_votes",
+          "tableTo": "profiles",
+          "columnsFrom": [
+            "voter_profile_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "essay_votes_created_by_profile_id_fkey": {
+          "name": "essay_votes_created_by_profile_id_fkey",
+          "tableFrom": "essay_votes",
+          "tableTo": "profiles",
+          "columnsFrom": [
+            "created_by_profile_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "essay_votes_updated_by_profile_id_fkey": {
+          "name": "essay_votes_updated_by_profile_id_fkey",
+          "tableFrom": "essay_votes",
+          "tableTo": "profiles",
+          "columnsFrom": [
+            "updated_by_profile_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "essay_votes_pkey": {
+          "name": "essay_votes_pkey",
+          "columns": [
+            "essay_id",
+            "voter_profile_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {
+        "Users can vote (not own essays)": {
+          "name": "Users can vote (not own essays)",
+          "as": "PERMISSIVE",
+          "for": "INSERT",
+          "to": [
+            "authenticated"
+          ],
+          "withCheck": "((voter_profile_id = current_profile_id()) AND (NOT (essay_id IN ( SELECT essays.id\n   FROM essays\n  WHERE (essays.author_profile_id = current_profile_id())))))"
+        },
+        "Authenticated users can view votes": {
+          "name": "Authenticated users can view votes",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": [
+            "authenticated"
+          ],
+          "using": "true"
+        },
+        "Users can remove own votes": {
+          "name": "Users can remove own votes",
+          "as": "PERMISSIVE",
+          "for": "DELETE",
+          "to": [
+            "authenticated"
+          ],
+          "using": "(voter_profile_id = current_profile_id())"
+        }
+      },
+      "checkConstraints": {},
+      "isRLSEnabled": true
+    },
+    "public.essays": {
+      "name": "essays",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "external_id": {
+          "name": "external_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "author_profile_id": {
+          "name": "author_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "book_id": {
+          "name": "book_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "published_at": {
+          "name": "published_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pinned_at": {
+          "name": "pinned_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pinned_by_profile_id": {
+          "name": "pinned_by_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "removed_at": {
+          "name": "removed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_by_profile_id": {
+          "name": "created_by_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_by_profile_id": {
+          "name": "updated_by_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "essays_author_idx": {
+          "name": "essays_author_idx",
+          "columns": [
+            {
+              "expression": "author_profile_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "uuid_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "essays_book_idx": {
+          "name": "essays_book_idx",
+          "columns": [
+            {
+              "expression": "book_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "uuid_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "essays_created_desc_idx": {
+          "name": "essays_created_desc_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "first",
+              "opclass": "timestamptz_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "essays_author_profile_id_fkey": {
+          "name": "essays_author_profile_id_fkey",
+          "tableFrom": "essays",
+          "tableTo": "profiles",
+          "columnsFrom": [
+            "author_profile_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "essays_book_id_fkey": {
+          "name": "essays_book_id_fkey",
+          "tableFrom": "essays",
+          "tableTo": "books",
+          "columnsFrom": [
+            "book_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "essays_pinned_by_profile_id_fkey": {
+          "name": "essays_pinned_by_profile_id_fkey",
+          "tableFrom": "essays",
+          "tableTo": "profiles",
+          "columnsFrom": [
+            "pinned_by_profile_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "essays_created_by_profile_id_fkey": {
+          "name": "essays_created_by_profile_id_fkey",
+          "tableFrom": "essays",
+          "tableTo": "profiles",
+          "columnsFrom": [
+            "created_by_profile_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "essays_updated_by_profile_id_fkey": {
+          "name": "essays_updated_by_profile_id_fkey",
+          "tableFrom": "essays",
+          "tableTo": "profiles",
+          "columnsFrom": [
+            "updated_by_profile_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {
+        "Authors can create their own essays": {
+          "name": "Authors can create their own essays",
+          "as": "PERMISSIVE",
+          "for": "INSERT",
+          "to": [
+            "authenticated"
+          ],
+          "withCheck": "(author_profile_id = current_profile_id())"
+        },
+        "Authenticated users can view all essays": {
+          "name": "Authenticated users can view all essays",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": [
+            "authenticated"
+          ],
+          "using": "((published_at IS NOT NULL) OR (author_profile_id = ( SELECT current_profile_id())) OR ( SELECT is_admin()))"
+        },
+        "Authors and admins can delete essays": {
+          "name": "Authors and admins can delete essays",
+          "as": "PERMISSIVE",
+          "for": "DELETE",
+          "to": [
+            "authenticated"
+          ],
+          "using": "((author_profile_id = current_profile_id()) OR is_admin())"
+        },
+        "Authors can update their own essays": {
+          "name": "Authors can update their own essays",
+          "as": "PERMISSIVE",
+          "for": "UPDATE",
+          "to": [
+            "authenticated"
+          ],
+          "using": "(author_profile_id = current_profile_id())",
+          "withCheck": "(author_profile_id = current_profile_id())"
+        }
+      },
+      "checkConstraints": {},
+      "isRLSEnabled": true
+    },
+    "public.feedback": {
+      "name": "feedback",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "author_profile_id": {
+          "name": "author_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "resolved_at": {
+          "name": "resolved_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_by_profile_id": {
+          "name": "created_by_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_by_profile_id": {
+          "name": "updated_by_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "feedback_active_created_idx": {
+          "name": "feedback_active_created_idx",
+          "columns": [
+            {
+              "expression": "resolved_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "timestamptz_ops"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "first",
+              "opclass": "timestamptz_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "feedback_author_idx": {
+          "name": "feedback_author_idx",
+          "columns": [
+            {
+              "expression": "author_profile_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "uuid_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "feedback_author_profile_id_fkey": {
+          "name": "feedback_author_profile_id_fkey",
+          "tableFrom": "feedback",
+          "tableTo": "profiles",
+          "columnsFrom": [
+            "author_profile_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "feedback_created_by_profile_id_fkey": {
+          "name": "feedback_created_by_profile_id_fkey",
+          "tableFrom": "feedback",
+          "tableTo": "profiles",
+          "columnsFrom": [
+            "created_by_profile_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "feedback_updated_by_profile_id_fkey": {
+          "name": "feedback_updated_by_profile_id_fkey",
+          "tableFrom": "feedback",
+          "tableTo": "profiles",
+          "columnsFrom": [
+            "updated_by_profile_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {
+        "Authenticated users can view feedback": {
+          "name": "Authenticated users can view feedback",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": [
+            "authenticated"
+          ],
+          "using": "true"
+        },
+        "Authenticated users can create feedback": {
+          "name": "Authenticated users can create feedback",
+          "as": "PERMISSIVE",
+          "for": "INSERT",
+          "to": [
+            "authenticated"
+          ],
+          "withCheck": "(author_profile_id = current_profile_id())"
+        },
+        "Admins can update feedback": {
+          "name": "Admins can update feedback",
+          "as": "PERMISSIVE",
+          "for": "UPDATE",
+          "to": [
+            "authenticated"
+          ],
+          "using": "is_admin()",
+          "withCheck": "is_admin()"
+        },
+        "Authors and admins can delete feedback": {
+          "name": "Authors and admins can delete feedback",
+          "as": "PERMISSIVE",
+          "for": "DELETE",
+          "to": [
+            "authenticated"
+          ],
+          "using": "((author_profile_id = current_profile_id()) OR is_admin())"
+        }
+      },
+      "checkConstraints": {
+        "feedback_body_check": {
+          "name": "feedback_body_check",
+          "value": "(char_length(body) >= 1) AND (char_length(body) <= 4000)"
+        }
+      },
+      "isRLSEnabled": true
+    },
+    "public.individual_coaching_sessions": {
+      "name": "individual_coaching_sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "profile_id": {
+          "name": "profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "session_at": {
+          "name": "session_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "coach_profile_id": {
+          "name": "coach_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "external_coach_name": {
+          "name": "external_coach_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "key_takeaways": {
+          "name": "key_takeaways",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "action_steps": {
+          "name": "action_steps",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "removed_at": {
+          "name": "removed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_by_profile_id": {
+          "name": "created_by_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_by_profile_id": {
+          "name": "updated_by_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "individual_coaching_sessions_profile_idx": {
+          "name": "individual_coaching_sessions_profile_idx",
+          "columns": [
+            {
+              "expression": "profile_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "uuid_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "individual_coaching_sessions_coach_idx": {
+          "name": "individual_coaching_sessions_coach_idx",
+          "columns": [
+            {
+              "expression": "coach_profile_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "uuid_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "individual_coaching_sessions_created_desc_idx": {
+          "name": "individual_coaching_sessions_created_desc_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "first",
+              "opclass": "timestamptz_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "individual_coaching_sessions_profile_id_fkey": {
+          "name": "individual_coaching_sessions_profile_id_fkey",
+          "tableFrom": "individual_coaching_sessions",
+          "tableTo": "profiles",
+          "columnsFrom": [
+            "profile_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "individual_coaching_sessions_coach_profile_id_fkey": {
+          "name": "individual_coaching_sessions_coach_profile_id_fkey",
+          "tableFrom": "individual_coaching_sessions",
+          "tableTo": "profiles",
+          "columnsFrom": [
+            "coach_profile_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "individual_coaching_sessions_created_by_profile_id_fkey": {
+          "name": "individual_coaching_sessions_created_by_profile_id_fkey",
+          "tableFrom": "individual_coaching_sessions",
+          "tableTo": "profiles",
+          "columnsFrom": [
+            "created_by_profile_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "individual_coaching_sessions_updated_by_profile_id_fkey": {
+          "name": "individual_coaching_sessions_updated_by_profile_id_fkey",
+          "tableFrom": "individual_coaching_sessions",
+          "tableTo": "profiles",
+          "columnsFrom": [
+            "updated_by_profile_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {
+        "Users can view their own coaching sessions": {
+          "name": "Users can view their own coaching sessions",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": [
+            "authenticated"
+          ],
+          "using": "(profile_id = current_profile_id())"
+        },
+        "Users can create their own coaching sessions": {
+          "name": "Users can create their own coaching sessions",
+          "as": "PERMISSIVE",
+          "for": "INSERT",
+          "to": [
+            "authenticated"
+          ],
+          "withCheck": "(profile_id = current_profile_id())"
+        },
+        "Users can update their own coaching sessions": {
+          "name": "Users can update their own coaching sessions",
+          "as": "PERMISSIVE",
+          "for": "UPDATE",
+          "to": [
+            "authenticated"
+          ],
+          "using": "(profile_id = current_profile_id())",
+          "withCheck": "(profile_id = current_profile_id())"
+        },
+        "Users can delete their own coaching sessions": {
+          "name": "Users can delete their own coaching sessions",
+          "as": "PERMISSIVE",
+          "for": "DELETE",
+          "to": [
+            "authenticated"
+          ],
+          "using": "(profile_id = current_profile_id())"
+        }
+      },
+      "checkConstraints": {
+        "individual_coaching_sessions_coach_xor": {
+          "name": "individual_coaching_sessions_coach_xor",
+          "value": "(coach_profile_id IS NOT NULL) <> (external_coach_name IS NOT NULL)"
+        }
+      },
+      "isRLSEnabled": true
+    },
+    "public.notification_preferences": {
+      "name": "notification_preferences",
+      "schema": "",
+      "columns": {
+        "profile_id": {
+          "name": "profile_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "essay_coach_read_email": {
+          "name": "essay_coach_read_email",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "essay_comment_email": {
+          "name": "essay_comment_email",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "essay_vote_email": {
+          "name": "essay_vote_email",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "book_submitted_email": {
+          "name": "book_submitted_email",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_by_profile_id": {
+          "name": "created_by_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_by_profile_id": {
+          "name": "updated_by_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "notification_preferences_profile_id_fkey": {
+          "name": "notification_preferences_profile_id_fkey",
+          "tableFrom": "notification_preferences",
+          "tableTo": "profiles",
+          "columnsFrom": [
+            "profile_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "notification_preferences_created_by_profile_id_fkey": {
+          "name": "notification_preferences_created_by_profile_id_fkey",
+          "tableFrom": "notification_preferences",
+          "tableTo": "profiles",
+          "columnsFrom": [
+            "created_by_profile_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "notification_preferences_updated_by_profile_id_fkey": {
+          "name": "notification_preferences_updated_by_profile_id_fkey",
+          "tableFrom": "notification_preferences",
+          "tableTo": "profiles",
+          "columnsFrom": [
+            "updated_by_profile_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {
+        "Users can view their own notification preferences": {
+          "name": "Users can view their own notification preferences",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": [
+            "authenticated"
+          ],
+          "using": "(profile_id = current_profile_id())"
+        },
+        "Users can insert their own notification preferences": {
+          "name": "Users can insert their own notification preferences",
+          "as": "PERMISSIVE",
+          "for": "INSERT",
+          "to": [
+            "authenticated"
+          ],
+          "withCheck": "(profile_id = current_profile_id())"
+        },
+        "Users can update their own notification preferences": {
+          "name": "Users can update their own notification preferences",
+          "as": "PERMISSIVE",
+          "for": "UPDATE",
+          "to": [
+            "authenticated"
+          ],
+          "using": "(profile_id = current_profile_id())",
+          "withCheck": "(profile_id = current_profile_id())"
+        }
+      },
+      "checkConstraints": {},
+      "isRLSEnabled": true
+    },
+    "public.personality_tests": {
+      "name": "personality_tests",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "profile_id": {
+          "name": "profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "test_type": {
+          "name": "test_type",
+          "type": "personality_test_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "test_type_other": {
+          "name": "test_type_other",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tested_on": {
+          "name": "tested_on",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "file_path": {
+          "name": "file_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "file_name": {
+          "name": "file_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "file_size": {
+          "name": "file_size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "removed_at": {
+          "name": "removed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_by_profile_id": {
+          "name": "created_by_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_by_profile_id": {
+          "name": "updated_by_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "personality_tests_profile_tested_on_idx": {
+          "name": "personality_tests_profile_tested_on_idx",
+          "columns": [
+            {
+              "expression": "profile_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "uuid_ops"
+            },
+            {
+              "expression": "tested_on",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "date_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "personality_tests_profile_id_fkey": {
+          "name": "personality_tests_profile_id_fkey",
+          "tableFrom": "personality_tests",
+          "tableTo": "profiles",
+          "columnsFrom": [
+            "profile_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "personality_tests_created_by_profile_id_fkey": {
+          "name": "personality_tests_created_by_profile_id_fkey",
+          "tableFrom": "personality_tests",
+          "tableTo": "profiles",
+          "columnsFrom": [
+            "created_by_profile_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "personality_tests_updated_by_profile_id_fkey": {
+          "name": "personality_tests_updated_by_profile_id_fkey",
+          "tableFrom": "personality_tests",
+          "tableTo": "profiles",
+          "columnsFrom": [
+            "updated_by_profile_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {
+        "Verified users can view personality tests": {
+          "name": "Verified users can view personality tests",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": [
+            "authenticated"
+          ],
+          "using": "(removed_at IS NULL) AND (EXISTS (SELECT 1 FROM users WHERE (users.auth_user_id = (SELECT auth.uid()) AND users.verified_work_email IS NOT NULL)))"
+        },
+        "Users can create their own personality tests": {
+          "name": "Users can create their own personality tests",
+          "as": "PERMISSIVE",
+          "for": "INSERT",
+          "to": [
+            "authenticated"
+          ],
+          "withCheck": "(profile_id = current_profile_id())"
+        },
+        "Users can update their own personality tests": {
+          "name": "Users can update their own personality tests",
+          "as": "PERMISSIVE",
+          "for": "UPDATE",
+          "to": [
+            "authenticated"
+          ],
+          "using": "(profile_id = current_profile_id())",
+          "withCheck": "(profile_id = current_profile_id())"
+        },
+        "Users can delete their own personality tests": {
+          "name": "Users can delete their own personality tests",
+          "as": "PERMISSIVE",
+          "for": "DELETE",
+          "to": [
+            "authenticated"
+          ],
+          "using": "(profile_id = current_profile_id())"
+        }
+      },
+      "checkConstraints": {
+        "personality_tests_other_type_required": {
+          "name": "personality_tests_other_type_required",
+          "value": "(test_type <> 'other' OR (test_type_other IS NOT NULL AND length(trim(test_type_other)) > 0))"
+        }
+      },
+      "isRLSEnabled": true
+    },
+    "public.profiles": {
+      "name": "profiles",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "picture": {
+          "name": "picture",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "work_email": {
+          "name": "work_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "profile_role",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'student'"
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "phone_number": {
+          "name": "phone_number",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "personal_email": {
+          "name": "personal_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "date_of_birth": {
+          "name": "date_of_birth",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_removed_at": {
+          "name": "access_removed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_removed_by_profile_id": {
+          "name": "access_removed_by_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "beta_access_granted_at": {
+          "name": "beta_access_granted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_by_profile_id": {
+          "name": "created_by_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_by_profile_id": {
+          "name": "updated_by_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "profiles_team_id_idx": {
+          "name": "profiles_team_id_idx",
+          "columns": [
+            {
+              "expression": "team_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "uuid_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "profiles_team_id_user_id_idx": {
+          "name": "profiles_team_id_user_id_idx",
+          "columns": [
+            {
+              "expression": "team_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "uuid_ops"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "uuid_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "profiles_user_id_idx": {
+          "name": "profiles_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "uuid_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "profiles_work_email_idx": {
+          "name": "profiles_work_email_idx",
+          "columns": [
+            {
+              "expression": "work_email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "text_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "profiles_user_id_fkey": {
+          "name": "profiles_user_id_fkey",
+          "tableFrom": "profiles",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "profiles_team_id_fkey": {
+          "name": "profiles_team_id_fkey",
+          "tableFrom": "profiles",
+          "tableTo": "teams",
+          "columnsFrom": [
+            "team_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "profiles_access_removed_by_profile_id_fkey": {
+          "name": "profiles_access_removed_by_profile_id_fkey",
+          "tableFrom": "profiles",
+          "tableTo": "profiles",
+          "columnsFrom": [
+            "access_removed_by_profile_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "profiles_created_by_profile_id_fkey": {
+          "name": "profiles_created_by_profile_id_fkey",
+          "tableFrom": "profiles",
+          "tableTo": "profiles",
+          "columnsFrom": [
+            "created_by_profile_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "profiles_updated_by_profile_id_fkey": {
+          "name": "profiles_updated_by_profile_id_fkey",
+          "tableFrom": "profiles",
+          "tableTo": "profiles",
+          "columnsFrom": [
+            "updated_by_profile_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "profiles_user_id_key": {
+          "name": "profiles_user_id_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id"
+          ]
+        },
+        "profiles_work_email_key": {
+          "name": "profiles_work_email_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "work_email"
+          ]
+        }
+      },
+      "policies": {
+        "Verified users can view all profiles": {
+          "name": "Verified users can view all profiles",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": [
+            "authenticated"
+          ],
+          "using": "((access_removed_at IS NULL) AND (EXISTS ( SELECT 1\n   FROM users\n  WHERE ((users.auth_user_id = ( SELECT auth.uid() AS uid)) AND (users.verified_work_email IS NOT NULL)))))"
+        },
+        "Users can update their own profile picture": {
+          "name": "Users can update their own profile picture",
+          "as": "PERMISSIVE",
+          "for": "UPDATE",
+          "to": [
+            "authenticated"
+          ],
+          "using": "(user_id IN ( SELECT users.id\n   FROM users\n  WHERE (users.auth_user_id = ( SELECT auth.uid() AS uid))))",
+          "withCheck": "(user_id IN ( SELECT users.id\n   FROM users\n  WHERE (users.auth_user_id = ( SELECT auth.uid() AS uid))))"
+        }
+      },
+      "checkConstraints": {
+        "valid_czu_domain": {
+          "name": "valid_czu_domain",
+          "value": "(lower(split_part(work_email, '@'::text, 2)) = ANY (ARRAY['pef.czu.cz'::text, 'studenti.czu.cz'::text, 'rektorat.czu.cz'::text]))"
+        }
+      },
+      "isRLSEnabled": true
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "auth_user_id": {
+          "name": "auth_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "google_email": {
+          "name": "google_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "suggested_work_email": {
+          "name": "suggested_work_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "verified_work_email": {
+          "name": "verified_work_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "verified_work_email_at": {
+          "name": "verified_work_email_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_otp_sent_at": {
+          "name": "last_otp_sent_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "users_google_email_idx": {
+          "name": "users_google_email_idx",
+          "columns": [
+            {
+              "expression": "google_email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "text_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "users_suggested_work_email_idx": {
+          "name": "users_suggested_work_email_idx",
+          "columns": [
+            {
+              "expression": "suggested_work_email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "text_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "users_auth_user_id_fkey": {
+          "name": "users_auth_user_id_fkey",
+          "tableFrom": "users",
+          "tableTo": "users",
+          "schemaTo": "auth",
+          "columnsFrom": [
+            "auth_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_auth_user_id_key": {
+          "name": "users_auth_user_id_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "auth_user_id"
+          ]
+        },
+        "users_google_email_key": {
+          "name": "users_google_email_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "google_email"
+          ]
+        }
+      },
+      "policies": {
+        "Users can update only suggested_work_email": {
+          "name": "Users can update only suggested_work_email",
+          "as": "PERMISSIVE",
+          "for": "UPDATE",
+          "to": [
+            "authenticated"
+          ],
+          "using": "(( SELECT auth.uid() AS uid) = auth_user_id)",
+          "withCheck": "(( SELECT auth.uid() AS uid) = auth_user_id)"
+        },
+        "Users can insert their own user record": {
+          "name": "Users can insert their own user record",
+          "as": "PERMISSIVE",
+          "for": "INSERT",
+          "to": [
+            "authenticated"
+          ],
+          "withCheck": "(( SELECT auth.uid() AS uid) = auth_user_id)"
+        },
+        "Users can view their own user record": {
+          "name": "Users can view their own user record",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": [
+            "authenticated"
+          ],
+          "using": "(( SELECT auth.uid() AS uid) = auth_user_id)"
+        }
+      },
+      "checkConstraints": {},
+      "isRLSEnabled": true
+    },
+    "public.recurring_schedules": {
+      "name": "recurring_schedules",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "room_id": {
+          "name": "room_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "schedule_type": {
+          "name": "schedule_type",
+          "type": "schedule_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "day_of_week": {
+          "name": "day_of_week",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "start_time": {
+          "name": "start_time",
+          "type": "time",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "end_time": {
+          "name": "end_time",
+          "type": "time",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "valid_from": {
+          "name": "valid_from",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "valid_until": {
+          "name": "valid_until",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "removed_at": {
+          "name": "removed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_by_profile_id": {
+          "name": "created_by_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_by_profile_id": {
+          "name": "updated_by_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "idx_recurring_schedules_day": {
+          "name": "idx_recurring_schedules_day",
+          "columns": [
+            {
+              "expression": "day_of_week",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "int2_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_recurring_schedules_room": {
+          "name": "idx_recurring_schedules_room",
+          "columns": [
+            {
+              "expression": "room_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "uuid_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_recurring_schedules_team": {
+          "name": "idx_recurring_schedules_team",
+          "columns": [
+            {
+              "expression": "team_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "uuid_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_recurring_schedules_type": {
+          "name": "idx_recurring_schedules_type",
+          "columns": [
+            {
+              "expression": "schedule_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "enum_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_recurring_schedules_valid": {
+          "name": "idx_recurring_schedules_valid",
+          "columns": [
+            {
+              "expression": "valid_from",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "date_ops"
+            },
+            {
+              "expression": "valid_until",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "date_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "recurring_schedules_room_id_fkey": {
+          "name": "recurring_schedules_room_id_fkey",
+          "tableFrom": "recurring_schedules",
+          "tableTo": "rooms",
+          "columnsFrom": [
+            "room_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "recurring_schedules_team_id_fkey": {
+          "name": "recurring_schedules_team_id_fkey",
+          "tableFrom": "recurring_schedules",
+          "tableTo": "teams",
+          "columnsFrom": [
+            "team_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "recurring_schedules_created_by_profile_id_fkey": {
+          "name": "recurring_schedules_created_by_profile_id_fkey",
+          "tableFrom": "recurring_schedules",
+          "tableTo": "profiles",
+          "columnsFrom": [
+            "created_by_profile_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "recurring_schedules_updated_by_profile_id_fkey": {
+          "name": "recurring_schedules_updated_by_profile_id_fkey",
+          "tableFrom": "recurring_schedules",
+          "tableTo": "profiles",
+          "columnsFrom": [
+            "updated_by_profile_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {
+        "Coaches can manage recurring_schedules": {
+          "name": "Coaches can manage recurring_schedules",
+          "as": "PERMISSIVE",
+          "for": "ALL",
+          "to": [
+            "authenticated"
+          ],
+          "using": "(EXISTS ( SELECT 1\n   FROM profiles\n  WHERE ((profiles.user_id IN ( SELECT users.id\n           FROM users\n          WHERE (users.auth_user_id = ( SELECT auth.uid() AS uid)))) AND (profiles.role = ANY (ARRAY['coach'::profile_role, 'admin'::profile_role])))))",
+          "withCheck": "(EXISTS ( SELECT 1\n   FROM profiles\n  WHERE ((profiles.user_id IN ( SELECT users.id\n           FROM users\n          WHERE (users.auth_user_id = ( SELECT auth.uid() AS uid)))) AND (profiles.role = ANY (ARRAY['coach'::profile_role, 'admin'::profile_role])))))"
+        },
+        "Authenticated can read recurring_schedules": {
+          "name": "Authenticated can read recurring_schedules",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": [
+            "authenticated"
+          ],
+          "using": "true"
+        }
+      },
+      "checkConstraints": {
+        "recurring_schedules_day_of_week_check": {
+          "name": "recurring_schedules_day_of_week_check",
+          "value": "(day_of_week >= 0) AND (day_of_week <= 6)"
+        },
+        "valid_time_range": {
+          "name": "valid_time_range",
+          "value": "end_time > start_time"
+        },
+        "valid_schedule_dates": {
+          "name": "valid_schedule_dates",
+          "value": "(valid_until IS NULL) OR (valid_until >= valid_from)"
+        },
+        "recurring_schedules_team_for_ts": {
+          "name": "recurring_schedules_team_for_ts",
+          "value": "(schedule_type <> 'training_session'::schedule_type) OR (team_id IS NOT NULL)"
+        }
+      },
+      "isRLSEnabled": true
+    },
+    "public.reservations": {
+      "name": "reservations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "room_id": {
+          "name": "room_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "owner_profile_id": {
+          "name": "owner_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "person_count": {
+          "name": "person_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "start_at": {
+          "name": "start_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "end_at": {
+          "name": "end_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cancelled_at": {
+          "name": "cancelled_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cancelled_by_profile_id": {
+          "name": "cancelled_by_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_by_profile_id": {
+          "name": "created_by_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_by_profile_id": {
+          "name": "updated_by_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "idx_reservations_room_time": {
+          "name": "idx_reservations_room_time",
+          "columns": [
+            {
+              "expression": "room_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "uuid_ops"
+            },
+            {
+              "expression": "start_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "timestamptz_ops"
+            },
+            {
+              "expression": "end_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "timestamptz_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_reservations_start": {
+          "name": "idx_reservations_start",
+          "columns": [
+            {
+              "expression": "start_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "timestamptz_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_reservations_owner": {
+          "name": "idx_reservations_owner",
+          "columns": [
+            {
+              "expression": "owner_profile_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "uuid_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "reservations_room_id_fkey": {
+          "name": "reservations_room_id_fkey",
+          "tableFrom": "reservations",
+          "tableTo": "rooms",
+          "columnsFrom": [
+            "room_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "reservations_owner_profile_id_fkey": {
+          "name": "reservations_owner_profile_id_fkey",
+          "tableFrom": "reservations",
+          "tableTo": "profiles",
+          "columnsFrom": [
+            "owner_profile_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "reservations_cancelled_by_profile_id_fkey": {
+          "name": "reservations_cancelled_by_profile_id_fkey",
+          "tableFrom": "reservations",
+          "tableTo": "profiles",
+          "columnsFrom": [
+            "cancelled_by_profile_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "reservations_created_by_profile_id_fkey": {
+          "name": "reservations_created_by_profile_id_fkey",
+          "tableFrom": "reservations",
+          "tableTo": "profiles",
+          "columnsFrom": [
+            "created_by_profile_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "reservations_updated_by_profile_id_fkey": {
+          "name": "reservations_updated_by_profile_id_fkey",
+          "tableFrom": "reservations",
+          "tableTo": "profiles",
+          "columnsFrom": [
+            "updated_by_profile_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {
+        "Authenticated can read reservations": {
+          "name": "Authenticated can read reservations",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": [
+            "authenticated"
+          ],
+          "using": "true"
+        },
+        "Users can delete own reservations": {
+          "name": "Users can delete own reservations",
+          "as": "PERMISSIVE",
+          "for": "DELETE",
+          "to": [
+            "authenticated"
+          ],
+          "using": "(owner_profile_id IN ( SELECT profiles.id\n   FROM profiles\n  WHERE (profiles.user_id IN ( SELECT users.id\n           FROM users\n          WHERE (users.auth_user_id = ( SELECT auth.uid() AS uid))))))"
+        },
+        "Users can update own reservations": {
+          "name": "Users can update own reservations",
+          "as": "PERMISSIVE",
+          "for": "UPDATE",
+          "to": [
+            "authenticated"
+          ],
+          "using": "(owner_profile_id IN ( SELECT profiles.id\n   FROM profiles\n  WHERE (profiles.user_id IN ( SELECT users.id\n           FROM users\n          WHERE (users.auth_user_id = ( SELECT auth.uid() AS uid))))))",
+          "withCheck": "(owner_profile_id IN ( SELECT profiles.id\n   FROM profiles\n  WHERE (profiles.user_id IN ( SELECT users.id\n           FROM users\n          WHERE (users.auth_user_id = ( SELECT auth.uid() AS uid))))))"
+        },
+        "Users can create own reservations": {
+          "name": "Users can create own reservations",
+          "as": "PERMISSIVE",
+          "for": "INSERT",
+          "to": [
+            "authenticated"
+          ],
+          "withCheck": "(owner_profile_id IN ( SELECT profiles.id\n   FROM profiles\n  WHERE (profiles.user_id IN ( SELECT users.id\n           FROM users\n          WHERE (users.auth_user_id = ( SELECT auth.uid() AS uid))))))"
+        }
+      },
+      "checkConstraints": {
+        "valid_reservation_time": {
+          "name": "valid_reservation_time",
+          "value": "end_at > start_at"
+        }
+      },
+      "isRLSEnabled": true
+    },
+    "public.rooms": {
+      "name": "rooms",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "code": {
+          "name": "code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "available_days": {
+          "name": "available_days",
+          "type": "integer[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "can_have_ts": {
+          "name": "can_have_ts",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "removed_at": {
+          "name": "removed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_by_profile_id": {
+          "name": "created_by_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_by_profile_id": {
+          "name": "updated_by_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "idx_rooms_code": {
+          "name": "idx_rooms_code",
+          "columns": [
+            {
+              "expression": "code",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "text_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "rooms_created_by_profile_id_fkey": {
+          "name": "rooms_created_by_profile_id_fkey",
+          "tableFrom": "rooms",
+          "tableTo": "profiles",
+          "columnsFrom": [
+            "created_by_profile_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "rooms_updated_by_profile_id_fkey": {
+          "name": "rooms_updated_by_profile_id_fkey",
+          "tableFrom": "rooms",
+          "tableTo": "profiles",
+          "columnsFrom": [
+            "updated_by_profile_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "rooms_code_key": {
+          "name": "rooms_code_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "code"
+          ]
+        }
+      },
+      "policies": {
+        "Admins can manage rooms": {
+          "name": "Admins can manage rooms",
+          "as": "PERMISSIVE",
+          "for": "ALL",
+          "to": [
+            "authenticated"
+          ],
+          "using": "(EXISTS ( SELECT 1\n   FROM profiles\n  WHERE ((profiles.user_id IN ( SELECT users.id\n           FROM users\n          WHERE (users.auth_user_id = ( SELECT auth.uid() AS uid)))) AND (profiles.role = 'admin'::profile_role))))",
+          "withCheck": "(EXISTS ( SELECT 1\n   FROM profiles\n  WHERE ((profiles.user_id IN ( SELECT users.id\n           FROM users\n          WHERE (users.auth_user_id = ( SELECT auth.uid() AS uid)))) AND (profiles.role = 'admin'::profile_role))))"
+        },
+        "Authenticated can read rooms": {
+          "name": "Authenticated can read rooms",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": [
+            "authenticated"
+          ],
+          "using": "true"
+        }
+      },
+      "checkConstraints": {},
+      "isRLSEnabled": true
+    },
+    "public.schedule_breaks": {
+      "name": "schedule_breaks",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "start_date": {
+          "name": "start_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "end_date": {
+          "name": "end_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_by_profile_id": {
+          "name": "created_by_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_by_profile_id": {
+          "name": "updated_by_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "idx_schedule_breaks_dates": {
+          "name": "idx_schedule_breaks_dates",
+          "columns": [
+            {
+              "expression": "start_date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "date_ops"
+            },
+            {
+              "expression": "end_date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "date_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "schedule_breaks_created_by_profile_id_fkey": {
+          "name": "schedule_breaks_created_by_profile_id_fkey",
+          "tableFrom": "schedule_breaks",
+          "tableTo": "profiles",
+          "columnsFrom": [
+            "created_by_profile_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "schedule_breaks_updated_by_profile_id_fkey": {
+          "name": "schedule_breaks_updated_by_profile_id_fkey",
+          "tableFrom": "schedule_breaks",
+          "tableTo": "profiles",
+          "columnsFrom": [
+            "updated_by_profile_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {
+        "Coaches can manage schedule_breaks": {
+          "name": "Coaches can manage schedule_breaks",
+          "as": "PERMISSIVE",
+          "for": "ALL",
+          "to": [
+            "authenticated"
+          ],
+          "using": "(EXISTS ( SELECT 1\n   FROM profiles\n  WHERE ((profiles.user_id IN ( SELECT users.id\n           FROM users\n          WHERE (users.auth_user_id = ( SELECT auth.uid() AS uid)))) AND (profiles.role = ANY (ARRAY['coach'::profile_role, 'admin'::profile_role])))))",
+          "withCheck": "(EXISTS ( SELECT 1\n   FROM profiles\n  WHERE ((profiles.user_id IN ( SELECT users.id\n           FROM users\n          WHERE (users.auth_user_id = ( SELECT auth.uid() AS uid)))) AND (profiles.role = ANY (ARRAY['coach'::profile_role, 'admin'::profile_role])))))"
+        },
+        "Authenticated can read schedule_breaks": {
+          "name": "Authenticated can read schedule_breaks",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": [
+            "authenticated"
+          ],
+          "using": "true"
+        }
+      },
+      "checkConstraints": {
+        "valid_break_date_range": {
+          "name": "valid_break_date_range",
+          "value": "end_date >= start_date"
+        }
+      },
+      "isRLSEnabled": true
+    },
+    "public.team_activities": {
+      "name": "team_activities",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "occurred_at": {
+          "name": "occurred_at",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "activity_type": {
+          "name": "activity_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "participants": {
+          "name": "participants",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reflection": {
+          "name": "reflection",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "removed_at": {
+          "name": "removed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_by_profile_id": {
+          "name": "created_by_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_by_profile_id": {
+          "name": "updated_by_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "team_activities_team_occurred_at_idx": {
+          "name": "team_activities_team_occurred_at_idx",
+          "columns": [
+            {
+              "expression": "team_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "uuid_ops"
+            },
+            {
+              "expression": "occurred_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "date_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "team_activities_team_id_fkey": {
+          "name": "team_activities_team_id_fkey",
+          "tableFrom": "team_activities",
+          "tableTo": "teams",
+          "columnsFrom": [
+            "team_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "team_activities_created_by_profile_id_fkey": {
+          "name": "team_activities_created_by_profile_id_fkey",
+          "tableFrom": "team_activities",
+          "tableTo": "profiles",
+          "columnsFrom": [
+            "created_by_profile_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "team_activities_updated_by_profile_id_fkey": {
+          "name": "team_activities_updated_by_profile_id_fkey",
+          "tableFrom": "team_activities",
+          "tableTo": "profiles",
+          "columnsFrom": [
+            "updated_by_profile_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {
+        "Team members can view activities": {
+          "name": "Team members can view activities",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": [
+            "authenticated"
+          ],
+          "using": "team_id IN (SELECT team_id FROM profiles WHERE id = current_profile_id() AND access_removed_at IS NULL)"
+        },
+        "Team members can create activities": {
+          "name": "Team members can create activities",
+          "as": "PERMISSIVE",
+          "for": "INSERT",
+          "to": [
+            "authenticated"
+          ],
+          "withCheck": "team_id IN (SELECT team_id FROM profiles WHERE id = current_profile_id() AND access_removed_at IS NULL)"
+        },
+        "Team members can update activities": {
+          "name": "Team members can update activities",
+          "as": "PERMISSIVE",
+          "for": "UPDATE",
+          "to": [
+            "authenticated"
+          ],
+          "using": "team_id IN (SELECT team_id FROM profiles WHERE id = current_profile_id() AND access_removed_at IS NULL)",
+          "withCheck": "team_id IN (SELECT team_id FROM profiles WHERE id = current_profile_id() AND access_removed_at IS NULL)"
+        },
+        "Team members can delete activities": {
+          "name": "Team members can delete activities",
+          "as": "PERMISSIVE",
+          "for": "DELETE",
+          "to": [
+            "authenticated"
+          ],
+          "using": "team_id IN (SELECT team_id FROM profiles WHERE id = current_profile_id() AND access_removed_at IS NULL)"
+        }
+      },
+      "checkConstraints": {},
+      "isRLSEnabled": true
+    },
+    "public.team_reflections": {
+      "name": "team_reflections",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "month": {
+          "name": "month",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "what_went_well": {
+          "name": "what_went_well",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "what_didnt_go_well": {
+          "name": "what_didnt_go_well",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "what_we_do_differently": {
+          "name": "what_we_do_differently",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "planned_action_steps": {
+          "name": "planned_action_steps",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "responsible_person": {
+          "name": "responsible_person",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "removed_at": {
+          "name": "removed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_by_profile_id": {
+          "name": "created_by_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_by_profile_id": {
+          "name": "updated_by_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "team_reflections_team_month_idx": {
+          "name": "team_reflections_team_month_idx",
+          "columns": [
+            {
+              "expression": "team_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "uuid_ops"
+            },
+            {
+              "expression": "month",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "date_ops"
+            }
+          ],
+          "isUnique": true,
+          "where": "(removed_at IS NULL)",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "team_reflections_team_id_fkey": {
+          "name": "team_reflections_team_id_fkey",
+          "tableFrom": "team_reflections",
+          "tableTo": "teams",
+          "columnsFrom": [
+            "team_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "team_reflections_created_by_profile_id_fkey": {
+          "name": "team_reflections_created_by_profile_id_fkey",
+          "tableFrom": "team_reflections",
+          "tableTo": "profiles",
+          "columnsFrom": [
+            "created_by_profile_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "team_reflections_updated_by_profile_id_fkey": {
+          "name": "team_reflections_updated_by_profile_id_fkey",
+          "tableFrom": "team_reflections",
+          "tableTo": "profiles",
+          "columnsFrom": [
+            "updated_by_profile_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {
+        "Team members can view reflections": {
+          "name": "Team members can view reflections",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": [
+            "authenticated"
+          ],
+          "using": "team_id IN (SELECT team_id FROM profiles WHERE id = current_profile_id() AND access_removed_at IS NULL)"
+        },
+        "Team members can create reflections": {
+          "name": "Team members can create reflections",
+          "as": "PERMISSIVE",
+          "for": "INSERT",
+          "to": [
+            "authenticated"
+          ],
+          "withCheck": "team_id IN (SELECT team_id FROM profiles WHERE id = current_profile_id() AND access_removed_at IS NULL)"
+        },
+        "Team members can update reflections": {
+          "name": "Team members can update reflections",
+          "as": "PERMISSIVE",
+          "for": "UPDATE",
+          "to": [
+            "authenticated"
+          ],
+          "using": "team_id IN (SELECT team_id FROM profiles WHERE id = current_profile_id() AND access_removed_at IS NULL)",
+          "withCheck": "team_id IN (SELECT team_id FROM profiles WHERE id = current_profile_id() AND access_removed_at IS NULL)"
+        },
+        "Team members can delete reflections": {
+          "name": "Team members can delete reflections",
+          "as": "PERMISSIVE",
+          "for": "DELETE",
+          "to": [
+            "authenticated"
+          ],
+          "using": "team_id IN (SELECT team_id FROM profiles WHERE id = current_profile_id() AND access_removed_at IS NULL)"
+        }
+      },
+      "checkConstraints": {},
+      "isRLSEnabled": true
+    },
+    "public.team_semester_reflection_entries": {
+      "name": "team_semester_reflection_entries",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "semester_reflection_id": {
+          "name": "semester_reflection_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "topic": {
+          "name": "topic",
+          "type": "semester_reflection_topic",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "what_went_well": {
+          "name": "what_went_well",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "what_didnt_go_well": {
+          "name": "what_didnt_go_well",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "what_next_time": {
+          "name": "what_next_time",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_by_profile_id": {
+          "name": "updated_by_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "team_semester_reflection_entries_reflection_topic_idx": {
+          "name": "team_semester_reflection_entries_reflection_topic_idx",
+          "columns": [
+            {
+              "expression": "semester_reflection_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "uuid_ops"
+            },
+            {
+              "expression": "topic",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "enum_ops"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "team_semester_reflection_entries_reflection_idx": {
+          "name": "team_semester_reflection_entries_reflection_idx",
+          "columns": [
+            {
+              "expression": "semester_reflection_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "uuid_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "team_semester_reflection_entries_semester_reflection_id_fkey": {
+          "name": "team_semester_reflection_entries_semester_reflection_id_fkey",
+          "tableFrom": "team_semester_reflection_entries",
+          "tableTo": "team_semester_reflections",
+          "columnsFrom": [
+            "semester_reflection_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "team_semester_reflection_entries_updated_by_profile_id_fkey": {
+          "name": "team_semester_reflection_entries_updated_by_profile_id_fkey",
+          "tableFrom": "team_semester_reflection_entries",
+          "tableTo": "profiles",
+          "columnsFrom": [
+            "updated_by_profile_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {
+        "Team members can view semester reflection entries": {
+          "name": "Team members can view semester reflection entries",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": [
+            "authenticated"
+          ],
+          "using": "EXISTS (SELECT 1 FROM team_semester_reflections tsr WHERE tsr.id = team_semester_reflection_entries.semester_reflection_id AND tsr.team_id IN (SELECT team_id FROM profiles WHERE id = current_profile_id() AND access_removed_at IS NULL))"
+        },
+        "Team members can create semester reflection entries": {
+          "name": "Team members can create semester reflection entries",
+          "as": "PERMISSIVE",
+          "for": "INSERT",
+          "to": [
+            "authenticated"
+          ],
+          "withCheck": "EXISTS (SELECT 1 FROM team_semester_reflections tsr WHERE tsr.id = team_semester_reflection_entries.semester_reflection_id AND tsr.team_id IN (SELECT team_id FROM profiles WHERE id = current_profile_id() AND access_removed_at IS NULL))"
+        },
+        "Team members can update semester reflection entries": {
+          "name": "Team members can update semester reflection entries",
+          "as": "PERMISSIVE",
+          "for": "UPDATE",
+          "to": [
+            "authenticated"
+          ],
+          "using": "EXISTS (SELECT 1 FROM team_semester_reflections tsr WHERE tsr.id = team_semester_reflection_entries.semester_reflection_id AND tsr.team_id IN (SELECT team_id FROM profiles WHERE id = current_profile_id() AND access_removed_at IS NULL))",
+          "withCheck": "EXISTS (SELECT 1 FROM team_semester_reflections tsr WHERE tsr.id = team_semester_reflection_entries.semester_reflection_id AND tsr.team_id IN (SELECT team_id FROM profiles WHERE id = current_profile_id() AND access_removed_at IS NULL))"
+        }
+      },
+      "checkConstraints": {},
+      "isRLSEnabled": true
+    },
+    "public.team_semester_reflections": {
+      "name": "team_semester_reflections",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "semester_month": {
+          "name": "semester_month",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "removed_at": {
+          "name": "removed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_by_profile_id": {
+          "name": "created_by_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_by_profile_id": {
+          "name": "updated_by_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "team_semester_reflections_team_month_idx": {
+          "name": "team_semester_reflections_team_month_idx",
+          "columns": [
+            {
+              "expression": "team_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "uuid_ops"
+            },
+            {
+              "expression": "semester_month",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "date_ops"
+            }
+          ],
+          "isUnique": true,
+          "where": "(removed_at IS NULL)",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "team_semester_reflections_team_id_fkey": {
+          "name": "team_semester_reflections_team_id_fkey",
+          "tableFrom": "team_semester_reflections",
+          "tableTo": "teams",
+          "columnsFrom": [
+            "team_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "team_semester_reflections_created_by_profile_id_fkey": {
+          "name": "team_semester_reflections_created_by_profile_id_fkey",
+          "tableFrom": "team_semester_reflections",
+          "tableTo": "profiles",
+          "columnsFrom": [
+            "created_by_profile_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "team_semester_reflections_updated_by_profile_id_fkey": {
+          "name": "team_semester_reflections_updated_by_profile_id_fkey",
+          "tableFrom": "team_semester_reflections",
+          "tableTo": "profiles",
+          "columnsFrom": [
+            "updated_by_profile_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {
+        "Team members can view semester reflections": {
+          "name": "Team members can view semester reflections",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": [
+            "authenticated"
+          ],
+          "using": "team_id IN (SELECT team_id FROM profiles WHERE id = current_profile_id() AND access_removed_at IS NULL)"
+        },
+        "Team members can create semester reflections": {
+          "name": "Team members can create semester reflections",
+          "as": "PERMISSIVE",
+          "for": "INSERT",
+          "to": [
+            "authenticated"
+          ],
+          "withCheck": "team_id IN (SELECT team_id FROM profiles WHERE id = current_profile_id() AND access_removed_at IS NULL)"
+        },
+        "Team members can update semester reflections": {
+          "name": "Team members can update semester reflections",
+          "as": "PERMISSIVE",
+          "for": "UPDATE",
+          "to": [
+            "authenticated"
+          ],
+          "using": "team_id IN (SELECT team_id FROM profiles WHERE id = current_profile_id() AND access_removed_at IS NULL)",
+          "withCheck": "team_id IN (SELECT team_id FROM profiles WHERE id = current_profile_id() AND access_removed_at IS NULL)"
+        },
+        "Team members can delete semester reflections": {
+          "name": "Team members can delete semester reflections",
+          "as": "PERMISSIVE",
+          "for": "DELETE",
+          "to": [
+            "authenticated"
+          ],
+          "using": "team_id IN (SELECT team_id FROM profiles WHERE id = current_profile_id() AND access_removed_at IS NULL)"
+        }
+      },
+      "checkConstraints": {
+        "team_semester_reflections_month_check": {
+          "name": "team_semester_reflections_month_check",
+          "value": "EXTRACT(MONTH FROM semester_month) IN (1, 5)"
+        }
+      },
+      "isRLSEnabled": true
+    },
+    "public.teams": {
+      "name": "teams",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "picture": {
+          "name": "picture",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "color": {
+          "name": "color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "onboardingYear": {
+          "name": "onboardingYear",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "removed_at": {
+          "name": "removed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_by_profile_id": {
+          "name": "created_by_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_by_profile_id": {
+          "name": "updated_by_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {
+        "Authenticated users can read teams": {
+          "name": "Authenticated users can read teams",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": [
+            "authenticated"
+          ],
+          "using": "true"
+        }
+      },
+      "checkConstraints": {},
+      "isRLSEnabled": true
+    },
+    "public.tools_techniques": {
+      "name": "tools_techniques",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "profile_id": {
+          "name": "profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tool_type": {
+          "name": "tool_type",
+          "type": "tool_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reflection": {
+          "name": "reflection",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "removed_at": {
+          "name": "removed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_by_profile_id": {
+          "name": "created_by_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_by_profile_id": {
+          "name": "updated_by_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "tools_techniques_profile_idx": {
+          "name": "tools_techniques_profile_idx",
+          "columns": [
+            {
+              "expression": "profile_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "uuid_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "tools_techniques_profile_id_fkey": {
+          "name": "tools_techniques_profile_id_fkey",
+          "tableFrom": "tools_techniques",
+          "tableTo": "profiles",
+          "columnsFrom": [
+            "profile_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "tools_techniques_created_by_profile_id_fkey": {
+          "name": "tools_techniques_created_by_profile_id_fkey",
+          "tableFrom": "tools_techniques",
+          "tableTo": "profiles",
+          "columnsFrom": [
+            "created_by_profile_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "tools_techniques_updated_by_profile_id_fkey": {
+          "name": "tools_techniques_updated_by_profile_id_fkey",
+          "tableFrom": "tools_techniques",
+          "tableTo": "profiles",
+          "columnsFrom": [
+            "updated_by_profile_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {
+        "Users can view their own tools and techniques": {
+          "name": "Users can view their own tools and techniques",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": [
+            "authenticated"
+          ],
+          "using": "(profile_id = current_profile_id())"
+        },
+        "Users can create their own tools and techniques": {
+          "name": "Users can create their own tools and techniques",
+          "as": "PERMISSIVE",
+          "for": "INSERT",
+          "to": [
+            "authenticated"
+          ],
+          "withCheck": "(profile_id = current_profile_id())"
+        },
+        "Users can update their own tools and techniques": {
+          "name": "Users can update their own tools and techniques",
+          "as": "PERMISSIVE",
+          "for": "UPDATE",
+          "to": [
+            "authenticated"
+          ],
+          "using": "(profile_id = current_profile_id())",
+          "withCheck": "(profile_id = current_profile_id())"
+        },
+        "Users can delete their own tools and techniques": {
+          "name": "Users can delete their own tools and techniques",
+          "as": "PERMISSIVE",
+          "for": "DELETE",
+          "to": [
+            "authenticated"
+          ],
+          "using": "(profile_id = current_profile_id())"
+        }
+      },
+      "checkConstraints": {},
+      "isRLSEnabled": true
+    }
+  },
+  "enums": {
+    "public.book_list_status": {
+      "name": "book_list_status",
+      "schema": "public",
+      "values": [
+        "processing",
+        "shortlist",
+        "longlist",
+        "archived"
+      ]
+    },
+    "public.book_source": {
+      "name": "book_source",
+      "schema": "public",
+      "values": [
+        "manual",
+        "google_books",
+        "open_library"
+      ]
+    },
+    "public.personality_test_type": {
+      "name": "personality_test_type",
+      "schema": "public",
+      "values": [
+        "gallup",
+        "mbti",
+        "disc",
+        "big_five",
+        "enneagram",
+        "belbin",
+        "other"
+      ]
+    },
+    "public.profile_role": {
+      "name": "profile_role",
+      "schema": "public",
+      "values": [
+        "student",
+        "mentor",
+        "coach",
+        "admin"
+      ]
+    },
+    "public.schedule_type": {
+      "name": "schedule_type",
+      "schema": "public",
+      "values": [
+        "training_session",
+        "houston_calling"
+      ]
+    },
+    "public.semester_reflection_topic": {
+      "name": "semester_reflection_topic",
+      "schema": "public",
+      "values": [
+        "predmety_zkousky_vyucujici",
+        "metodika_a_metriky",
+        "kouci_a_mentori",
+        "tymy_a_tymove_spolecnosti",
+        "individualni_prinos",
+        "komunita",
+        "komunitni_role",
+        "komunitni_akce",
+        "komunitni_a_cross_projekty",
+        "zacleneni_tucnaku",
+        "dalsi"
+      ]
+    },
+    "public.tool_type": {
+      "name": "tool_type",
+      "schema": "public",
+      "values": [
+        "model",
+        "technique",
+        "tool"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {
+    "public.books_with_essay_count": {
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "title_cs": {
+          "name": "title_cs",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "title_en": {
+          "name": "title_en",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "author": {
+          "name": "author",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "isbn_13": {
+          "name": "isbn_13",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "google_books_cover_url": {
+          "name": "google_books_cover_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "book_points": {
+          "name": "book_points",
+          "type": "numeric(3, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "page_count": {
+          "name": "page_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "preview_link": {
+          "name": "preview_link",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source": {
+          "name": "source",
+          "type": "book_source",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "external_id": {
+          "name": "external_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "list_status": {
+          "name": "list_status",
+          "type": "book_list_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "list_status_changed_at": {
+          "name": "list_status_changed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "list_status_changed_by_profile_id": {
+          "name": "list_status_changed_by_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "list_status_reason": {
+          "name": "list_status_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "highlight_category_id": {
+          "name": "highlight_category_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_rocket_model": {
+          "name": "is_rocket_model",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by_profile_id": {
+          "name": "created_by_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_by_profile_id": {
+          "name": "updated_by_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "essay_count": {
+          "name": "essay_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "definition": "SELECT b.id, b.title_cs, b.title_en, b.author, b.isbn_13, b.description, b.google_books_cover_url, b.book_points, b.page_count, b.preview_link, b.source, b.external_id, b.list_status, b.list_status_changed_at, b.list_status_changed_by_profile_id, b.list_status_reason, b.highlight_category_id, b.is_rocket_model, b.created_at, b.updated_at, b.created_by_profile_id, b.updated_by_profile_id, COALESCE(ec.essay_count, 0) AS essay_count FROM books b LEFT JOIN ( SELECT essays.book_id, count(*)::integer AS essay_count FROM essays WHERE essays.book_id IS NOT NULL AND essays.published_at IS NOT NULL AND essays.removed_at IS NULL GROUP BY essays.book_id) ec ON ec.book_id = b.id",
+      "name": "books_with_essay_count",
+      "schema": "public",
+      "isExisting": false,
+      "materialized": false
+    }
+  },
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/supabase/migrations/meta/20260818181637_snapshot.json
+++ b/supabase/migrations/meta/20260818181637_snapshot.json
@@ -1,0 +1,5831 @@
+{
+  "id": "564fc955-c46c-491c-8a82-17b131dd5264",
+  "prevId": "30f83aae-8ffe-4311-80a9-3fbc4700454b",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.book_loans": {
+      "name": "book_loans",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "library_book_id": {
+          "name": "library_book_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "borrower_id": {
+          "name": "borrower_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "borrowed_at": {
+          "name": "borrowed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "due_at": {
+          "name": "due_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "returned_at": {
+          "name": "returned_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "book_loans_library_book_id_idx": {
+          "name": "book_loans_library_book_id_idx",
+          "columns": [
+            {
+              "expression": "library_book_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "uuid_ops"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "book_loans_borrower_id_idx": {
+          "name": "book_loans_borrower_id_idx",
+          "columns": [
+            {
+              "expression": "borrower_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "uuid_ops"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "book_loans_active_idx": {
+          "name": "book_loans_active_idx",
+          "columns": [
+            {
+              "expression": "library_book_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "uuid_ops"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "where": "(returned_at IS NULL)",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "book_loans_library_book_id_fkey": {
+          "name": "book_loans_library_book_id_fkey",
+          "tableFrom": "book_loans",
+          "columnsFrom": [
+            "library_book_id"
+          ],
+          "tableTo": "library_books",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "restrict"
+        },
+        "book_loans_borrower_id_fkey": {
+          "name": "book_loans_borrower_id_fkey",
+          "tableFrom": "book_loans",
+          "columnsFrom": [
+            "borrower_id"
+          ],
+          "tableTo": "profiles",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "restrict"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {
+        "Authenticated users can view loans": {
+          "name": "Authenticated users can view loans",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": [
+            "authenticated"
+          ],
+          "using": "true"
+        },
+        "Users can borrow for themselves": {
+          "name": "Users can borrow for themselves",
+          "as": "PERMISSIVE",
+          "for": "INSERT",
+          "to": [
+            "authenticated"
+          ],
+          "withCheck": "(borrower_id = current_profile_id())"
+        },
+        "Borrower can return their own loan": {
+          "name": "Borrower can return their own loan",
+          "as": "PERMISSIVE",
+          "for": "UPDATE",
+          "to": [
+            "authenticated"
+          ],
+          "using": "(borrower_id = current_profile_id())",
+          "withCheck": "(borrower_id = current_profile_id())"
+        }
+      },
+      "checkConstraints": {},
+      "isRLSEnabled": true
+    },
+    "public.book_tags": {
+      "name": "book_tags",
+      "schema": "",
+      "columns": {
+        "book_id": {
+          "name": "book_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tag_id": {
+          "name": "tag_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_by_profile_id": {
+          "name": "created_by_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_by_profile_id": {
+          "name": "updated_by_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "book_tags_tag_idx": {
+          "name": "book_tags_tag_idx",
+          "columns": [
+            {
+              "expression": "tag_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "uuid_ops"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "book_tags_book_id_fkey": {
+          "name": "book_tags_book_id_fkey",
+          "tableFrom": "book_tags",
+          "columnsFrom": [
+            "book_id"
+          ],
+          "tableTo": "books",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        },
+        "book_tags_tag_id_fkey": {
+          "name": "book_tags_tag_id_fkey",
+          "tableFrom": "book_tags",
+          "columnsFrom": [
+            "tag_id"
+          ],
+          "tableTo": "tags",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        },
+        "book_tags_created_by_profile_id_fkey": {
+          "name": "book_tags_created_by_profile_id_fkey",
+          "tableFrom": "book_tags",
+          "columnsFrom": [
+            "created_by_profile_id"
+          ],
+          "tableTo": "profiles",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "restrict"
+        },
+        "book_tags_updated_by_profile_id_fkey": {
+          "name": "book_tags_updated_by_profile_id_fkey",
+          "tableFrom": "book_tags",
+          "columnsFrom": [
+            "updated_by_profile_id"
+          ],
+          "tableTo": "profiles",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "restrict"
+        }
+      },
+      "compositePrimaryKeys": {
+        "book_tags_pkey": {
+          "name": "book_tags_pkey",
+          "columns": [
+            "book_id",
+            "tag_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {
+        "Authenticated users can view book tags": {
+          "name": "Authenticated users can view book tags",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": [
+            "authenticated"
+          ],
+          "using": "true"
+        },
+        "Authenticated users can assign book tags": {
+          "name": "Authenticated users can assign book tags",
+          "as": "PERMISSIVE",
+          "for": "INSERT",
+          "to": [
+            "authenticated"
+          ],
+          "withCheck": "(created_by_profile_id = current_profile_id())"
+        },
+        "Coaches and admins can update book tags": {
+          "name": "Coaches and admins can update book tags",
+          "as": "PERMISSIVE",
+          "for": "UPDATE",
+          "to": [
+            "authenticated"
+          ],
+          "using": "is_coach_or_admin()",
+          "withCheck": "is_coach_or_admin()"
+        },
+        "Coaches and admins can remove book tags": {
+          "name": "Coaches and admins can remove book tags",
+          "as": "PERMISSIVE",
+          "for": "DELETE",
+          "to": [
+            "authenticated"
+          ],
+          "using": "is_coach_or_admin()"
+        }
+      },
+      "checkConstraints": {},
+      "isRLSEnabled": true
+    },
+    "public.books": {
+      "name": "books",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "title_cs": {
+          "name": "title_cs",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title_en": {
+          "name": "title_en",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "author": {
+          "name": "author",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "isbn_13": {
+          "name": "isbn_13",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "google_books_cover_url": {
+          "name": "google_books_cover_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "book_points": {
+          "name": "book_points",
+          "type": "numeric(3, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "page_count": {
+          "name": "page_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "preview_link": {
+          "name": "preview_link",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source": {
+          "name": "source",
+          "type": "book_source",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'manual'"
+        },
+        "external_id": {
+          "name": "external_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "list_status": {
+          "name": "list_status",
+          "type": "book_list_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'processing'"
+        },
+        "list_status_changed_at": {
+          "name": "list_status_changed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "list_status_changed_by_profile_id": {
+          "name": "list_status_changed_by_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "list_status_reason": {
+          "name": "list_status_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "highlight_category_id": {
+          "name": "highlight_category_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_rocket_model": {
+          "name": "is_rocket_model",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_by_profile_id": {
+          "name": "created_by_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_by_profile_id": {
+          "name": "updated_by_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "books_created_by_idx": {
+          "name": "books_created_by_idx",
+          "columns": [
+            {
+              "expression": "created_by_profile_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "uuid_ops"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "books_author_trgm_idx": {
+          "name": "books_author_trgm_idx",
+          "columns": [
+            {
+              "expression": "author",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "gin_trgm_ops"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "gin",
+          "concurrently": false
+        },
+        "books_created_desc_idx": {
+          "name": "books_created_desc_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "first",
+              "opclass": "timestamptz_ops"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "books_isbn_13_idx": {
+          "name": "books_isbn_13_idx",
+          "columns": [
+            {
+              "expression": "isbn_13",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "text_ops"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "where": "(isbn_13 IS NOT NULL)",
+          "concurrently": false
+        },
+        "books_list_status_idx": {
+          "name": "books_list_status_idx",
+          "columns": [
+            {
+              "expression": "list_status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "enum_ops"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "books_title_cs_trgm_idx": {
+          "name": "books_title_cs_trgm_idx",
+          "columns": [
+            {
+              "expression": "title_cs",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "gin_trgm_ops"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "gin",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "books_created_by_profile_id_fkey": {
+          "name": "books_created_by_profile_id_fkey",
+          "tableFrom": "books",
+          "columnsFrom": [
+            "created_by_profile_id"
+          ],
+          "tableTo": "profiles",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "restrict"
+        },
+        "books_updated_by_profile_id_fkey": {
+          "name": "books_updated_by_profile_id_fkey",
+          "tableFrom": "books",
+          "columnsFrom": [
+            "updated_by_profile_id"
+          ],
+          "tableTo": "profiles",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "restrict"
+        },
+        "books_list_status_changed_by_profile_id_fkey": {
+          "name": "books_list_status_changed_by_profile_id_fkey",
+          "tableFrom": "books",
+          "columnsFrom": [
+            "list_status_changed_by_profile_id"
+          ],
+          "tableTo": "profiles",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "set null"
+        },
+        "books_highlight_category_id_fkey": {
+          "name": "books_highlight_category_id_fkey",
+          "tableFrom": "books",
+          "columnsFrom": [
+            "highlight_category_id"
+          ],
+          "tableTo": "highlight_categories",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "set null"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {
+        "Coaches and admins can delete books": {
+          "name": "Coaches and admins can delete books",
+          "as": "PERMISSIVE",
+          "for": "DELETE",
+          "to": [
+            "public"
+          ],
+          "using": "is_coach_or_admin()"
+        },
+        "Coaches and admins can update books": {
+          "name": "Coaches and admins can update books",
+          "as": "PERMISSIVE",
+          "for": "UPDATE",
+          "to": [
+            "authenticated"
+          ],
+          "using": "is_coach_or_admin()",
+          "withCheck": "is_coach_or_admin()"
+        },
+        "Authenticated users can add books": {
+          "name": "Authenticated users can add books",
+          "as": "PERMISSIVE",
+          "for": "INSERT",
+          "to": [
+            "authenticated"
+          ],
+          "withCheck": "(created_by_profile_id = current_profile_id())"
+        },
+        "Authenticated users can view all books": {
+          "name": "Authenticated users can view all books",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": [
+            "authenticated"
+          ],
+          "using": "true"
+        }
+      },
+      "checkConstraints": {
+        "books_book_points_check": {
+          "name": "books_book_points_check",
+          "value": "(book_points IS NULL) OR ((book_points >= (0)::numeric) AND (book_points <= (3)::numeric))"
+        },
+        "books_archived_points_check": {
+          "name": "books_archived_points_check",
+          "value": "(list_status <> 'archived') OR (book_points = (0)::numeric)"
+        }
+      },
+      "isRLSEnabled": true
+    },
+    "public.highlight_categories": {
+      "name": "highlight_categories",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_by_profile_id": {
+          "name": "created_by_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_by_profile_id": {
+          "name": "updated_by_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "highlight_categories_created_by_profile_id_fkey": {
+          "name": "highlight_categories_created_by_profile_id_fkey",
+          "tableFrom": "highlight_categories",
+          "columnsFrom": [
+            "created_by_profile_id"
+          ],
+          "tableTo": "profiles",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "restrict"
+        },
+        "highlight_categories_updated_by_profile_id_fkey": {
+          "name": "highlight_categories_updated_by_profile_id_fkey",
+          "tableFrom": "highlight_categories",
+          "columnsFrom": [
+            "updated_by_profile_id"
+          ],
+          "tableTo": "profiles",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "restrict"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {
+        "Authenticated users can view highlight categories": {
+          "name": "Authenticated users can view highlight categories",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": [
+            "authenticated"
+          ],
+          "using": "true"
+        },
+        "Coaches and admins can add highlight categories": {
+          "name": "Coaches and admins can add highlight categories",
+          "as": "PERMISSIVE",
+          "for": "INSERT",
+          "to": [
+            "authenticated"
+          ],
+          "withCheck": "is_coach_or_admin()"
+        },
+        "Coaches and admins can update highlight categories": {
+          "name": "Coaches and admins can update highlight categories",
+          "as": "PERMISSIVE",
+          "for": "UPDATE",
+          "to": [
+            "authenticated"
+          ],
+          "using": "is_coach_or_admin()",
+          "withCheck": "is_coach_or_admin()"
+        },
+        "Coaches and admins can delete highlight categories": {
+          "name": "Coaches and admins can delete highlight categories",
+          "as": "PERMISSIVE",
+          "for": "DELETE",
+          "to": [
+            "authenticated"
+          ],
+          "using": "is_coach_or_admin()"
+        }
+      },
+      "checkConstraints": {},
+      "isRLSEnabled": true
+    },
+    "public.library_books": {
+      "name": "library_books",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "book_id": {
+          "name": "book_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "isbn_13": {
+          "name": "isbn_13",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_by_profile_id": {
+          "name": "created_by_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_by_profile_id": {
+          "name": "updated_by_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "library_books_book_id_idx": {
+          "name": "library_books_book_id_idx",
+          "columns": [
+            {
+              "expression": "book_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "uuid_ops"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "library_books_isbn_13_idx": {
+          "name": "library_books_isbn_13_idx",
+          "columns": [
+            {
+              "expression": "isbn_13",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "text_ops"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "where": "(isbn_13 IS NOT NULL)",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "library_books_book_id_fkey": {
+          "name": "library_books_book_id_fkey",
+          "tableFrom": "library_books",
+          "columnsFrom": [
+            "book_id"
+          ],
+          "tableTo": "books",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "restrict"
+        },
+        "library_books_created_by_profile_id_fkey": {
+          "name": "library_books_created_by_profile_id_fkey",
+          "tableFrom": "library_books",
+          "columnsFrom": [
+            "created_by_profile_id"
+          ],
+          "tableTo": "profiles",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "restrict"
+        },
+        "library_books_updated_by_profile_id_fkey": {
+          "name": "library_books_updated_by_profile_id_fkey",
+          "tableFrom": "library_books",
+          "columnsFrom": [
+            "updated_by_profile_id"
+          ],
+          "tableTo": "profiles",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "restrict"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {
+        "Authenticated users can view library books": {
+          "name": "Authenticated users can view library books",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": [
+            "authenticated"
+          ],
+          "using": "true"
+        },
+        "Coaches and admins can add library books": {
+          "name": "Coaches and admins can add library books",
+          "as": "PERMISSIVE",
+          "for": "INSERT",
+          "to": [
+            "authenticated"
+          ],
+          "withCheck": "is_coach_or_admin()"
+        },
+        "Coaches and admins can update library books": {
+          "name": "Coaches and admins can update library books",
+          "as": "PERMISSIVE",
+          "for": "UPDATE",
+          "to": [
+            "authenticated"
+          ],
+          "using": "is_coach_or_admin()",
+          "withCheck": "is_coach_or_admin()"
+        },
+        "Coaches and admins can delete library books": {
+          "name": "Coaches and admins can delete library books",
+          "as": "PERMISSIVE",
+          "for": "DELETE",
+          "to": [
+            "authenticated"
+          ],
+          "using": "is_coach_or_admin()"
+        }
+      },
+      "checkConstraints": {},
+      "isRLSEnabled": true
+    },
+    "public.tags": {
+      "name": "tags",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_by_profile_id": {
+          "name": "created_by_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_by_profile_id": {
+          "name": "updated_by_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "tags_created_by_profile_id_fkey": {
+          "name": "tags_created_by_profile_id_fkey",
+          "tableFrom": "tags",
+          "columnsFrom": [
+            "created_by_profile_id"
+          ],
+          "tableTo": "profiles",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "restrict"
+        },
+        "tags_updated_by_profile_id_fkey": {
+          "name": "tags_updated_by_profile_id_fkey",
+          "tableFrom": "tags",
+          "columnsFrom": [
+            "updated_by_profile_id"
+          ],
+          "tableTo": "profiles",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "restrict"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "tags_name_key": {
+          "name": "tags_name_key",
+          "columns": [
+            "name"
+          ],
+          "nullsNotDistinct": false
+        }
+      },
+      "policies": {
+        "Authenticated users can view tags": {
+          "name": "Authenticated users can view tags",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": [
+            "authenticated"
+          ],
+          "using": "true"
+        },
+        "Coaches and admins can add tags": {
+          "name": "Coaches and admins can add tags",
+          "as": "PERMISSIVE",
+          "for": "INSERT",
+          "to": [
+            "authenticated"
+          ],
+          "withCheck": "is_coach_or_admin()"
+        },
+        "Coaches and admins can update tags": {
+          "name": "Coaches and admins can update tags",
+          "as": "PERMISSIVE",
+          "for": "UPDATE",
+          "to": [
+            "authenticated"
+          ],
+          "using": "is_coach_or_admin()",
+          "withCheck": "is_coach_or_admin()"
+        },
+        "Coaches and admins can delete tags": {
+          "name": "Coaches and admins can delete tags",
+          "as": "PERMISSIVE",
+          "for": "DELETE",
+          "to": [
+            "authenticated"
+          ],
+          "using": "is_coach_or_admin()"
+        }
+      },
+      "checkConstraints": {},
+      "isRLSEnabled": true
+    },
+    "public.customer_meetings": {
+      "name": "customer_meetings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "profile_id": {
+          "name": "profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "meeting_at": {
+          "name": "meeting_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "company": {
+          "name": "company",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "contact_person": {
+          "name": "contact_person",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "position": {
+          "name": "position",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "objective": {
+          "name": "objective",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "post_mortem": {
+          "name": "post_mortem",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "team_share": {
+          "name": "team_share",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "removed_at": {
+          "name": "removed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_by_profile_id": {
+          "name": "created_by_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_by_profile_id": {
+          "name": "updated_by_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "customer_meetings_profile_idx": {
+          "name": "customer_meetings_profile_idx",
+          "columns": [
+            {
+              "expression": "profile_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "uuid_ops"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "customer_meetings_created_desc_idx": {
+          "name": "customer_meetings_created_desc_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "first",
+              "opclass": "timestamptz_ops"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "customer_meetings_profile_id_fkey": {
+          "name": "customer_meetings_profile_id_fkey",
+          "tableFrom": "customer_meetings",
+          "columnsFrom": [
+            "profile_id"
+          ],
+          "tableTo": "profiles",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        },
+        "customer_meetings_created_by_profile_id_fkey": {
+          "name": "customer_meetings_created_by_profile_id_fkey",
+          "tableFrom": "customer_meetings",
+          "columnsFrom": [
+            "created_by_profile_id"
+          ],
+          "tableTo": "profiles",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "restrict"
+        },
+        "customer_meetings_updated_by_profile_id_fkey": {
+          "name": "customer_meetings_updated_by_profile_id_fkey",
+          "tableFrom": "customer_meetings",
+          "columnsFrom": [
+            "updated_by_profile_id"
+          ],
+          "tableTo": "profiles",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "restrict"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {
+        "Users can view their own customer meetings": {
+          "name": "Users can view their own customer meetings",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": [
+            "authenticated"
+          ],
+          "using": "(profile_id = current_profile_id())"
+        },
+        "Users can create their own customer meetings": {
+          "name": "Users can create their own customer meetings",
+          "as": "PERMISSIVE",
+          "for": "INSERT",
+          "to": [
+            "authenticated"
+          ],
+          "withCheck": "(profile_id = current_profile_id())"
+        },
+        "Users can update their own customer meetings": {
+          "name": "Users can update their own customer meetings",
+          "as": "PERMISSIVE",
+          "for": "UPDATE",
+          "to": [
+            "authenticated"
+          ],
+          "using": "(profile_id = current_profile_id())",
+          "withCheck": "(profile_id = current_profile_id())"
+        },
+        "Users can delete their own customer meetings": {
+          "name": "Users can delete their own customer meetings",
+          "as": "PERMISSIVE",
+          "for": "DELETE",
+          "to": [
+            "authenticated"
+          ],
+          "using": "(profile_id = current_profile_id())"
+        }
+      },
+      "checkConstraints": {},
+      "isRLSEnabled": true
+    },
+    "public.dashboard_layouts": {
+      "name": "dashboard_layouts",
+      "schema": "",
+      "columns": {
+        "profile_id": {
+          "name": "profile_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "widgets": {
+          "name": "widgets",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_by_profile_id": {
+          "name": "created_by_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_by_profile_id": {
+          "name": "updated_by_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "dashboard_layouts_profile_id_fkey": {
+          "name": "dashboard_layouts_profile_id_fkey",
+          "tableFrom": "dashboard_layouts",
+          "columnsFrom": [
+            "profile_id"
+          ],
+          "tableTo": "profiles",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        },
+        "dashboard_layouts_created_by_profile_id_fkey": {
+          "name": "dashboard_layouts_created_by_profile_id_fkey",
+          "tableFrom": "dashboard_layouts",
+          "columnsFrom": [
+            "created_by_profile_id"
+          ],
+          "tableTo": "profiles",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "restrict"
+        },
+        "dashboard_layouts_updated_by_profile_id_fkey": {
+          "name": "dashboard_layouts_updated_by_profile_id_fkey",
+          "tableFrom": "dashboard_layouts",
+          "columnsFrom": [
+            "updated_by_profile_id"
+          ],
+          "tableTo": "profiles",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "restrict"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {
+        "Users can delete their own dashboard layout": {
+          "name": "Users can delete their own dashboard layout",
+          "as": "PERMISSIVE",
+          "for": "DELETE",
+          "to": [
+            "public"
+          ],
+          "using": "(profile_id = current_profile_id())"
+        },
+        "Users can update their own dashboard layout": {
+          "name": "Users can update their own dashboard layout",
+          "as": "PERMISSIVE",
+          "for": "UPDATE",
+          "to": [
+            "public"
+          ],
+          "using": "(profile_id = current_profile_id())",
+          "withCheck": "(profile_id = current_profile_id())"
+        },
+        "Users can insert their own dashboard layout": {
+          "name": "Users can insert their own dashboard layout",
+          "as": "PERMISSIVE",
+          "for": "INSERT",
+          "to": [
+            "public"
+          ],
+          "withCheck": "(profile_id = current_profile_id())"
+        },
+        "Users can view their own dashboard layout": {
+          "name": "Users can view their own dashboard layout",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": [
+            "public"
+          ],
+          "using": "(profile_id = current_profile_id())"
+        }
+      },
+      "checkConstraints": {},
+      "isRLSEnabled": true
+    },
+    "public.essay_coach_reads": {
+      "name": "essay_coach_reads",
+      "schema": "",
+      "columns": {
+        "essay_id": {
+          "name": "essay_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "coach_profile_id": {
+          "name": "coach_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "read_at": {
+          "name": "read_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_by_profile_id": {
+          "name": "created_by_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_by_profile_id": {
+          "name": "updated_by_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "essay_coach_reads_coach_idx": {
+          "name": "essay_coach_reads_coach_idx",
+          "columns": [
+            {
+              "expression": "coach_profile_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "uuid_ops"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "essay_coach_reads_essay_id_fkey": {
+          "name": "essay_coach_reads_essay_id_fkey",
+          "tableFrom": "essay_coach_reads",
+          "columnsFrom": [
+            "essay_id"
+          ],
+          "tableTo": "essays",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        },
+        "essay_coach_reads_coach_profile_id_fkey": {
+          "name": "essay_coach_reads_coach_profile_id_fkey",
+          "tableFrom": "essay_coach_reads",
+          "columnsFrom": [
+            "coach_profile_id"
+          ],
+          "tableTo": "profiles",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        },
+        "essay_coach_reads_created_by_profile_id_fkey": {
+          "name": "essay_coach_reads_created_by_profile_id_fkey",
+          "tableFrom": "essay_coach_reads",
+          "columnsFrom": [
+            "created_by_profile_id"
+          ],
+          "tableTo": "profiles",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "restrict"
+        },
+        "essay_coach_reads_updated_by_profile_id_fkey": {
+          "name": "essay_coach_reads_updated_by_profile_id_fkey",
+          "tableFrom": "essay_coach_reads",
+          "columnsFrom": [
+            "updated_by_profile_id"
+          ],
+          "tableTo": "profiles",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "restrict"
+        }
+      },
+      "compositePrimaryKeys": {
+        "essay_coach_reads_pkey": {
+          "name": "essay_coach_reads_pkey",
+          "columns": [
+            "essay_id",
+            "coach_profile_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {
+        "Coaches remove own reads": {
+          "name": "Coaches remove own reads",
+          "as": "PERMISSIVE",
+          "for": "DELETE",
+          "to": [
+            "authenticated"
+          ],
+          "using": "(coach_profile_id = current_profile_id())"
+        },
+        "Coaches mark own reads within their team": {
+          "name": "Coaches mark own reads within their team",
+          "as": "PERMISSIVE",
+          "for": "INSERT",
+          "to": [
+            "authenticated"
+          ],
+          "withCheck": "((coach_profile_id = current_profile_id()) AND coach_can_review_essay(essay_id))"
+        },
+        "Coach sees own reads; author sees reads of own essays": {
+          "name": "Coach sees own reads; author sees reads of own essays",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": [
+            "authenticated"
+          ],
+          "using": "((coach_profile_id = current_profile_id()) OR (EXISTS ( SELECT 1\n   FROM essays e\n  WHERE ((e.id = essay_coach_reads.essay_id) AND (e.author_profile_id = current_profile_id())))))"
+        }
+      },
+      "checkConstraints": {},
+      "isRLSEnabled": true
+    },
+    "public.essay_comments": {
+      "name": "essay_comments",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "essay_id": {
+          "name": "essay_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "author_profile_id": {
+          "name": "author_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "parent_id": {
+          "name": "parent_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "removed_at": {
+          "name": "removed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_by_profile_id": {
+          "name": "created_by_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_by_profile_id": {
+          "name": "updated_by_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "essay_comments_author_idx": {
+          "name": "essay_comments_author_idx",
+          "columns": [
+            {
+              "expression": "author_profile_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "uuid_ops"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "essay_comments_essay_idx": {
+          "name": "essay_comments_essay_idx",
+          "columns": [
+            {
+              "expression": "essay_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "uuid_ops"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "essay_comments_essay_id_fkey": {
+          "name": "essay_comments_essay_id_fkey",
+          "tableFrom": "essay_comments",
+          "columnsFrom": [
+            "essay_id"
+          ],
+          "tableTo": "essays",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        },
+        "essay_comments_author_profile_id_fkey": {
+          "name": "essay_comments_author_profile_id_fkey",
+          "tableFrom": "essay_comments",
+          "columnsFrom": [
+            "author_profile_id"
+          ],
+          "tableTo": "profiles",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        },
+        "essay_comments_created_by_profile_id_fkey": {
+          "name": "essay_comments_created_by_profile_id_fkey",
+          "tableFrom": "essay_comments",
+          "columnsFrom": [
+            "created_by_profile_id"
+          ],
+          "tableTo": "profiles",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "restrict"
+        },
+        "essay_comments_updated_by_profile_id_fkey": {
+          "name": "essay_comments_updated_by_profile_id_fkey",
+          "tableFrom": "essay_comments",
+          "columnsFrom": [
+            "updated_by_profile_id"
+          ],
+          "tableTo": "profiles",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "restrict"
+        },
+        "essay_comments_parent_id_fkey": {
+          "name": "essay_comments_parent_id_fkey",
+          "tableFrom": "essay_comments",
+          "columnsFrom": [
+            "parent_id"
+          ],
+          "tableTo": "essay_comments",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "set null"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {
+        "Authors and admins can delete essay comments": {
+          "name": "Authors and admins can delete essay comments",
+          "as": "PERMISSIVE",
+          "for": "DELETE",
+          "to": [
+            "authenticated"
+          ],
+          "using": "((author_profile_id = current_profile_id()) OR is_admin())"
+        },
+        "Authors can update their own essay comments": {
+          "name": "Authors can update their own essay comments",
+          "as": "PERMISSIVE",
+          "for": "UPDATE",
+          "to": [
+            "authenticated"
+          ],
+          "using": "(author_profile_id = current_profile_id())",
+          "withCheck": "(author_profile_id = current_profile_id())"
+        },
+        "Authenticated users can add essay comments": {
+          "name": "Authenticated users can add essay comments",
+          "as": "PERMISSIVE",
+          "for": "INSERT",
+          "to": [
+            "authenticated"
+          ],
+          "withCheck": "(author_profile_id = current_profile_id())"
+        },
+        "Authenticated users can view essay comments": {
+          "name": "Authenticated users can view essay comments",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": [
+            "authenticated"
+          ],
+          "using": "true"
+        }
+      },
+      "checkConstraints": {
+        "essay_comments_body_check": {
+          "name": "essay_comments_body_check",
+          "value": "(char_length(body) >= 1) AND (char_length(body) <= 4000)"
+        }
+      },
+      "isRLSEnabled": true
+    },
+    "public.essay_revisions": {
+      "name": "essay_revisions",
+      "schema": "",
+      "columns": {
+        "essay_id": {
+          "name": "essay_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "revision_no": {
+          "name": "revision_no",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content_json": {
+          "name": "content_json",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "invalid_since": {
+          "name": "invalid_since",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_by_profile_id": {
+          "name": "created_by_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_by_profile_id": {
+          "name": "updated_by_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "essay_revisions_essay_id_fkey": {
+          "name": "essay_revisions_essay_id_fkey",
+          "tableFrom": "essay_revisions",
+          "columnsFrom": [
+            "essay_id"
+          ],
+          "tableTo": "essays",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        },
+        "essay_revisions_created_by_profile_id_fkey": {
+          "name": "essay_revisions_created_by_profile_id_fkey",
+          "tableFrom": "essay_revisions",
+          "columnsFrom": [
+            "created_by_profile_id"
+          ],
+          "tableTo": "profiles",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "restrict"
+        },
+        "essay_revisions_updated_by_profile_id_fkey": {
+          "name": "essay_revisions_updated_by_profile_id_fkey",
+          "tableFrom": "essay_revisions",
+          "columnsFrom": [
+            "updated_by_profile_id"
+          ],
+          "tableTo": "profiles",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "restrict"
+        }
+      },
+      "compositePrimaryKeys": {
+        "essay_revisions_pkey": {
+          "name": "essay_revisions_pkey",
+          "columns": [
+            "essay_id",
+            "revision_no"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {
+        "Authenticated users can view essay revisions": {
+          "name": "Authenticated users can view essay revisions",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": [
+            "authenticated"
+          ],
+          "using": "(EXISTS ( SELECT 1\n   FROM essays e\n  WHERE ((e.id = essay_revisions.essay_id) AND ((e.published_at IS NOT NULL) OR (e.author_profile_id = ( SELECT current_profile_id())) OR ( SELECT is_admin())))))"
+        },
+        "Authors can create essay revisions": {
+          "name": "Authors can create essay revisions",
+          "as": "PERMISSIVE",
+          "for": "INSERT",
+          "to": [
+            "authenticated"
+          ],
+          "withCheck": "(created_by_profile_id = current_profile_id())"
+        },
+        "Authors can update their newest recent essay revision": {
+          "name": "Authors can update their newest recent essay revision",
+          "as": "PERMISSIVE",
+          "for": "UPDATE",
+          "to": [
+            "authenticated"
+          ],
+          "using": "((created_by_profile_id = ( SELECT current_profile_id())) AND (created_at > (now() - '00:30:00'::interval)))",
+          "withCheck": "(created_by_profile_id = ( SELECT current_profile_id()))"
+        },
+        "Essay revisions cannot be deleted": {
+          "name": "Essay revisions cannot be deleted",
+          "as": "PERMISSIVE",
+          "for": "DELETE",
+          "to": [
+            "authenticated"
+          ],
+          "using": "false"
+        }
+      },
+      "checkConstraints": {},
+      "isRLSEnabled": true
+    },
+    "public.essay_views": {
+      "name": "essay_views",
+      "schema": "",
+      "columns": {
+        "essay_id": {
+          "name": "essay_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "viewer_profile_id": {
+          "name": "viewer_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "first_viewed_at": {
+          "name": "first_viewed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_viewed_at": {
+          "name": "last_viewed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_by_profile_id": {
+          "name": "created_by_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_by_profile_id": {
+          "name": "updated_by_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "essay_views_viewer_idx": {
+          "name": "essay_views_viewer_idx",
+          "columns": [
+            {
+              "expression": "viewer_profile_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "uuid_ops"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "essay_views_essay_id_fkey": {
+          "name": "essay_views_essay_id_fkey",
+          "tableFrom": "essay_views",
+          "columnsFrom": [
+            "essay_id"
+          ],
+          "tableTo": "essays",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        },
+        "essay_views_viewer_profile_id_fkey": {
+          "name": "essay_views_viewer_profile_id_fkey",
+          "tableFrom": "essay_views",
+          "columnsFrom": [
+            "viewer_profile_id"
+          ],
+          "tableTo": "profiles",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        },
+        "essay_views_created_by_profile_id_fkey": {
+          "name": "essay_views_created_by_profile_id_fkey",
+          "tableFrom": "essay_views",
+          "columnsFrom": [
+            "created_by_profile_id"
+          ],
+          "tableTo": "profiles",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "restrict"
+        },
+        "essay_views_updated_by_profile_id_fkey": {
+          "name": "essay_views_updated_by_profile_id_fkey",
+          "tableFrom": "essay_views",
+          "columnsFrom": [
+            "updated_by_profile_id"
+          ],
+          "tableTo": "profiles",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "restrict"
+        }
+      },
+      "compositePrimaryKeys": {
+        "essay_views_pkey": {
+          "name": "essay_views_pkey",
+          "columns": [
+            "essay_id",
+            "viewer_profile_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {
+        "No direct inserts to essay_views": {
+          "name": "No direct inserts to essay_views",
+          "as": "PERMISSIVE",
+          "for": "INSERT",
+          "to": [
+            "authenticated"
+          ],
+          "withCheck": "false"
+        },
+        "Authors see all viewers; others see own row": {
+          "name": "Authors see all viewers; others see own row",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": [
+            "authenticated"
+          ],
+          "using": "((viewer_profile_id = current_profile_id()) OR (EXISTS ( SELECT 1\n   FROM essays e\n  WHERE ((e.id = essay_views.essay_id) AND (e.author_profile_id = current_profile_id())))))"
+        }
+      },
+      "checkConstraints": {},
+      "isRLSEnabled": true
+    },
+    "public.essay_votes": {
+      "name": "essay_votes",
+      "schema": "",
+      "columns": {
+        "essay_id": {
+          "name": "essay_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "voter_profile_id": {
+          "name": "voter_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_by_profile_id": {
+          "name": "created_by_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_by_profile_id": {
+          "name": "updated_by_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "essay_votes_voter_idx": {
+          "name": "essay_votes_voter_idx",
+          "columns": [
+            {
+              "expression": "voter_profile_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "uuid_ops"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "essay_votes_essay_id_fkey": {
+          "name": "essay_votes_essay_id_fkey",
+          "tableFrom": "essay_votes",
+          "columnsFrom": [
+            "essay_id"
+          ],
+          "tableTo": "essays",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        },
+        "essay_votes_voter_profile_id_fkey": {
+          "name": "essay_votes_voter_profile_id_fkey",
+          "tableFrom": "essay_votes",
+          "columnsFrom": [
+            "voter_profile_id"
+          ],
+          "tableTo": "profiles",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        },
+        "essay_votes_created_by_profile_id_fkey": {
+          "name": "essay_votes_created_by_profile_id_fkey",
+          "tableFrom": "essay_votes",
+          "columnsFrom": [
+            "created_by_profile_id"
+          ],
+          "tableTo": "profiles",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "restrict"
+        },
+        "essay_votes_updated_by_profile_id_fkey": {
+          "name": "essay_votes_updated_by_profile_id_fkey",
+          "tableFrom": "essay_votes",
+          "columnsFrom": [
+            "updated_by_profile_id"
+          ],
+          "tableTo": "profiles",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "restrict"
+        }
+      },
+      "compositePrimaryKeys": {
+        "essay_votes_pkey": {
+          "name": "essay_votes_pkey",
+          "columns": [
+            "essay_id",
+            "voter_profile_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {
+        "Users can vote (not own essays)": {
+          "name": "Users can vote (not own essays)",
+          "as": "PERMISSIVE",
+          "for": "INSERT",
+          "to": [
+            "authenticated"
+          ],
+          "withCheck": "((voter_profile_id = current_profile_id()) AND (NOT (essay_id IN ( SELECT essays.id\n   FROM essays\n  WHERE (essays.author_profile_id = current_profile_id())))))"
+        },
+        "Authenticated users can view votes": {
+          "name": "Authenticated users can view votes",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": [
+            "authenticated"
+          ],
+          "using": "true"
+        },
+        "Users can remove own votes": {
+          "name": "Users can remove own votes",
+          "as": "PERMISSIVE",
+          "for": "DELETE",
+          "to": [
+            "authenticated"
+          ],
+          "using": "(voter_profile_id = current_profile_id())"
+        }
+      },
+      "checkConstraints": {},
+      "isRLSEnabled": true
+    },
+    "public.essays": {
+      "name": "essays",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "external_id": {
+          "name": "external_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "author_profile_id": {
+          "name": "author_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "book_id": {
+          "name": "book_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "published_at": {
+          "name": "published_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pinned_at": {
+          "name": "pinned_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pinned_by_profile_id": {
+          "name": "pinned_by_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "removed_at": {
+          "name": "removed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_by_profile_id": {
+          "name": "created_by_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_by_profile_id": {
+          "name": "updated_by_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "essays_author_idx": {
+          "name": "essays_author_idx",
+          "columns": [
+            {
+              "expression": "author_profile_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "uuid_ops"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "essays_book_idx": {
+          "name": "essays_book_idx",
+          "columns": [
+            {
+              "expression": "book_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "uuid_ops"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "essays_created_desc_idx": {
+          "name": "essays_created_desc_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "first",
+              "opclass": "timestamptz_ops"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "essays_author_profile_id_fkey": {
+          "name": "essays_author_profile_id_fkey",
+          "tableFrom": "essays",
+          "columnsFrom": [
+            "author_profile_id"
+          ],
+          "tableTo": "profiles",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        },
+        "essays_book_id_fkey": {
+          "name": "essays_book_id_fkey",
+          "tableFrom": "essays",
+          "columnsFrom": [
+            "book_id"
+          ],
+          "tableTo": "books",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "set null"
+        },
+        "essays_pinned_by_profile_id_fkey": {
+          "name": "essays_pinned_by_profile_id_fkey",
+          "tableFrom": "essays",
+          "columnsFrom": [
+            "pinned_by_profile_id"
+          ],
+          "tableTo": "profiles",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "set null"
+        },
+        "essays_created_by_profile_id_fkey": {
+          "name": "essays_created_by_profile_id_fkey",
+          "tableFrom": "essays",
+          "columnsFrom": [
+            "created_by_profile_id"
+          ],
+          "tableTo": "profiles",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "restrict"
+        },
+        "essays_updated_by_profile_id_fkey": {
+          "name": "essays_updated_by_profile_id_fkey",
+          "tableFrom": "essays",
+          "columnsFrom": [
+            "updated_by_profile_id"
+          ],
+          "tableTo": "profiles",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "restrict"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {
+        "Authors can create their own essays": {
+          "name": "Authors can create their own essays",
+          "as": "PERMISSIVE",
+          "for": "INSERT",
+          "to": [
+            "authenticated"
+          ],
+          "withCheck": "(author_profile_id = current_profile_id())"
+        },
+        "Authenticated users can view all essays": {
+          "name": "Authenticated users can view all essays",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": [
+            "authenticated"
+          ],
+          "using": "((published_at IS NOT NULL) OR (author_profile_id = ( SELECT current_profile_id())) OR ( SELECT is_admin()))"
+        },
+        "Authors and admins can delete essays": {
+          "name": "Authors and admins can delete essays",
+          "as": "PERMISSIVE",
+          "for": "DELETE",
+          "to": [
+            "authenticated"
+          ],
+          "using": "((author_profile_id = current_profile_id()) OR is_admin())"
+        },
+        "Authors can update their own essays": {
+          "name": "Authors can update their own essays",
+          "as": "PERMISSIVE",
+          "for": "UPDATE",
+          "to": [
+            "authenticated"
+          ],
+          "using": "(author_profile_id = current_profile_id())",
+          "withCheck": "(author_profile_id = current_profile_id())"
+        }
+      },
+      "checkConstraints": {},
+      "isRLSEnabled": true
+    },
+    "public.feedback": {
+      "name": "feedback",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "author_profile_id": {
+          "name": "author_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "resolved_at": {
+          "name": "resolved_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_by_profile_id": {
+          "name": "created_by_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_by_profile_id": {
+          "name": "updated_by_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "feedback_active_created_idx": {
+          "name": "feedback_active_created_idx",
+          "columns": [
+            {
+              "expression": "resolved_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "timestamptz_ops"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "first",
+              "opclass": "timestamptz_ops"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "feedback_author_idx": {
+          "name": "feedback_author_idx",
+          "columns": [
+            {
+              "expression": "author_profile_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "uuid_ops"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "feedback_author_profile_id_fkey": {
+          "name": "feedback_author_profile_id_fkey",
+          "tableFrom": "feedback",
+          "columnsFrom": [
+            "author_profile_id"
+          ],
+          "tableTo": "profiles",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        },
+        "feedback_created_by_profile_id_fkey": {
+          "name": "feedback_created_by_profile_id_fkey",
+          "tableFrom": "feedback",
+          "columnsFrom": [
+            "created_by_profile_id"
+          ],
+          "tableTo": "profiles",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "restrict"
+        },
+        "feedback_updated_by_profile_id_fkey": {
+          "name": "feedback_updated_by_profile_id_fkey",
+          "tableFrom": "feedback",
+          "columnsFrom": [
+            "updated_by_profile_id"
+          ],
+          "tableTo": "profiles",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "restrict"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {
+        "Authenticated users can view feedback": {
+          "name": "Authenticated users can view feedback",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": [
+            "authenticated"
+          ],
+          "using": "true"
+        },
+        "Authenticated users can create feedback": {
+          "name": "Authenticated users can create feedback",
+          "as": "PERMISSIVE",
+          "for": "INSERT",
+          "to": [
+            "authenticated"
+          ],
+          "withCheck": "(author_profile_id = current_profile_id())"
+        },
+        "Admins can update feedback": {
+          "name": "Admins can update feedback",
+          "as": "PERMISSIVE",
+          "for": "UPDATE",
+          "to": [
+            "authenticated"
+          ],
+          "using": "is_admin()",
+          "withCheck": "is_admin()"
+        },
+        "Authors and admins can delete feedback": {
+          "name": "Authors and admins can delete feedback",
+          "as": "PERMISSIVE",
+          "for": "DELETE",
+          "to": [
+            "authenticated"
+          ],
+          "using": "((author_profile_id = current_profile_id()) OR is_admin())"
+        }
+      },
+      "checkConstraints": {
+        "feedback_body_check": {
+          "name": "feedback_body_check",
+          "value": "(char_length(body) >= 1) AND (char_length(body) <= 4000)"
+        }
+      },
+      "isRLSEnabled": true
+    },
+    "public.individual_coaching_sessions": {
+      "name": "individual_coaching_sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "profile_id": {
+          "name": "profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "session_at": {
+          "name": "session_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "coach_profile_id": {
+          "name": "coach_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "external_coach_name": {
+          "name": "external_coach_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "key_takeaways": {
+          "name": "key_takeaways",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "action_steps": {
+          "name": "action_steps",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "removed_at": {
+          "name": "removed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_by_profile_id": {
+          "name": "created_by_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_by_profile_id": {
+          "name": "updated_by_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "individual_coaching_sessions_profile_idx": {
+          "name": "individual_coaching_sessions_profile_idx",
+          "columns": [
+            {
+              "expression": "profile_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "uuid_ops"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "individual_coaching_sessions_coach_idx": {
+          "name": "individual_coaching_sessions_coach_idx",
+          "columns": [
+            {
+              "expression": "coach_profile_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "uuid_ops"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "individual_coaching_sessions_created_desc_idx": {
+          "name": "individual_coaching_sessions_created_desc_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "first",
+              "opclass": "timestamptz_ops"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "individual_coaching_sessions_profile_id_fkey": {
+          "name": "individual_coaching_sessions_profile_id_fkey",
+          "tableFrom": "individual_coaching_sessions",
+          "columnsFrom": [
+            "profile_id"
+          ],
+          "tableTo": "profiles",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        },
+        "individual_coaching_sessions_coach_profile_id_fkey": {
+          "name": "individual_coaching_sessions_coach_profile_id_fkey",
+          "tableFrom": "individual_coaching_sessions",
+          "columnsFrom": [
+            "coach_profile_id"
+          ],
+          "tableTo": "profiles",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "set null"
+        },
+        "individual_coaching_sessions_created_by_profile_id_fkey": {
+          "name": "individual_coaching_sessions_created_by_profile_id_fkey",
+          "tableFrom": "individual_coaching_sessions",
+          "columnsFrom": [
+            "created_by_profile_id"
+          ],
+          "tableTo": "profiles",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "restrict"
+        },
+        "individual_coaching_sessions_updated_by_profile_id_fkey": {
+          "name": "individual_coaching_sessions_updated_by_profile_id_fkey",
+          "tableFrom": "individual_coaching_sessions",
+          "columnsFrom": [
+            "updated_by_profile_id"
+          ],
+          "tableTo": "profiles",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "restrict"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {
+        "Users can view their own coaching sessions": {
+          "name": "Users can view their own coaching sessions",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": [
+            "authenticated"
+          ],
+          "using": "(profile_id = current_profile_id())"
+        },
+        "Users can create their own coaching sessions": {
+          "name": "Users can create their own coaching sessions",
+          "as": "PERMISSIVE",
+          "for": "INSERT",
+          "to": [
+            "authenticated"
+          ],
+          "withCheck": "(profile_id = current_profile_id())"
+        },
+        "Users can update their own coaching sessions": {
+          "name": "Users can update their own coaching sessions",
+          "as": "PERMISSIVE",
+          "for": "UPDATE",
+          "to": [
+            "authenticated"
+          ],
+          "using": "(profile_id = current_profile_id())",
+          "withCheck": "(profile_id = current_profile_id())"
+        },
+        "Users can delete their own coaching sessions": {
+          "name": "Users can delete their own coaching sessions",
+          "as": "PERMISSIVE",
+          "for": "DELETE",
+          "to": [
+            "authenticated"
+          ],
+          "using": "(profile_id = current_profile_id())"
+        }
+      },
+      "checkConstraints": {
+        "individual_coaching_sessions_coach_xor": {
+          "name": "individual_coaching_sessions_coach_xor",
+          "value": "(coach_profile_id IS NOT NULL) <> (external_coach_name IS NOT NULL)"
+        }
+      },
+      "isRLSEnabled": true
+    },
+    "public.notification_preferences": {
+      "name": "notification_preferences",
+      "schema": "",
+      "columns": {
+        "profile_id": {
+          "name": "profile_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "essay_coach_read_email": {
+          "name": "essay_coach_read_email",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "essay_comment_email": {
+          "name": "essay_comment_email",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "essay_vote_email": {
+          "name": "essay_vote_email",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "book_submitted_email": {
+          "name": "book_submitted_email",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_by_profile_id": {
+          "name": "created_by_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_by_profile_id": {
+          "name": "updated_by_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "notification_preferences_profile_id_fkey": {
+          "name": "notification_preferences_profile_id_fkey",
+          "tableFrom": "notification_preferences",
+          "columnsFrom": [
+            "profile_id"
+          ],
+          "tableTo": "profiles",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        },
+        "notification_preferences_created_by_profile_id_fkey": {
+          "name": "notification_preferences_created_by_profile_id_fkey",
+          "tableFrom": "notification_preferences",
+          "columnsFrom": [
+            "created_by_profile_id"
+          ],
+          "tableTo": "profiles",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "restrict"
+        },
+        "notification_preferences_updated_by_profile_id_fkey": {
+          "name": "notification_preferences_updated_by_profile_id_fkey",
+          "tableFrom": "notification_preferences",
+          "columnsFrom": [
+            "updated_by_profile_id"
+          ],
+          "tableTo": "profiles",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "restrict"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {
+        "Users can view their own notification preferences": {
+          "name": "Users can view their own notification preferences",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": [
+            "authenticated"
+          ],
+          "using": "(profile_id = current_profile_id())"
+        },
+        "Users can insert their own notification preferences": {
+          "name": "Users can insert their own notification preferences",
+          "as": "PERMISSIVE",
+          "for": "INSERT",
+          "to": [
+            "authenticated"
+          ],
+          "withCheck": "(profile_id = current_profile_id())"
+        },
+        "Users can update their own notification preferences": {
+          "name": "Users can update their own notification preferences",
+          "as": "PERMISSIVE",
+          "for": "UPDATE",
+          "to": [
+            "authenticated"
+          ],
+          "using": "(profile_id = current_profile_id())",
+          "withCheck": "(profile_id = current_profile_id())"
+        }
+      },
+      "checkConstraints": {},
+      "isRLSEnabled": true
+    },
+    "public.personality_tests": {
+      "name": "personality_tests",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "profile_id": {
+          "name": "profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "test_type": {
+          "name": "test_type",
+          "type": "personality_test_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "test_type_other": {
+          "name": "test_type_other",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tested_on": {
+          "name": "tested_on",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "file_path": {
+          "name": "file_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "file_name": {
+          "name": "file_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "file_size": {
+          "name": "file_size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "removed_at": {
+          "name": "removed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_by_profile_id": {
+          "name": "created_by_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_by_profile_id": {
+          "name": "updated_by_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "personality_tests_profile_tested_on_idx": {
+          "name": "personality_tests_profile_tested_on_idx",
+          "columns": [
+            {
+              "expression": "profile_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "uuid_ops"
+            },
+            {
+              "expression": "tested_on",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "date_ops"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "personality_tests_profile_id_fkey": {
+          "name": "personality_tests_profile_id_fkey",
+          "tableFrom": "personality_tests",
+          "columnsFrom": [
+            "profile_id"
+          ],
+          "tableTo": "profiles",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        },
+        "personality_tests_created_by_profile_id_fkey": {
+          "name": "personality_tests_created_by_profile_id_fkey",
+          "tableFrom": "personality_tests",
+          "columnsFrom": [
+            "created_by_profile_id"
+          ],
+          "tableTo": "profiles",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "restrict"
+        },
+        "personality_tests_updated_by_profile_id_fkey": {
+          "name": "personality_tests_updated_by_profile_id_fkey",
+          "tableFrom": "personality_tests",
+          "columnsFrom": [
+            "updated_by_profile_id"
+          ],
+          "tableTo": "profiles",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "restrict"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {
+        "Verified users can view personality tests": {
+          "name": "Verified users can view personality tests",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": [
+            "authenticated"
+          ],
+          "using": "(removed_at IS NULL) AND (EXISTS (SELECT 1 FROM users WHERE (users.auth_user_id = (SELECT auth.uid()) AND users.verified_work_email IS NOT NULL)))"
+        },
+        "Users can create their own personality tests": {
+          "name": "Users can create their own personality tests",
+          "as": "PERMISSIVE",
+          "for": "INSERT",
+          "to": [
+            "authenticated"
+          ],
+          "withCheck": "(profile_id = current_profile_id())"
+        },
+        "Users can update their own personality tests": {
+          "name": "Users can update their own personality tests",
+          "as": "PERMISSIVE",
+          "for": "UPDATE",
+          "to": [
+            "authenticated"
+          ],
+          "using": "(profile_id = current_profile_id())",
+          "withCheck": "(profile_id = current_profile_id())"
+        },
+        "Users can delete their own personality tests": {
+          "name": "Users can delete their own personality tests",
+          "as": "PERMISSIVE",
+          "for": "DELETE",
+          "to": [
+            "authenticated"
+          ],
+          "using": "(profile_id = current_profile_id())"
+        }
+      },
+      "checkConstraints": {
+        "personality_tests_other_type_required": {
+          "name": "personality_tests_other_type_required",
+          "value": "(test_type <> 'other' OR (test_type_other IS NOT NULL AND length(trim(test_type_other)) > 0))"
+        }
+      },
+      "isRLSEnabled": true
+    },
+    "public.profiles": {
+      "name": "profiles",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "picture": {
+          "name": "picture",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "work_email": {
+          "name": "work_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "profile_role",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'student'"
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "phone_number": {
+          "name": "phone_number",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "personal_email": {
+          "name": "personal_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "date_of_birth": {
+          "name": "date_of_birth",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_removed_at": {
+          "name": "access_removed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_removed_by_profile_id": {
+          "name": "access_removed_by_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "beta_access_granted_at": {
+          "name": "beta_access_granted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_by_profile_id": {
+          "name": "created_by_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_by_profile_id": {
+          "name": "updated_by_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "profiles_team_id_idx": {
+          "name": "profiles_team_id_idx",
+          "columns": [
+            {
+              "expression": "team_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "uuid_ops"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "profiles_team_id_user_id_idx": {
+          "name": "profiles_team_id_user_id_idx",
+          "columns": [
+            {
+              "expression": "team_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "uuid_ops"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "uuid_ops"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "profiles_user_id_idx": {
+          "name": "profiles_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "uuid_ops"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "profiles_work_email_idx": {
+          "name": "profiles_work_email_idx",
+          "columns": [
+            {
+              "expression": "work_email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "text_ops"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "profiles_user_id_fkey": {
+          "name": "profiles_user_id_fkey",
+          "tableFrom": "profiles",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "tableTo": "users",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "set null"
+        },
+        "profiles_team_id_fkey": {
+          "name": "profiles_team_id_fkey",
+          "tableFrom": "profiles",
+          "columnsFrom": [
+            "team_id"
+          ],
+          "tableTo": "teams",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "set null"
+        },
+        "profiles_access_removed_by_profile_id_fkey": {
+          "name": "profiles_access_removed_by_profile_id_fkey",
+          "tableFrom": "profiles",
+          "columnsFrom": [
+            "access_removed_by_profile_id"
+          ],
+          "tableTo": "profiles",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "set null"
+        },
+        "profiles_created_by_profile_id_fkey": {
+          "name": "profiles_created_by_profile_id_fkey",
+          "tableFrom": "profiles",
+          "columnsFrom": [
+            "created_by_profile_id"
+          ],
+          "tableTo": "profiles",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "set null"
+        },
+        "profiles_updated_by_profile_id_fkey": {
+          "name": "profiles_updated_by_profile_id_fkey",
+          "tableFrom": "profiles",
+          "columnsFrom": [
+            "updated_by_profile_id"
+          ],
+          "tableTo": "profiles",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "set null"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "profiles_user_id_key": {
+          "name": "profiles_user_id_key",
+          "columns": [
+            "user_id"
+          ],
+          "nullsNotDistinct": false
+        },
+        "profiles_work_email_key": {
+          "name": "profiles_work_email_key",
+          "columns": [
+            "work_email"
+          ],
+          "nullsNotDistinct": false
+        }
+      },
+      "policies": {
+        "Verified users can view all profiles": {
+          "name": "Verified users can view all profiles",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": [
+            "authenticated"
+          ],
+          "using": "((access_removed_at IS NULL) AND (EXISTS ( SELECT 1\n   FROM users\n  WHERE ((users.auth_user_id = ( SELECT auth.uid() AS uid)) AND (users.verified_work_email IS NOT NULL)))))"
+        },
+        "Users can update their own profile picture": {
+          "name": "Users can update their own profile picture",
+          "as": "PERMISSIVE",
+          "for": "UPDATE",
+          "to": [
+            "authenticated"
+          ],
+          "using": "(user_id IN ( SELECT users.id\n   FROM users\n  WHERE (users.auth_user_id = ( SELECT auth.uid() AS uid))))",
+          "withCheck": "(user_id IN ( SELECT users.id\n   FROM users\n  WHERE (users.auth_user_id = ( SELECT auth.uid() AS uid))))"
+        }
+      },
+      "checkConstraints": {
+        "valid_czu_domain": {
+          "name": "valid_czu_domain",
+          "value": "(lower(split_part(work_email, '@'::text, 2)) = ANY (ARRAY['pef.czu.cz'::text, 'studenti.czu.cz'::text, 'rektorat.czu.cz'::text]))"
+        }
+      },
+      "isRLSEnabled": true
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "auth_user_id": {
+          "name": "auth_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "google_email": {
+          "name": "google_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "suggested_work_email": {
+          "name": "suggested_work_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "verified_work_email": {
+          "name": "verified_work_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "verified_work_email_at": {
+          "name": "verified_work_email_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_otp_sent_at": {
+          "name": "last_otp_sent_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "users_google_email_idx": {
+          "name": "users_google_email_idx",
+          "columns": [
+            {
+              "expression": "google_email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "text_ops"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "users_suggested_work_email_idx": {
+          "name": "users_suggested_work_email_idx",
+          "columns": [
+            {
+              "expression": "suggested_work_email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "text_ops"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "users_auth_user_id_fkey": {
+          "name": "users_auth_user_id_fkey",
+          "tableFrom": "users",
+          "columnsFrom": [
+            "auth_user_id"
+          ],
+          "tableTo": "users",
+          "schemaTo": "auth",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_auth_user_id_key": {
+          "name": "users_auth_user_id_key",
+          "columns": [
+            "auth_user_id"
+          ],
+          "nullsNotDistinct": false
+        },
+        "users_google_email_key": {
+          "name": "users_google_email_key",
+          "columns": [
+            "google_email"
+          ],
+          "nullsNotDistinct": false
+        }
+      },
+      "policies": {
+        "Users can update only suggested_work_email": {
+          "name": "Users can update only suggested_work_email",
+          "as": "PERMISSIVE",
+          "for": "UPDATE",
+          "to": [
+            "authenticated"
+          ],
+          "using": "(( SELECT auth.uid() AS uid) = auth_user_id)",
+          "withCheck": "(( SELECT auth.uid() AS uid) = auth_user_id)"
+        },
+        "Users can insert their own user record": {
+          "name": "Users can insert their own user record",
+          "as": "PERMISSIVE",
+          "for": "INSERT",
+          "to": [
+            "authenticated"
+          ],
+          "withCheck": "(( SELECT auth.uid() AS uid) = auth_user_id)"
+        },
+        "Users can view their own user record": {
+          "name": "Users can view their own user record",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": [
+            "authenticated"
+          ],
+          "using": "(( SELECT auth.uid() AS uid) = auth_user_id)"
+        }
+      },
+      "checkConstraints": {},
+      "isRLSEnabled": true
+    },
+    "public.recurring_schedules": {
+      "name": "recurring_schedules",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "room_id": {
+          "name": "room_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "schedule_type": {
+          "name": "schedule_type",
+          "type": "schedule_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "day_of_week": {
+          "name": "day_of_week",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "start_time": {
+          "name": "start_time",
+          "type": "time",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "end_time": {
+          "name": "end_time",
+          "type": "time",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "valid_from": {
+          "name": "valid_from",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "valid_until": {
+          "name": "valid_until",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "removed_at": {
+          "name": "removed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_by_profile_id": {
+          "name": "created_by_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_by_profile_id": {
+          "name": "updated_by_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "idx_recurring_schedules_day": {
+          "name": "idx_recurring_schedules_day",
+          "columns": [
+            {
+              "expression": "day_of_week",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "int2_ops"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "idx_recurring_schedules_room": {
+          "name": "idx_recurring_schedules_room",
+          "columns": [
+            {
+              "expression": "room_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "uuid_ops"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "idx_recurring_schedules_team": {
+          "name": "idx_recurring_schedules_team",
+          "columns": [
+            {
+              "expression": "team_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "uuid_ops"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "idx_recurring_schedules_type": {
+          "name": "idx_recurring_schedules_type",
+          "columns": [
+            {
+              "expression": "schedule_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "enum_ops"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "idx_recurring_schedules_valid": {
+          "name": "idx_recurring_schedules_valid",
+          "columns": [
+            {
+              "expression": "valid_from",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "date_ops"
+            },
+            {
+              "expression": "valid_until",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "date_ops"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "recurring_schedules_room_id_fkey": {
+          "name": "recurring_schedules_room_id_fkey",
+          "tableFrom": "recurring_schedules",
+          "columnsFrom": [
+            "room_id"
+          ],
+          "tableTo": "rooms",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        },
+        "recurring_schedules_team_id_fkey": {
+          "name": "recurring_schedules_team_id_fkey",
+          "tableFrom": "recurring_schedules",
+          "columnsFrom": [
+            "team_id"
+          ],
+          "tableTo": "teams",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        },
+        "recurring_schedules_created_by_profile_id_fkey": {
+          "name": "recurring_schedules_created_by_profile_id_fkey",
+          "tableFrom": "recurring_schedules",
+          "columnsFrom": [
+            "created_by_profile_id"
+          ],
+          "tableTo": "profiles",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "restrict"
+        },
+        "recurring_schedules_updated_by_profile_id_fkey": {
+          "name": "recurring_schedules_updated_by_profile_id_fkey",
+          "tableFrom": "recurring_schedules",
+          "columnsFrom": [
+            "updated_by_profile_id"
+          ],
+          "tableTo": "profiles",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "restrict"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {
+        "Coaches can manage recurring_schedules": {
+          "name": "Coaches can manage recurring_schedules",
+          "as": "PERMISSIVE",
+          "for": "ALL",
+          "to": [
+            "authenticated"
+          ],
+          "using": "(EXISTS ( SELECT 1\n   FROM profiles\n  WHERE ((profiles.user_id IN ( SELECT users.id\n           FROM users\n          WHERE (users.auth_user_id = ( SELECT auth.uid() AS uid)))) AND (profiles.role = ANY (ARRAY['coach'::profile_role, 'admin'::profile_role])))))",
+          "withCheck": "(EXISTS ( SELECT 1\n   FROM profiles\n  WHERE ((profiles.user_id IN ( SELECT users.id\n           FROM users\n          WHERE (users.auth_user_id = ( SELECT auth.uid() AS uid)))) AND (profiles.role = ANY (ARRAY['coach'::profile_role, 'admin'::profile_role])))))"
+        },
+        "Authenticated can read recurring_schedules": {
+          "name": "Authenticated can read recurring_schedules",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": [
+            "authenticated"
+          ],
+          "using": "true"
+        }
+      },
+      "checkConstraints": {
+        "recurring_schedules_day_of_week_check": {
+          "name": "recurring_schedules_day_of_week_check",
+          "value": "(day_of_week >= 0) AND (day_of_week <= 6)"
+        },
+        "valid_time_range": {
+          "name": "valid_time_range",
+          "value": "end_time > start_time"
+        },
+        "valid_schedule_dates": {
+          "name": "valid_schedule_dates",
+          "value": "(valid_until IS NULL) OR (valid_until >= valid_from)"
+        },
+        "recurring_schedules_team_for_ts": {
+          "name": "recurring_schedules_team_for_ts",
+          "value": "(schedule_type <> 'training_session'::schedule_type) OR (team_id IS NOT NULL)"
+        }
+      },
+      "isRLSEnabled": true
+    },
+    "public.reservations": {
+      "name": "reservations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "room_id": {
+          "name": "room_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "owner_profile_id": {
+          "name": "owner_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "person_count": {
+          "name": "person_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "start_at": {
+          "name": "start_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "end_at": {
+          "name": "end_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cancelled_at": {
+          "name": "cancelled_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cancelled_by_profile_id": {
+          "name": "cancelled_by_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_by_profile_id": {
+          "name": "created_by_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_by_profile_id": {
+          "name": "updated_by_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "idx_reservations_room_time": {
+          "name": "idx_reservations_room_time",
+          "columns": [
+            {
+              "expression": "room_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "uuid_ops"
+            },
+            {
+              "expression": "start_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "timestamptz_ops"
+            },
+            {
+              "expression": "end_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "timestamptz_ops"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "idx_reservations_start": {
+          "name": "idx_reservations_start",
+          "columns": [
+            {
+              "expression": "start_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "timestamptz_ops"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "idx_reservations_owner": {
+          "name": "idx_reservations_owner",
+          "columns": [
+            {
+              "expression": "owner_profile_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "uuid_ops"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "reservations_room_id_fkey": {
+          "name": "reservations_room_id_fkey",
+          "tableFrom": "reservations",
+          "columnsFrom": [
+            "room_id"
+          ],
+          "tableTo": "rooms",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        },
+        "reservations_owner_profile_id_fkey": {
+          "name": "reservations_owner_profile_id_fkey",
+          "tableFrom": "reservations",
+          "columnsFrom": [
+            "owner_profile_id"
+          ],
+          "tableTo": "profiles",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "set null"
+        },
+        "reservations_cancelled_by_profile_id_fkey": {
+          "name": "reservations_cancelled_by_profile_id_fkey",
+          "tableFrom": "reservations",
+          "columnsFrom": [
+            "cancelled_by_profile_id"
+          ],
+          "tableTo": "profiles",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "set null"
+        },
+        "reservations_created_by_profile_id_fkey": {
+          "name": "reservations_created_by_profile_id_fkey",
+          "tableFrom": "reservations",
+          "columnsFrom": [
+            "created_by_profile_id"
+          ],
+          "tableTo": "profiles",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "restrict"
+        },
+        "reservations_updated_by_profile_id_fkey": {
+          "name": "reservations_updated_by_profile_id_fkey",
+          "tableFrom": "reservations",
+          "columnsFrom": [
+            "updated_by_profile_id"
+          ],
+          "tableTo": "profiles",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "restrict"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {
+        "Authenticated can read reservations": {
+          "name": "Authenticated can read reservations",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": [
+            "authenticated"
+          ],
+          "using": "true"
+        },
+        "Users can delete own reservations": {
+          "name": "Users can delete own reservations",
+          "as": "PERMISSIVE",
+          "for": "DELETE",
+          "to": [
+            "authenticated"
+          ],
+          "using": "(owner_profile_id IN ( SELECT profiles.id\n   FROM profiles\n  WHERE (profiles.user_id IN ( SELECT users.id\n           FROM users\n          WHERE (users.auth_user_id = ( SELECT auth.uid() AS uid))))))"
+        },
+        "Users can update own reservations": {
+          "name": "Users can update own reservations",
+          "as": "PERMISSIVE",
+          "for": "UPDATE",
+          "to": [
+            "authenticated"
+          ],
+          "using": "(owner_profile_id IN ( SELECT profiles.id\n   FROM profiles\n  WHERE (profiles.user_id IN ( SELECT users.id\n           FROM users\n          WHERE (users.auth_user_id = ( SELECT auth.uid() AS uid))))))",
+          "withCheck": "(owner_profile_id IN ( SELECT profiles.id\n   FROM profiles\n  WHERE (profiles.user_id IN ( SELECT users.id\n           FROM users\n          WHERE (users.auth_user_id = ( SELECT auth.uid() AS uid))))))"
+        },
+        "Users can create own reservations": {
+          "name": "Users can create own reservations",
+          "as": "PERMISSIVE",
+          "for": "INSERT",
+          "to": [
+            "authenticated"
+          ],
+          "withCheck": "(owner_profile_id IN ( SELECT profiles.id\n   FROM profiles\n  WHERE (profiles.user_id IN ( SELECT users.id\n           FROM users\n          WHERE (users.auth_user_id = ( SELECT auth.uid() AS uid))))))"
+        }
+      },
+      "checkConstraints": {
+        "valid_reservation_time": {
+          "name": "valid_reservation_time",
+          "value": "end_at > start_at"
+        }
+      },
+      "isRLSEnabled": true
+    },
+    "public.rooms": {
+      "name": "rooms",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "code": {
+          "name": "code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "available_days": {
+          "name": "available_days",
+          "type": "integer[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "can_have_ts": {
+          "name": "can_have_ts",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "removed_at": {
+          "name": "removed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_by_profile_id": {
+          "name": "created_by_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_by_profile_id": {
+          "name": "updated_by_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "idx_rooms_code": {
+          "name": "idx_rooms_code",
+          "columns": [
+            {
+              "expression": "code",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "text_ops"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "rooms_created_by_profile_id_fkey": {
+          "name": "rooms_created_by_profile_id_fkey",
+          "tableFrom": "rooms",
+          "columnsFrom": [
+            "created_by_profile_id"
+          ],
+          "tableTo": "profiles",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "restrict"
+        },
+        "rooms_updated_by_profile_id_fkey": {
+          "name": "rooms_updated_by_profile_id_fkey",
+          "tableFrom": "rooms",
+          "columnsFrom": [
+            "updated_by_profile_id"
+          ],
+          "tableTo": "profiles",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "restrict"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "rooms_code_key": {
+          "name": "rooms_code_key",
+          "columns": [
+            "code"
+          ],
+          "nullsNotDistinct": false
+        }
+      },
+      "policies": {
+        "Admins can manage rooms": {
+          "name": "Admins can manage rooms",
+          "as": "PERMISSIVE",
+          "for": "ALL",
+          "to": [
+            "authenticated"
+          ],
+          "using": "(EXISTS ( SELECT 1\n   FROM profiles\n  WHERE ((profiles.user_id IN ( SELECT users.id\n           FROM users\n          WHERE (users.auth_user_id = ( SELECT auth.uid() AS uid)))) AND (profiles.role = 'admin'::profile_role))))",
+          "withCheck": "(EXISTS ( SELECT 1\n   FROM profiles\n  WHERE ((profiles.user_id IN ( SELECT users.id\n           FROM users\n          WHERE (users.auth_user_id = ( SELECT auth.uid() AS uid)))) AND (profiles.role = 'admin'::profile_role))))"
+        },
+        "Authenticated can read rooms": {
+          "name": "Authenticated can read rooms",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": [
+            "authenticated"
+          ],
+          "using": "true"
+        }
+      },
+      "checkConstraints": {},
+      "isRLSEnabled": true
+    },
+    "public.schedule_breaks": {
+      "name": "schedule_breaks",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "start_date": {
+          "name": "start_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "end_date": {
+          "name": "end_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_by_profile_id": {
+          "name": "created_by_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_by_profile_id": {
+          "name": "updated_by_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "idx_schedule_breaks_dates": {
+          "name": "idx_schedule_breaks_dates",
+          "columns": [
+            {
+              "expression": "start_date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "date_ops"
+            },
+            {
+              "expression": "end_date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "date_ops"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "schedule_breaks_created_by_profile_id_fkey": {
+          "name": "schedule_breaks_created_by_profile_id_fkey",
+          "tableFrom": "schedule_breaks",
+          "columnsFrom": [
+            "created_by_profile_id"
+          ],
+          "tableTo": "profiles",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "restrict"
+        },
+        "schedule_breaks_updated_by_profile_id_fkey": {
+          "name": "schedule_breaks_updated_by_profile_id_fkey",
+          "tableFrom": "schedule_breaks",
+          "columnsFrom": [
+            "updated_by_profile_id"
+          ],
+          "tableTo": "profiles",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "restrict"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {
+        "Coaches can manage schedule_breaks": {
+          "name": "Coaches can manage schedule_breaks",
+          "as": "PERMISSIVE",
+          "for": "ALL",
+          "to": [
+            "authenticated"
+          ],
+          "using": "(EXISTS ( SELECT 1\n   FROM profiles\n  WHERE ((profiles.user_id IN ( SELECT users.id\n           FROM users\n          WHERE (users.auth_user_id = ( SELECT auth.uid() AS uid)))) AND (profiles.role = ANY (ARRAY['coach'::profile_role, 'admin'::profile_role])))))",
+          "withCheck": "(EXISTS ( SELECT 1\n   FROM profiles\n  WHERE ((profiles.user_id IN ( SELECT users.id\n           FROM users\n          WHERE (users.auth_user_id = ( SELECT auth.uid() AS uid)))) AND (profiles.role = ANY (ARRAY['coach'::profile_role, 'admin'::profile_role])))))"
+        },
+        "Authenticated can read schedule_breaks": {
+          "name": "Authenticated can read schedule_breaks",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": [
+            "authenticated"
+          ],
+          "using": "true"
+        }
+      },
+      "checkConstraints": {
+        "valid_break_date_range": {
+          "name": "valid_break_date_range",
+          "value": "end_date >= start_date"
+        }
+      },
+      "isRLSEnabled": true
+    },
+    "public.team_activities": {
+      "name": "team_activities",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "occurred_at": {
+          "name": "occurred_at",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "activity_type": {
+          "name": "activity_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "participants": {
+          "name": "participants",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reflection": {
+          "name": "reflection",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "removed_at": {
+          "name": "removed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_by_profile_id": {
+          "name": "created_by_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_by_profile_id": {
+          "name": "updated_by_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "team_activities_team_occurred_at_idx": {
+          "name": "team_activities_team_occurred_at_idx",
+          "columns": [
+            {
+              "expression": "team_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "uuid_ops"
+            },
+            {
+              "expression": "occurred_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "date_ops"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "team_activities_team_id_fkey": {
+          "name": "team_activities_team_id_fkey",
+          "tableFrom": "team_activities",
+          "columnsFrom": [
+            "team_id"
+          ],
+          "tableTo": "teams",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        },
+        "team_activities_created_by_profile_id_fkey": {
+          "name": "team_activities_created_by_profile_id_fkey",
+          "tableFrom": "team_activities",
+          "columnsFrom": [
+            "created_by_profile_id"
+          ],
+          "tableTo": "profiles",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "restrict"
+        },
+        "team_activities_updated_by_profile_id_fkey": {
+          "name": "team_activities_updated_by_profile_id_fkey",
+          "tableFrom": "team_activities",
+          "columnsFrom": [
+            "updated_by_profile_id"
+          ],
+          "tableTo": "profiles",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "restrict"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {
+        "Team members can view activities": {
+          "name": "Team members can view activities",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": [
+            "authenticated"
+          ],
+          "using": "team_id IN (SELECT team_id FROM profiles WHERE id = current_profile_id() AND access_removed_at IS NULL)"
+        },
+        "Team members can create activities": {
+          "name": "Team members can create activities",
+          "as": "PERMISSIVE",
+          "for": "INSERT",
+          "to": [
+            "authenticated"
+          ],
+          "withCheck": "team_id IN (SELECT team_id FROM profiles WHERE id = current_profile_id() AND access_removed_at IS NULL)"
+        },
+        "Team members can update activities": {
+          "name": "Team members can update activities",
+          "as": "PERMISSIVE",
+          "for": "UPDATE",
+          "to": [
+            "authenticated"
+          ],
+          "using": "team_id IN (SELECT team_id FROM profiles WHERE id = current_profile_id() AND access_removed_at IS NULL)",
+          "withCheck": "team_id IN (SELECT team_id FROM profiles WHERE id = current_profile_id() AND access_removed_at IS NULL)"
+        },
+        "Team members can delete activities": {
+          "name": "Team members can delete activities",
+          "as": "PERMISSIVE",
+          "for": "DELETE",
+          "to": [
+            "authenticated"
+          ],
+          "using": "team_id IN (SELECT team_id FROM profiles WHERE id = current_profile_id() AND access_removed_at IS NULL)"
+        }
+      },
+      "checkConstraints": {},
+      "isRLSEnabled": true
+    },
+    "public.team_reflections": {
+      "name": "team_reflections",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "month": {
+          "name": "month",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "what_went_well": {
+          "name": "what_went_well",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "what_didnt_go_well": {
+          "name": "what_didnt_go_well",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "what_we_do_differently": {
+          "name": "what_we_do_differently",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "planned_action_steps": {
+          "name": "planned_action_steps",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "responsible_person": {
+          "name": "responsible_person",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "removed_at": {
+          "name": "removed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_by_profile_id": {
+          "name": "created_by_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_by_profile_id": {
+          "name": "updated_by_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "team_reflections_team_month_idx": {
+          "name": "team_reflections_team_month_idx",
+          "columns": [
+            {
+              "expression": "team_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "uuid_ops"
+            },
+            {
+              "expression": "month",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "date_ops"
+            }
+          ],
+          "isUnique": true,
+          "with": {},
+          "method": "btree",
+          "where": "(removed_at IS NULL)",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "team_reflections_team_id_fkey": {
+          "name": "team_reflections_team_id_fkey",
+          "tableFrom": "team_reflections",
+          "columnsFrom": [
+            "team_id"
+          ],
+          "tableTo": "teams",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        },
+        "team_reflections_created_by_profile_id_fkey": {
+          "name": "team_reflections_created_by_profile_id_fkey",
+          "tableFrom": "team_reflections",
+          "columnsFrom": [
+            "created_by_profile_id"
+          ],
+          "tableTo": "profiles",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "restrict"
+        },
+        "team_reflections_updated_by_profile_id_fkey": {
+          "name": "team_reflections_updated_by_profile_id_fkey",
+          "tableFrom": "team_reflections",
+          "columnsFrom": [
+            "updated_by_profile_id"
+          ],
+          "tableTo": "profiles",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "restrict"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {
+        "Team members can view reflections": {
+          "name": "Team members can view reflections",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": [
+            "authenticated"
+          ],
+          "using": "team_id IN (SELECT team_id FROM profiles WHERE id = current_profile_id() AND access_removed_at IS NULL)"
+        },
+        "Team members can create reflections": {
+          "name": "Team members can create reflections",
+          "as": "PERMISSIVE",
+          "for": "INSERT",
+          "to": [
+            "authenticated"
+          ],
+          "withCheck": "team_id IN (SELECT team_id FROM profiles WHERE id = current_profile_id() AND access_removed_at IS NULL)"
+        },
+        "Team members can update reflections": {
+          "name": "Team members can update reflections",
+          "as": "PERMISSIVE",
+          "for": "UPDATE",
+          "to": [
+            "authenticated"
+          ],
+          "using": "team_id IN (SELECT team_id FROM profiles WHERE id = current_profile_id() AND access_removed_at IS NULL)",
+          "withCheck": "team_id IN (SELECT team_id FROM profiles WHERE id = current_profile_id() AND access_removed_at IS NULL)"
+        },
+        "Team members can delete reflections": {
+          "name": "Team members can delete reflections",
+          "as": "PERMISSIVE",
+          "for": "DELETE",
+          "to": [
+            "authenticated"
+          ],
+          "using": "team_id IN (SELECT team_id FROM profiles WHERE id = current_profile_id() AND access_removed_at IS NULL)"
+        }
+      },
+      "checkConstraints": {},
+      "isRLSEnabled": true
+    },
+    "public.team_semester_reflection_entries": {
+      "name": "team_semester_reflection_entries",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "semester_reflection_id": {
+          "name": "semester_reflection_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "topic": {
+          "name": "topic",
+          "type": "semester_reflection_topic",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "what_went_well": {
+          "name": "what_went_well",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "what_didnt_go_well": {
+          "name": "what_didnt_go_well",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "what_next_time": {
+          "name": "what_next_time",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_by_profile_id": {
+          "name": "updated_by_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "team_semester_reflection_entries_reflection_topic_idx": {
+          "name": "team_semester_reflection_entries_reflection_topic_idx",
+          "columns": [
+            {
+              "expression": "semester_reflection_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "uuid_ops"
+            },
+            {
+              "expression": "topic",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "enum_ops"
+            }
+          ],
+          "isUnique": true,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "team_semester_reflection_entries_reflection_idx": {
+          "name": "team_semester_reflection_entries_reflection_idx",
+          "columns": [
+            {
+              "expression": "semester_reflection_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "uuid_ops"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "team_semester_reflection_entries_semester_reflection_id_fkey": {
+          "name": "team_semester_reflection_entries_semester_reflection_id_fkey",
+          "tableFrom": "team_semester_reflection_entries",
+          "columnsFrom": [
+            "semester_reflection_id"
+          ],
+          "tableTo": "team_semester_reflections",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        },
+        "team_semester_reflection_entries_updated_by_profile_id_fkey": {
+          "name": "team_semester_reflection_entries_updated_by_profile_id_fkey",
+          "tableFrom": "team_semester_reflection_entries",
+          "columnsFrom": [
+            "updated_by_profile_id"
+          ],
+          "tableTo": "profiles",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "restrict"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {
+        "Team members can view semester reflection entries": {
+          "name": "Team members can view semester reflection entries",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": [
+            "authenticated"
+          ],
+          "using": "EXISTS (SELECT 1 FROM team_semester_reflections tsr WHERE tsr.id = team_semester_reflection_entries.semester_reflection_id AND tsr.team_id IN (SELECT team_id FROM profiles WHERE id = current_profile_id() AND access_removed_at IS NULL))"
+        },
+        "Team members can create semester reflection entries": {
+          "name": "Team members can create semester reflection entries",
+          "as": "PERMISSIVE",
+          "for": "INSERT",
+          "to": [
+            "authenticated"
+          ],
+          "withCheck": "EXISTS (SELECT 1 FROM team_semester_reflections tsr WHERE tsr.id = team_semester_reflection_entries.semester_reflection_id AND tsr.team_id IN (SELECT team_id FROM profiles WHERE id = current_profile_id() AND access_removed_at IS NULL))"
+        },
+        "Team members can update semester reflection entries": {
+          "name": "Team members can update semester reflection entries",
+          "as": "PERMISSIVE",
+          "for": "UPDATE",
+          "to": [
+            "authenticated"
+          ],
+          "using": "EXISTS (SELECT 1 FROM team_semester_reflections tsr WHERE tsr.id = team_semester_reflection_entries.semester_reflection_id AND tsr.team_id IN (SELECT team_id FROM profiles WHERE id = current_profile_id() AND access_removed_at IS NULL))",
+          "withCheck": "EXISTS (SELECT 1 FROM team_semester_reflections tsr WHERE tsr.id = team_semester_reflection_entries.semester_reflection_id AND tsr.team_id IN (SELECT team_id FROM profiles WHERE id = current_profile_id() AND access_removed_at IS NULL))"
+        }
+      },
+      "checkConstraints": {},
+      "isRLSEnabled": true
+    },
+    "public.team_semester_reflections": {
+      "name": "team_semester_reflections",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "semester_month": {
+          "name": "semester_month",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "removed_at": {
+          "name": "removed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_by_profile_id": {
+          "name": "created_by_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_by_profile_id": {
+          "name": "updated_by_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "team_semester_reflections_team_month_idx": {
+          "name": "team_semester_reflections_team_month_idx",
+          "columns": [
+            {
+              "expression": "team_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "uuid_ops"
+            },
+            {
+              "expression": "semester_month",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "date_ops"
+            }
+          ],
+          "isUnique": true,
+          "with": {},
+          "method": "btree",
+          "where": "(removed_at IS NULL)",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "team_semester_reflections_team_id_fkey": {
+          "name": "team_semester_reflections_team_id_fkey",
+          "tableFrom": "team_semester_reflections",
+          "columnsFrom": [
+            "team_id"
+          ],
+          "tableTo": "teams",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        },
+        "team_semester_reflections_created_by_profile_id_fkey": {
+          "name": "team_semester_reflections_created_by_profile_id_fkey",
+          "tableFrom": "team_semester_reflections",
+          "columnsFrom": [
+            "created_by_profile_id"
+          ],
+          "tableTo": "profiles",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "restrict"
+        },
+        "team_semester_reflections_updated_by_profile_id_fkey": {
+          "name": "team_semester_reflections_updated_by_profile_id_fkey",
+          "tableFrom": "team_semester_reflections",
+          "columnsFrom": [
+            "updated_by_profile_id"
+          ],
+          "tableTo": "profiles",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "restrict"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {
+        "Team members can view semester reflections": {
+          "name": "Team members can view semester reflections",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": [
+            "authenticated"
+          ],
+          "using": "team_id IN (SELECT team_id FROM profiles WHERE id = current_profile_id() AND access_removed_at IS NULL)"
+        },
+        "Team members can create semester reflections": {
+          "name": "Team members can create semester reflections",
+          "as": "PERMISSIVE",
+          "for": "INSERT",
+          "to": [
+            "authenticated"
+          ],
+          "withCheck": "team_id IN (SELECT team_id FROM profiles WHERE id = current_profile_id() AND access_removed_at IS NULL)"
+        },
+        "Team members can update semester reflections": {
+          "name": "Team members can update semester reflections",
+          "as": "PERMISSIVE",
+          "for": "UPDATE",
+          "to": [
+            "authenticated"
+          ],
+          "using": "team_id IN (SELECT team_id FROM profiles WHERE id = current_profile_id() AND access_removed_at IS NULL)",
+          "withCheck": "team_id IN (SELECT team_id FROM profiles WHERE id = current_profile_id() AND access_removed_at IS NULL)"
+        },
+        "Team members can delete semester reflections": {
+          "name": "Team members can delete semester reflections",
+          "as": "PERMISSIVE",
+          "for": "DELETE",
+          "to": [
+            "authenticated"
+          ],
+          "using": "team_id IN (SELECT team_id FROM profiles WHERE id = current_profile_id() AND access_removed_at IS NULL)"
+        }
+      },
+      "checkConstraints": {
+        "team_semester_reflections_month_check": {
+          "name": "team_semester_reflections_month_check",
+          "value": "EXTRACT(MONTH FROM semester_month) IN (1, 5)"
+        }
+      },
+      "isRLSEnabled": true
+    },
+    "public.teams": {
+      "name": "teams",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "picture": {
+          "name": "picture",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "color": {
+          "name": "color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "onboardingYear": {
+          "name": "onboardingYear",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "removed_at": {
+          "name": "removed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_by_profile_id": {
+          "name": "created_by_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_by_profile_id": {
+          "name": "updated_by_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {
+        "Authenticated users can read teams": {
+          "name": "Authenticated users can read teams",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": [
+            "authenticated"
+          ],
+          "using": "true"
+        }
+      },
+      "checkConstraints": {},
+      "isRLSEnabled": true
+    },
+    "public.tools_techniques": {
+      "name": "tools_techniques",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "profile_id": {
+          "name": "profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tool_type": {
+          "name": "tool_type",
+          "type": "tool_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reflection": {
+          "name": "reflection",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "removed_at": {
+          "name": "removed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_by_profile_id": {
+          "name": "created_by_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_by_profile_id": {
+          "name": "updated_by_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "tools_techniques_profile_idx": {
+          "name": "tools_techniques_profile_idx",
+          "columns": [
+            {
+              "expression": "profile_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "uuid_ops"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "tools_techniques_profile_id_fkey": {
+          "name": "tools_techniques_profile_id_fkey",
+          "tableFrom": "tools_techniques",
+          "columnsFrom": [
+            "profile_id"
+          ],
+          "tableTo": "profiles",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        },
+        "tools_techniques_created_by_profile_id_fkey": {
+          "name": "tools_techniques_created_by_profile_id_fkey",
+          "tableFrom": "tools_techniques",
+          "columnsFrom": [
+            "created_by_profile_id"
+          ],
+          "tableTo": "profiles",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "restrict"
+        },
+        "tools_techniques_updated_by_profile_id_fkey": {
+          "name": "tools_techniques_updated_by_profile_id_fkey",
+          "tableFrom": "tools_techniques",
+          "columnsFrom": [
+            "updated_by_profile_id"
+          ],
+          "tableTo": "profiles",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "restrict"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {
+        "Users can view their own tools and techniques": {
+          "name": "Users can view their own tools and techniques",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": [
+            "authenticated"
+          ],
+          "using": "(profile_id = current_profile_id())"
+        },
+        "Users can create their own tools and techniques": {
+          "name": "Users can create their own tools and techniques",
+          "as": "PERMISSIVE",
+          "for": "INSERT",
+          "to": [
+            "authenticated"
+          ],
+          "withCheck": "(profile_id = current_profile_id())"
+        },
+        "Users can update their own tools and techniques": {
+          "name": "Users can update their own tools and techniques",
+          "as": "PERMISSIVE",
+          "for": "UPDATE",
+          "to": [
+            "authenticated"
+          ],
+          "using": "(profile_id = current_profile_id())",
+          "withCheck": "(profile_id = current_profile_id())"
+        },
+        "Users can delete their own tools and techniques": {
+          "name": "Users can delete their own tools and techniques",
+          "as": "PERMISSIVE",
+          "for": "DELETE",
+          "to": [
+            "authenticated"
+          ],
+          "using": "(profile_id = current_profile_id())"
+        }
+      },
+      "checkConstraints": {},
+      "isRLSEnabled": true
+    }
+  },
+  "enums": {
+    "public.book_list_status": {
+      "name": "book_list_status",
+      "schema": "public",
+      "values": [
+        "processing",
+        "shortlist",
+        "longlist",
+        "archived"
+      ]
+    },
+    "public.book_source": {
+      "name": "book_source",
+      "schema": "public",
+      "values": [
+        "manual",
+        "google_books",
+        "open_library"
+      ]
+    },
+    "public.personality_test_type": {
+      "name": "personality_test_type",
+      "schema": "public",
+      "values": [
+        "gallup",
+        "mbti",
+        "disc",
+        "big_five",
+        "enneagram",
+        "belbin",
+        "other"
+      ]
+    },
+    "public.profile_role": {
+      "name": "profile_role",
+      "schema": "public",
+      "values": [
+        "student",
+        "mentor",
+        "coach",
+        "admin"
+      ]
+    },
+    "public.schedule_type": {
+      "name": "schedule_type",
+      "schema": "public",
+      "values": [
+        "training_session",
+        "houston_calling"
+      ]
+    },
+    "public.semester_reflection_topic": {
+      "name": "semester_reflection_topic",
+      "schema": "public",
+      "values": [
+        "predmety_zkousky_vyucujici",
+        "metodika_a_metriky",
+        "kouci_a_mentori",
+        "tymy_a_tymove_spolecnosti",
+        "individualni_prinos",
+        "komunita",
+        "komunitni_role",
+        "komunitni_akce",
+        "komunitni_a_cross_projekty",
+        "zacleneni_tucnaku",
+        "dalsi"
+      ]
+    },
+    "public.tool_type": {
+      "name": "tool_type",
+      "schema": "public",
+      "values": [
+        "model",
+        "technique",
+        "tool"
+      ]
+    }
+  },
+  "schemas": {},
+  "views": {
+    "public.books_with_essay_count": {
+      "name": "books_with_essay_count",
+      "schema": "public",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "title_cs": {
+          "name": "title_cs",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "title_en": {
+          "name": "title_en",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "author": {
+          "name": "author",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "isbn_13": {
+          "name": "isbn_13",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "google_books_cover_url": {
+          "name": "google_books_cover_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "book_points": {
+          "name": "book_points",
+          "type": "numeric(3, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "page_count": {
+          "name": "page_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "preview_link": {
+          "name": "preview_link",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source": {
+          "name": "source",
+          "type": "book_source",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "external_id": {
+          "name": "external_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "list_status": {
+          "name": "list_status",
+          "type": "book_list_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "list_status_changed_at": {
+          "name": "list_status_changed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "list_status_changed_by_profile_id": {
+          "name": "list_status_changed_by_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "list_status_reason": {
+          "name": "list_status_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "highlight_category_id": {
+          "name": "highlight_category_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_rocket_model": {
+          "name": "is_rocket_model",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by_profile_id": {
+          "name": "created_by_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_by_profile_id": {
+          "name": "updated_by_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "essay_count": {
+          "name": "essay_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "definition": "SELECT b.id, b.title_cs, b.title_en, b.author, b.isbn_13, b.description, b.google_books_cover_url, b.book_points, b.page_count, b.preview_link, b.source, b.external_id, b.list_status, b.list_status_changed_at, b.list_status_changed_by_profile_id, b.list_status_reason, b.highlight_category_id, b.is_rocket_model, b.created_at, b.updated_at, b.created_by_profile_id, b.updated_by_profile_id, COALESCE(ec.essay_count, 0) AS essay_count FROM books b LEFT JOIN ( SELECT essays.book_id, count(*)::integer AS essay_count FROM essays WHERE essays.book_id IS NOT NULL AND essays.published_at IS NOT NULL AND essays.removed_at IS NULL GROUP BY essays.book_id) ec ON ec.book_id = b.id",
+      "materialized": false,
+      "isExisting": false
+    }
+  },
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/supabase/migrations/meta/20260818191117_snapshot.json
+++ b/supabase/migrations/meta/20260818191117_snapshot.json
@@ -1,0 +1,5831 @@
+{
+  "id": "31159044-1747-4a04-804d-a931817faf2d",
+  "prevId": "564fc955-c46c-491c-8a82-17b131dd5264",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.book_loans": {
+      "name": "book_loans",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "library_book_id": {
+          "name": "library_book_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "borrower_id": {
+          "name": "borrower_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "borrowed_at": {
+          "name": "borrowed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "due_at": {
+          "name": "due_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "returned_at": {
+          "name": "returned_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "book_loans_library_book_id_idx": {
+          "name": "book_loans_library_book_id_idx",
+          "columns": [
+            {
+              "expression": "library_book_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "uuid_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "book_loans_borrower_id_idx": {
+          "name": "book_loans_borrower_id_idx",
+          "columns": [
+            {
+              "expression": "borrower_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "uuid_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "book_loans_active_idx": {
+          "name": "book_loans_active_idx",
+          "columns": [
+            {
+              "expression": "library_book_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "uuid_ops"
+            }
+          ],
+          "isUnique": false,
+          "where": "(returned_at IS NULL)",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "book_loans_library_book_id_fkey": {
+          "name": "book_loans_library_book_id_fkey",
+          "tableFrom": "book_loans",
+          "tableTo": "library_books",
+          "columnsFrom": [
+            "library_book_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "book_loans_borrower_id_fkey": {
+          "name": "book_loans_borrower_id_fkey",
+          "tableFrom": "book_loans",
+          "tableTo": "profiles",
+          "columnsFrom": [
+            "borrower_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {
+        "Authenticated users can view loans": {
+          "name": "Authenticated users can view loans",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": [
+            "authenticated"
+          ],
+          "using": "true"
+        },
+        "Users can borrow for themselves": {
+          "name": "Users can borrow for themselves",
+          "as": "PERMISSIVE",
+          "for": "INSERT",
+          "to": [
+            "authenticated"
+          ],
+          "withCheck": "(borrower_id = current_profile_id())"
+        },
+        "Borrower can return their own loan": {
+          "name": "Borrower can return their own loan",
+          "as": "PERMISSIVE",
+          "for": "UPDATE",
+          "to": [
+            "authenticated"
+          ],
+          "using": "(borrower_id = current_profile_id())",
+          "withCheck": "(borrower_id = current_profile_id())"
+        }
+      },
+      "checkConstraints": {},
+      "isRLSEnabled": true
+    },
+    "public.book_tags": {
+      "name": "book_tags",
+      "schema": "",
+      "columns": {
+        "book_id": {
+          "name": "book_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tag_id": {
+          "name": "tag_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_by_profile_id": {
+          "name": "created_by_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_by_profile_id": {
+          "name": "updated_by_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "book_tags_tag_idx": {
+          "name": "book_tags_tag_idx",
+          "columns": [
+            {
+              "expression": "tag_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "uuid_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "book_tags_book_id_fkey": {
+          "name": "book_tags_book_id_fkey",
+          "tableFrom": "book_tags",
+          "tableTo": "books",
+          "columnsFrom": [
+            "book_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "book_tags_tag_id_fkey": {
+          "name": "book_tags_tag_id_fkey",
+          "tableFrom": "book_tags",
+          "tableTo": "tags",
+          "columnsFrom": [
+            "tag_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "book_tags_created_by_profile_id_fkey": {
+          "name": "book_tags_created_by_profile_id_fkey",
+          "tableFrom": "book_tags",
+          "tableTo": "profiles",
+          "columnsFrom": [
+            "created_by_profile_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "book_tags_updated_by_profile_id_fkey": {
+          "name": "book_tags_updated_by_profile_id_fkey",
+          "tableFrom": "book_tags",
+          "tableTo": "profiles",
+          "columnsFrom": [
+            "updated_by_profile_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "book_tags_pkey": {
+          "name": "book_tags_pkey",
+          "columns": [
+            "book_id",
+            "tag_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {
+        "Authenticated users can view book tags": {
+          "name": "Authenticated users can view book tags",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": [
+            "authenticated"
+          ],
+          "using": "true"
+        },
+        "Authenticated users can assign book tags": {
+          "name": "Authenticated users can assign book tags",
+          "as": "PERMISSIVE",
+          "for": "INSERT",
+          "to": [
+            "authenticated"
+          ],
+          "withCheck": "(created_by_profile_id = current_profile_id())"
+        },
+        "Coaches and admins can update book tags": {
+          "name": "Coaches and admins can update book tags",
+          "as": "PERMISSIVE",
+          "for": "UPDATE",
+          "to": [
+            "authenticated"
+          ],
+          "using": "is_coach_or_admin()",
+          "withCheck": "is_coach_or_admin()"
+        },
+        "Coaches and admins can remove book tags": {
+          "name": "Coaches and admins can remove book tags",
+          "as": "PERMISSIVE",
+          "for": "DELETE",
+          "to": [
+            "authenticated"
+          ],
+          "using": "is_coach_or_admin()"
+        }
+      },
+      "checkConstraints": {},
+      "isRLSEnabled": true
+    },
+    "public.books": {
+      "name": "books",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "title_cs": {
+          "name": "title_cs",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title_en": {
+          "name": "title_en",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "author": {
+          "name": "author",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "isbn_13": {
+          "name": "isbn_13",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "google_books_cover_url": {
+          "name": "google_books_cover_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "book_points": {
+          "name": "book_points",
+          "type": "numeric(3, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "page_count": {
+          "name": "page_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "preview_link": {
+          "name": "preview_link",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source": {
+          "name": "source",
+          "type": "book_source",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'manual'"
+        },
+        "external_id": {
+          "name": "external_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "list_status": {
+          "name": "list_status",
+          "type": "book_list_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'processing'"
+        },
+        "list_status_changed_at": {
+          "name": "list_status_changed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "list_status_changed_by_profile_id": {
+          "name": "list_status_changed_by_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "list_status_reason": {
+          "name": "list_status_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "highlight_category_id": {
+          "name": "highlight_category_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_rocket_model": {
+          "name": "is_rocket_model",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_by_profile_id": {
+          "name": "created_by_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_by_profile_id": {
+          "name": "updated_by_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "books_created_by_idx": {
+          "name": "books_created_by_idx",
+          "columns": [
+            {
+              "expression": "created_by_profile_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "uuid_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "books_author_trgm_idx": {
+          "name": "books_author_trgm_idx",
+          "columns": [
+            {
+              "expression": "author",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "gin_trgm_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        },
+        "books_created_desc_idx": {
+          "name": "books_created_desc_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "first",
+              "opclass": "timestamptz_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "books_isbn_13_idx": {
+          "name": "books_isbn_13_idx",
+          "columns": [
+            {
+              "expression": "isbn_13",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "text_ops"
+            }
+          ],
+          "isUnique": false,
+          "where": "(isbn_13 IS NOT NULL)",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "books_list_status_idx": {
+          "name": "books_list_status_idx",
+          "columns": [
+            {
+              "expression": "list_status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "enum_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "books_title_cs_trgm_idx": {
+          "name": "books_title_cs_trgm_idx",
+          "columns": [
+            {
+              "expression": "title_cs",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "gin_trgm_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "books_created_by_profile_id_fkey": {
+          "name": "books_created_by_profile_id_fkey",
+          "tableFrom": "books",
+          "tableTo": "profiles",
+          "columnsFrom": [
+            "created_by_profile_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "books_updated_by_profile_id_fkey": {
+          "name": "books_updated_by_profile_id_fkey",
+          "tableFrom": "books",
+          "tableTo": "profiles",
+          "columnsFrom": [
+            "updated_by_profile_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "books_list_status_changed_by_profile_id_fkey": {
+          "name": "books_list_status_changed_by_profile_id_fkey",
+          "tableFrom": "books",
+          "tableTo": "profiles",
+          "columnsFrom": [
+            "list_status_changed_by_profile_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "books_highlight_category_id_fkey": {
+          "name": "books_highlight_category_id_fkey",
+          "tableFrom": "books",
+          "tableTo": "highlight_categories",
+          "columnsFrom": [
+            "highlight_category_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {
+        "Coaches and admins can delete books": {
+          "name": "Coaches and admins can delete books",
+          "as": "PERMISSIVE",
+          "for": "DELETE",
+          "to": [
+            "public"
+          ],
+          "using": "is_coach_or_admin()"
+        },
+        "Coaches and admins can update books": {
+          "name": "Coaches and admins can update books",
+          "as": "PERMISSIVE",
+          "for": "UPDATE",
+          "to": [
+            "authenticated"
+          ],
+          "using": "is_coach_or_admin()",
+          "withCheck": "is_coach_or_admin()"
+        },
+        "Authenticated users can add books": {
+          "name": "Authenticated users can add books",
+          "as": "PERMISSIVE",
+          "for": "INSERT",
+          "to": [
+            "authenticated"
+          ],
+          "withCheck": "(created_by_profile_id = current_profile_id())"
+        },
+        "Authenticated users can view all books": {
+          "name": "Authenticated users can view all books",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": [
+            "authenticated"
+          ],
+          "using": "true"
+        }
+      },
+      "checkConstraints": {
+        "books_book_points_check": {
+          "name": "books_book_points_check",
+          "value": "(book_points IS NULL) OR ((book_points >= (0)::numeric) AND (book_points <= (3)::numeric))"
+        },
+        "books_archived_points_check": {
+          "name": "books_archived_points_check",
+          "value": "(list_status <> 'archived') OR (book_points = (0)::numeric)"
+        }
+      },
+      "isRLSEnabled": true
+    },
+    "public.highlight_categories": {
+      "name": "highlight_categories",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_by_profile_id": {
+          "name": "created_by_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_by_profile_id": {
+          "name": "updated_by_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "highlight_categories_created_by_profile_id_fkey": {
+          "name": "highlight_categories_created_by_profile_id_fkey",
+          "tableFrom": "highlight_categories",
+          "tableTo": "profiles",
+          "columnsFrom": [
+            "created_by_profile_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "highlight_categories_updated_by_profile_id_fkey": {
+          "name": "highlight_categories_updated_by_profile_id_fkey",
+          "tableFrom": "highlight_categories",
+          "tableTo": "profiles",
+          "columnsFrom": [
+            "updated_by_profile_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {
+        "Authenticated users can view highlight categories": {
+          "name": "Authenticated users can view highlight categories",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": [
+            "authenticated"
+          ],
+          "using": "true"
+        },
+        "Coaches and admins can add highlight categories": {
+          "name": "Coaches and admins can add highlight categories",
+          "as": "PERMISSIVE",
+          "for": "INSERT",
+          "to": [
+            "authenticated"
+          ],
+          "withCheck": "is_coach_or_admin()"
+        },
+        "Coaches and admins can update highlight categories": {
+          "name": "Coaches and admins can update highlight categories",
+          "as": "PERMISSIVE",
+          "for": "UPDATE",
+          "to": [
+            "authenticated"
+          ],
+          "using": "is_coach_or_admin()",
+          "withCheck": "is_coach_or_admin()"
+        },
+        "Coaches and admins can delete highlight categories": {
+          "name": "Coaches and admins can delete highlight categories",
+          "as": "PERMISSIVE",
+          "for": "DELETE",
+          "to": [
+            "authenticated"
+          ],
+          "using": "is_coach_or_admin()"
+        }
+      },
+      "checkConstraints": {},
+      "isRLSEnabled": true
+    },
+    "public.library_books": {
+      "name": "library_books",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "book_id": {
+          "name": "book_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "isbn_13": {
+          "name": "isbn_13",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_by_profile_id": {
+          "name": "created_by_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_by_profile_id": {
+          "name": "updated_by_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "library_books_book_id_idx": {
+          "name": "library_books_book_id_idx",
+          "columns": [
+            {
+              "expression": "book_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "uuid_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "library_books_isbn_13_idx": {
+          "name": "library_books_isbn_13_idx",
+          "columns": [
+            {
+              "expression": "isbn_13",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "text_ops"
+            }
+          ],
+          "isUnique": false,
+          "where": "(isbn_13 IS NOT NULL)",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "library_books_book_id_fkey": {
+          "name": "library_books_book_id_fkey",
+          "tableFrom": "library_books",
+          "tableTo": "books",
+          "columnsFrom": [
+            "book_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "library_books_created_by_profile_id_fkey": {
+          "name": "library_books_created_by_profile_id_fkey",
+          "tableFrom": "library_books",
+          "tableTo": "profiles",
+          "columnsFrom": [
+            "created_by_profile_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "library_books_updated_by_profile_id_fkey": {
+          "name": "library_books_updated_by_profile_id_fkey",
+          "tableFrom": "library_books",
+          "tableTo": "profiles",
+          "columnsFrom": [
+            "updated_by_profile_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {
+        "Authenticated users can view library books": {
+          "name": "Authenticated users can view library books",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": [
+            "authenticated"
+          ],
+          "using": "true"
+        },
+        "Coaches and admins can add library books": {
+          "name": "Coaches and admins can add library books",
+          "as": "PERMISSIVE",
+          "for": "INSERT",
+          "to": [
+            "authenticated"
+          ],
+          "withCheck": "is_coach_or_admin()"
+        },
+        "Coaches and admins can update library books": {
+          "name": "Coaches and admins can update library books",
+          "as": "PERMISSIVE",
+          "for": "UPDATE",
+          "to": [
+            "authenticated"
+          ],
+          "using": "is_coach_or_admin()",
+          "withCheck": "is_coach_or_admin()"
+        },
+        "Coaches and admins can delete library books": {
+          "name": "Coaches and admins can delete library books",
+          "as": "PERMISSIVE",
+          "for": "DELETE",
+          "to": [
+            "authenticated"
+          ],
+          "using": "is_coach_or_admin()"
+        }
+      },
+      "checkConstraints": {},
+      "isRLSEnabled": true
+    },
+    "public.tags": {
+      "name": "tags",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_by_profile_id": {
+          "name": "created_by_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_by_profile_id": {
+          "name": "updated_by_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "tags_created_by_profile_id_fkey": {
+          "name": "tags_created_by_profile_id_fkey",
+          "tableFrom": "tags",
+          "tableTo": "profiles",
+          "columnsFrom": [
+            "created_by_profile_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "tags_updated_by_profile_id_fkey": {
+          "name": "tags_updated_by_profile_id_fkey",
+          "tableFrom": "tags",
+          "tableTo": "profiles",
+          "columnsFrom": [
+            "updated_by_profile_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "tags_name_key": {
+          "name": "tags_name_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "name"
+          ]
+        }
+      },
+      "policies": {
+        "Authenticated users can view tags": {
+          "name": "Authenticated users can view tags",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": [
+            "authenticated"
+          ],
+          "using": "true"
+        },
+        "Coaches and admins can add tags": {
+          "name": "Coaches and admins can add tags",
+          "as": "PERMISSIVE",
+          "for": "INSERT",
+          "to": [
+            "authenticated"
+          ],
+          "withCheck": "is_coach_or_admin()"
+        },
+        "Coaches and admins can update tags": {
+          "name": "Coaches and admins can update tags",
+          "as": "PERMISSIVE",
+          "for": "UPDATE",
+          "to": [
+            "authenticated"
+          ],
+          "using": "is_coach_or_admin()",
+          "withCheck": "is_coach_or_admin()"
+        },
+        "Coaches and admins can delete tags": {
+          "name": "Coaches and admins can delete tags",
+          "as": "PERMISSIVE",
+          "for": "DELETE",
+          "to": [
+            "authenticated"
+          ],
+          "using": "is_coach_or_admin()"
+        }
+      },
+      "checkConstraints": {},
+      "isRLSEnabled": true
+    },
+    "public.customer_meetings": {
+      "name": "customer_meetings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "profile_id": {
+          "name": "profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "meeting_at": {
+          "name": "meeting_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "company": {
+          "name": "company",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "contact_person": {
+          "name": "contact_person",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "position": {
+          "name": "position",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "objective": {
+          "name": "objective",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "post_mortem": {
+          "name": "post_mortem",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "team_share": {
+          "name": "team_share",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "removed_at": {
+          "name": "removed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_by_profile_id": {
+          "name": "created_by_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_by_profile_id": {
+          "name": "updated_by_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "customer_meetings_profile_idx": {
+          "name": "customer_meetings_profile_idx",
+          "columns": [
+            {
+              "expression": "profile_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "uuid_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "customer_meetings_created_desc_idx": {
+          "name": "customer_meetings_created_desc_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "first",
+              "opclass": "timestamptz_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "customer_meetings_profile_id_fkey": {
+          "name": "customer_meetings_profile_id_fkey",
+          "tableFrom": "customer_meetings",
+          "tableTo": "profiles",
+          "columnsFrom": [
+            "profile_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "customer_meetings_created_by_profile_id_fkey": {
+          "name": "customer_meetings_created_by_profile_id_fkey",
+          "tableFrom": "customer_meetings",
+          "tableTo": "profiles",
+          "columnsFrom": [
+            "created_by_profile_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "customer_meetings_updated_by_profile_id_fkey": {
+          "name": "customer_meetings_updated_by_profile_id_fkey",
+          "tableFrom": "customer_meetings",
+          "tableTo": "profiles",
+          "columnsFrom": [
+            "updated_by_profile_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {
+        "Users can view their own customer meetings": {
+          "name": "Users can view their own customer meetings",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": [
+            "authenticated"
+          ],
+          "using": "(profile_id = current_profile_id())"
+        },
+        "Users can create their own customer meetings": {
+          "name": "Users can create their own customer meetings",
+          "as": "PERMISSIVE",
+          "for": "INSERT",
+          "to": [
+            "authenticated"
+          ],
+          "withCheck": "(profile_id = current_profile_id())"
+        },
+        "Users can update their own customer meetings": {
+          "name": "Users can update their own customer meetings",
+          "as": "PERMISSIVE",
+          "for": "UPDATE",
+          "to": [
+            "authenticated"
+          ],
+          "using": "(profile_id = current_profile_id())",
+          "withCheck": "(profile_id = current_profile_id())"
+        },
+        "Users can delete their own customer meetings": {
+          "name": "Users can delete their own customer meetings",
+          "as": "PERMISSIVE",
+          "for": "DELETE",
+          "to": [
+            "authenticated"
+          ],
+          "using": "(profile_id = current_profile_id())"
+        }
+      },
+      "checkConstraints": {},
+      "isRLSEnabled": true
+    },
+    "public.dashboard_layouts": {
+      "name": "dashboard_layouts",
+      "schema": "",
+      "columns": {
+        "profile_id": {
+          "name": "profile_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "widgets": {
+          "name": "widgets",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_by_profile_id": {
+          "name": "created_by_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_by_profile_id": {
+          "name": "updated_by_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "dashboard_layouts_profile_id_fkey": {
+          "name": "dashboard_layouts_profile_id_fkey",
+          "tableFrom": "dashboard_layouts",
+          "tableTo": "profiles",
+          "columnsFrom": [
+            "profile_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "dashboard_layouts_created_by_profile_id_fkey": {
+          "name": "dashboard_layouts_created_by_profile_id_fkey",
+          "tableFrom": "dashboard_layouts",
+          "tableTo": "profiles",
+          "columnsFrom": [
+            "created_by_profile_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "dashboard_layouts_updated_by_profile_id_fkey": {
+          "name": "dashboard_layouts_updated_by_profile_id_fkey",
+          "tableFrom": "dashboard_layouts",
+          "tableTo": "profiles",
+          "columnsFrom": [
+            "updated_by_profile_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {
+        "Users can delete their own dashboard layout": {
+          "name": "Users can delete their own dashboard layout",
+          "as": "PERMISSIVE",
+          "for": "DELETE",
+          "to": [
+            "public"
+          ],
+          "using": "(profile_id = current_profile_id())"
+        },
+        "Users can update their own dashboard layout": {
+          "name": "Users can update their own dashboard layout",
+          "as": "PERMISSIVE",
+          "for": "UPDATE",
+          "to": [
+            "public"
+          ],
+          "using": "(profile_id = current_profile_id())",
+          "withCheck": "(profile_id = current_profile_id())"
+        },
+        "Users can insert their own dashboard layout": {
+          "name": "Users can insert their own dashboard layout",
+          "as": "PERMISSIVE",
+          "for": "INSERT",
+          "to": [
+            "public"
+          ],
+          "withCheck": "(profile_id = current_profile_id())"
+        },
+        "Users can view their own dashboard layout": {
+          "name": "Users can view their own dashboard layout",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": [
+            "public"
+          ],
+          "using": "(profile_id = current_profile_id())"
+        }
+      },
+      "checkConstraints": {},
+      "isRLSEnabled": true
+    },
+    "public.essay_coach_reads": {
+      "name": "essay_coach_reads",
+      "schema": "",
+      "columns": {
+        "essay_id": {
+          "name": "essay_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "coach_profile_id": {
+          "name": "coach_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "read_at": {
+          "name": "read_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_by_profile_id": {
+          "name": "created_by_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_by_profile_id": {
+          "name": "updated_by_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "essay_coach_reads_coach_idx": {
+          "name": "essay_coach_reads_coach_idx",
+          "columns": [
+            {
+              "expression": "coach_profile_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "uuid_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "essay_coach_reads_essay_id_fkey": {
+          "name": "essay_coach_reads_essay_id_fkey",
+          "tableFrom": "essay_coach_reads",
+          "tableTo": "essays",
+          "columnsFrom": [
+            "essay_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "essay_coach_reads_coach_profile_id_fkey": {
+          "name": "essay_coach_reads_coach_profile_id_fkey",
+          "tableFrom": "essay_coach_reads",
+          "tableTo": "profiles",
+          "columnsFrom": [
+            "coach_profile_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "essay_coach_reads_created_by_profile_id_fkey": {
+          "name": "essay_coach_reads_created_by_profile_id_fkey",
+          "tableFrom": "essay_coach_reads",
+          "tableTo": "profiles",
+          "columnsFrom": [
+            "created_by_profile_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "essay_coach_reads_updated_by_profile_id_fkey": {
+          "name": "essay_coach_reads_updated_by_profile_id_fkey",
+          "tableFrom": "essay_coach_reads",
+          "tableTo": "profiles",
+          "columnsFrom": [
+            "updated_by_profile_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "essay_coach_reads_pkey": {
+          "name": "essay_coach_reads_pkey",
+          "columns": [
+            "essay_id",
+            "coach_profile_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {
+        "Coaches remove own reads": {
+          "name": "Coaches remove own reads",
+          "as": "PERMISSIVE",
+          "for": "DELETE",
+          "to": [
+            "authenticated"
+          ],
+          "using": "(coach_profile_id = current_profile_id())"
+        },
+        "Coaches mark own reads within their team": {
+          "name": "Coaches mark own reads within their team",
+          "as": "PERMISSIVE",
+          "for": "INSERT",
+          "to": [
+            "authenticated"
+          ],
+          "withCheck": "((coach_profile_id = current_profile_id()) AND coach_can_review_essay(essay_id))"
+        },
+        "Coach sees own reads; author sees reads of own essays": {
+          "name": "Coach sees own reads; author sees reads of own essays",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": [
+            "authenticated"
+          ],
+          "using": "((coach_profile_id = current_profile_id()) OR (EXISTS ( SELECT 1\n   FROM essays e\n  WHERE ((e.id = essay_coach_reads.essay_id) AND (e.author_profile_id = current_profile_id())))))"
+        }
+      },
+      "checkConstraints": {},
+      "isRLSEnabled": true
+    },
+    "public.essay_comments": {
+      "name": "essay_comments",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "essay_id": {
+          "name": "essay_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "author_profile_id": {
+          "name": "author_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "parent_id": {
+          "name": "parent_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "removed_at": {
+          "name": "removed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_by_profile_id": {
+          "name": "created_by_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_by_profile_id": {
+          "name": "updated_by_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "essay_comments_author_idx": {
+          "name": "essay_comments_author_idx",
+          "columns": [
+            {
+              "expression": "author_profile_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "uuid_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "essay_comments_essay_idx": {
+          "name": "essay_comments_essay_idx",
+          "columns": [
+            {
+              "expression": "essay_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "uuid_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "essay_comments_essay_id_fkey": {
+          "name": "essay_comments_essay_id_fkey",
+          "tableFrom": "essay_comments",
+          "tableTo": "essays",
+          "columnsFrom": [
+            "essay_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "essay_comments_author_profile_id_fkey": {
+          "name": "essay_comments_author_profile_id_fkey",
+          "tableFrom": "essay_comments",
+          "tableTo": "profiles",
+          "columnsFrom": [
+            "author_profile_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "essay_comments_created_by_profile_id_fkey": {
+          "name": "essay_comments_created_by_profile_id_fkey",
+          "tableFrom": "essay_comments",
+          "tableTo": "profiles",
+          "columnsFrom": [
+            "created_by_profile_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "essay_comments_updated_by_profile_id_fkey": {
+          "name": "essay_comments_updated_by_profile_id_fkey",
+          "tableFrom": "essay_comments",
+          "tableTo": "profiles",
+          "columnsFrom": [
+            "updated_by_profile_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "essay_comments_parent_id_fkey": {
+          "name": "essay_comments_parent_id_fkey",
+          "tableFrom": "essay_comments",
+          "tableTo": "essay_comments",
+          "columnsFrom": [
+            "parent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {
+        "Authors and admins can delete essay comments": {
+          "name": "Authors and admins can delete essay comments",
+          "as": "PERMISSIVE",
+          "for": "DELETE",
+          "to": [
+            "authenticated"
+          ],
+          "using": "((author_profile_id = current_profile_id()) OR is_admin())"
+        },
+        "Authors can update their own essay comments": {
+          "name": "Authors can update their own essay comments",
+          "as": "PERMISSIVE",
+          "for": "UPDATE",
+          "to": [
+            "authenticated"
+          ],
+          "using": "(author_profile_id = current_profile_id())",
+          "withCheck": "(author_profile_id = current_profile_id())"
+        },
+        "Authenticated users can add essay comments": {
+          "name": "Authenticated users can add essay comments",
+          "as": "PERMISSIVE",
+          "for": "INSERT",
+          "to": [
+            "authenticated"
+          ],
+          "withCheck": "(author_profile_id = current_profile_id())"
+        },
+        "Authenticated users can view essay comments": {
+          "name": "Authenticated users can view essay comments",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": [
+            "authenticated"
+          ],
+          "using": "true"
+        }
+      },
+      "checkConstraints": {
+        "essay_comments_body_check": {
+          "name": "essay_comments_body_check",
+          "value": "(char_length(body) >= 1) AND (char_length(body) <= 4000)"
+        }
+      },
+      "isRLSEnabled": true
+    },
+    "public.essay_revisions": {
+      "name": "essay_revisions",
+      "schema": "",
+      "columns": {
+        "essay_id": {
+          "name": "essay_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "revision_no": {
+          "name": "revision_no",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content_json": {
+          "name": "content_json",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "invalid_since": {
+          "name": "invalid_since",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_by_profile_id": {
+          "name": "created_by_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_by_profile_id": {
+          "name": "updated_by_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "essay_revisions_essay_id_fkey": {
+          "name": "essay_revisions_essay_id_fkey",
+          "tableFrom": "essay_revisions",
+          "tableTo": "essays",
+          "columnsFrom": [
+            "essay_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "essay_revisions_created_by_profile_id_fkey": {
+          "name": "essay_revisions_created_by_profile_id_fkey",
+          "tableFrom": "essay_revisions",
+          "tableTo": "profiles",
+          "columnsFrom": [
+            "created_by_profile_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "essay_revisions_updated_by_profile_id_fkey": {
+          "name": "essay_revisions_updated_by_profile_id_fkey",
+          "tableFrom": "essay_revisions",
+          "tableTo": "profiles",
+          "columnsFrom": [
+            "updated_by_profile_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "essay_revisions_pkey": {
+          "name": "essay_revisions_pkey",
+          "columns": [
+            "essay_id",
+            "revision_no"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {
+        "Authenticated users can view essay revisions": {
+          "name": "Authenticated users can view essay revisions",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": [
+            "authenticated"
+          ],
+          "using": "(EXISTS ( SELECT 1\n   FROM essays e\n  WHERE ((e.id = essay_revisions.essay_id) AND ((e.published_at IS NOT NULL) OR (e.author_profile_id = ( SELECT current_profile_id())) OR ( SELECT is_admin())))))"
+        },
+        "Authors can create essay revisions": {
+          "name": "Authors can create essay revisions",
+          "as": "PERMISSIVE",
+          "for": "INSERT",
+          "to": [
+            "authenticated"
+          ],
+          "withCheck": "(created_by_profile_id = current_profile_id())"
+        },
+        "Authors can update their newest recent essay revision": {
+          "name": "Authors can update their newest recent essay revision",
+          "as": "PERMISSIVE",
+          "for": "UPDATE",
+          "to": [
+            "authenticated"
+          ],
+          "using": "((created_by_profile_id = ( SELECT current_profile_id())) AND (created_at > (now() - '00:30:00'::interval)))",
+          "withCheck": "(created_by_profile_id = ( SELECT current_profile_id()))"
+        },
+        "Essay revisions cannot be deleted": {
+          "name": "Essay revisions cannot be deleted",
+          "as": "PERMISSIVE",
+          "for": "DELETE",
+          "to": [
+            "authenticated"
+          ],
+          "using": "false"
+        }
+      },
+      "checkConstraints": {},
+      "isRLSEnabled": true
+    },
+    "public.essay_views": {
+      "name": "essay_views",
+      "schema": "",
+      "columns": {
+        "essay_id": {
+          "name": "essay_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "viewer_profile_id": {
+          "name": "viewer_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "first_viewed_at": {
+          "name": "first_viewed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_viewed_at": {
+          "name": "last_viewed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_by_profile_id": {
+          "name": "created_by_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_by_profile_id": {
+          "name": "updated_by_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "essay_views_viewer_idx": {
+          "name": "essay_views_viewer_idx",
+          "columns": [
+            {
+              "expression": "viewer_profile_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "uuid_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "essay_views_essay_id_fkey": {
+          "name": "essay_views_essay_id_fkey",
+          "tableFrom": "essay_views",
+          "tableTo": "essays",
+          "columnsFrom": [
+            "essay_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "essay_views_viewer_profile_id_fkey": {
+          "name": "essay_views_viewer_profile_id_fkey",
+          "tableFrom": "essay_views",
+          "tableTo": "profiles",
+          "columnsFrom": [
+            "viewer_profile_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "essay_views_created_by_profile_id_fkey": {
+          "name": "essay_views_created_by_profile_id_fkey",
+          "tableFrom": "essay_views",
+          "tableTo": "profiles",
+          "columnsFrom": [
+            "created_by_profile_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "essay_views_updated_by_profile_id_fkey": {
+          "name": "essay_views_updated_by_profile_id_fkey",
+          "tableFrom": "essay_views",
+          "tableTo": "profiles",
+          "columnsFrom": [
+            "updated_by_profile_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "essay_views_pkey": {
+          "name": "essay_views_pkey",
+          "columns": [
+            "essay_id",
+            "viewer_profile_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {
+        "No direct inserts to essay_views": {
+          "name": "No direct inserts to essay_views",
+          "as": "PERMISSIVE",
+          "for": "INSERT",
+          "to": [
+            "authenticated"
+          ],
+          "withCheck": "false"
+        },
+        "Authors see all viewers; others see own row": {
+          "name": "Authors see all viewers; others see own row",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": [
+            "authenticated"
+          ],
+          "using": "((viewer_profile_id = current_profile_id()) OR (EXISTS ( SELECT 1\n   FROM essays e\n  WHERE ((e.id = essay_views.essay_id) AND (e.author_profile_id = current_profile_id())))))"
+        }
+      },
+      "checkConstraints": {},
+      "isRLSEnabled": true
+    },
+    "public.essay_votes": {
+      "name": "essay_votes",
+      "schema": "",
+      "columns": {
+        "essay_id": {
+          "name": "essay_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "voter_profile_id": {
+          "name": "voter_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_by_profile_id": {
+          "name": "created_by_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_by_profile_id": {
+          "name": "updated_by_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "essay_votes_voter_idx": {
+          "name": "essay_votes_voter_idx",
+          "columns": [
+            {
+              "expression": "voter_profile_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "uuid_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "essay_votes_essay_id_fkey": {
+          "name": "essay_votes_essay_id_fkey",
+          "tableFrom": "essay_votes",
+          "tableTo": "essays",
+          "columnsFrom": [
+            "essay_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "essay_votes_voter_profile_id_fkey": {
+          "name": "essay_votes_voter_profile_id_fkey",
+          "tableFrom": "essay_votes",
+          "tableTo": "profiles",
+          "columnsFrom": [
+            "voter_profile_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "essay_votes_created_by_profile_id_fkey": {
+          "name": "essay_votes_created_by_profile_id_fkey",
+          "tableFrom": "essay_votes",
+          "tableTo": "profiles",
+          "columnsFrom": [
+            "created_by_profile_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "essay_votes_updated_by_profile_id_fkey": {
+          "name": "essay_votes_updated_by_profile_id_fkey",
+          "tableFrom": "essay_votes",
+          "tableTo": "profiles",
+          "columnsFrom": [
+            "updated_by_profile_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "essay_votes_pkey": {
+          "name": "essay_votes_pkey",
+          "columns": [
+            "essay_id",
+            "voter_profile_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {
+        "Users can vote (not own essays)": {
+          "name": "Users can vote (not own essays)",
+          "as": "PERMISSIVE",
+          "for": "INSERT",
+          "to": [
+            "authenticated"
+          ],
+          "withCheck": "((voter_profile_id = current_profile_id()) AND (NOT (essay_id IN ( SELECT essays.id\n   FROM essays\n  WHERE (essays.author_profile_id = current_profile_id())))))"
+        },
+        "Authenticated users can view votes": {
+          "name": "Authenticated users can view votes",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": [
+            "authenticated"
+          ],
+          "using": "true"
+        },
+        "Users can remove own votes": {
+          "name": "Users can remove own votes",
+          "as": "PERMISSIVE",
+          "for": "DELETE",
+          "to": [
+            "authenticated"
+          ],
+          "using": "(voter_profile_id = current_profile_id())"
+        }
+      },
+      "checkConstraints": {},
+      "isRLSEnabled": true
+    },
+    "public.essays": {
+      "name": "essays",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "external_id": {
+          "name": "external_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "author_profile_id": {
+          "name": "author_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "book_id": {
+          "name": "book_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "published_at": {
+          "name": "published_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pinned_at": {
+          "name": "pinned_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pinned_by_profile_id": {
+          "name": "pinned_by_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "removed_at": {
+          "name": "removed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_by_profile_id": {
+          "name": "created_by_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_by_profile_id": {
+          "name": "updated_by_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "essays_author_idx": {
+          "name": "essays_author_idx",
+          "columns": [
+            {
+              "expression": "author_profile_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "uuid_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "essays_book_idx": {
+          "name": "essays_book_idx",
+          "columns": [
+            {
+              "expression": "book_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "uuid_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "essays_created_desc_idx": {
+          "name": "essays_created_desc_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "first",
+              "opclass": "timestamptz_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "essays_author_profile_id_fkey": {
+          "name": "essays_author_profile_id_fkey",
+          "tableFrom": "essays",
+          "tableTo": "profiles",
+          "columnsFrom": [
+            "author_profile_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "essays_book_id_fkey": {
+          "name": "essays_book_id_fkey",
+          "tableFrom": "essays",
+          "tableTo": "books",
+          "columnsFrom": [
+            "book_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "essays_pinned_by_profile_id_fkey": {
+          "name": "essays_pinned_by_profile_id_fkey",
+          "tableFrom": "essays",
+          "tableTo": "profiles",
+          "columnsFrom": [
+            "pinned_by_profile_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "essays_created_by_profile_id_fkey": {
+          "name": "essays_created_by_profile_id_fkey",
+          "tableFrom": "essays",
+          "tableTo": "profiles",
+          "columnsFrom": [
+            "created_by_profile_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "essays_updated_by_profile_id_fkey": {
+          "name": "essays_updated_by_profile_id_fkey",
+          "tableFrom": "essays",
+          "tableTo": "profiles",
+          "columnsFrom": [
+            "updated_by_profile_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {
+        "Authors can create their own essays": {
+          "name": "Authors can create their own essays",
+          "as": "PERMISSIVE",
+          "for": "INSERT",
+          "to": [
+            "authenticated"
+          ],
+          "withCheck": "(author_profile_id = current_profile_id())"
+        },
+        "Authenticated users can view all essays": {
+          "name": "Authenticated users can view all essays",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": [
+            "authenticated"
+          ],
+          "using": "((published_at IS NOT NULL) OR (author_profile_id = ( SELECT current_profile_id())) OR ( SELECT is_admin()))"
+        },
+        "Authors and admins can delete essays": {
+          "name": "Authors and admins can delete essays",
+          "as": "PERMISSIVE",
+          "for": "DELETE",
+          "to": [
+            "authenticated"
+          ],
+          "using": "((author_profile_id = current_profile_id()) OR is_admin())"
+        },
+        "Authors can update their own essays": {
+          "name": "Authors can update their own essays",
+          "as": "PERMISSIVE",
+          "for": "UPDATE",
+          "to": [
+            "authenticated"
+          ],
+          "using": "(author_profile_id = current_profile_id())",
+          "withCheck": "(author_profile_id = current_profile_id())"
+        }
+      },
+      "checkConstraints": {},
+      "isRLSEnabled": true
+    },
+    "public.feedback": {
+      "name": "feedback",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "author_profile_id": {
+          "name": "author_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "resolved_at": {
+          "name": "resolved_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_by_profile_id": {
+          "name": "created_by_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_by_profile_id": {
+          "name": "updated_by_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "feedback_active_created_idx": {
+          "name": "feedback_active_created_idx",
+          "columns": [
+            {
+              "expression": "resolved_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "timestamptz_ops"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "first",
+              "opclass": "timestamptz_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "feedback_author_idx": {
+          "name": "feedback_author_idx",
+          "columns": [
+            {
+              "expression": "author_profile_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "uuid_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "feedback_author_profile_id_fkey": {
+          "name": "feedback_author_profile_id_fkey",
+          "tableFrom": "feedback",
+          "tableTo": "profiles",
+          "columnsFrom": [
+            "author_profile_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "feedback_created_by_profile_id_fkey": {
+          "name": "feedback_created_by_profile_id_fkey",
+          "tableFrom": "feedback",
+          "tableTo": "profiles",
+          "columnsFrom": [
+            "created_by_profile_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "feedback_updated_by_profile_id_fkey": {
+          "name": "feedback_updated_by_profile_id_fkey",
+          "tableFrom": "feedback",
+          "tableTo": "profiles",
+          "columnsFrom": [
+            "updated_by_profile_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {
+        "Authenticated users can view feedback": {
+          "name": "Authenticated users can view feedback",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": [
+            "authenticated"
+          ],
+          "using": "true"
+        },
+        "Authenticated users can create feedback": {
+          "name": "Authenticated users can create feedback",
+          "as": "PERMISSIVE",
+          "for": "INSERT",
+          "to": [
+            "authenticated"
+          ],
+          "withCheck": "(author_profile_id = current_profile_id())"
+        },
+        "Admins can update feedback": {
+          "name": "Admins can update feedback",
+          "as": "PERMISSIVE",
+          "for": "UPDATE",
+          "to": [
+            "authenticated"
+          ],
+          "using": "is_admin()",
+          "withCheck": "is_admin()"
+        },
+        "Authors and admins can delete feedback": {
+          "name": "Authors and admins can delete feedback",
+          "as": "PERMISSIVE",
+          "for": "DELETE",
+          "to": [
+            "authenticated"
+          ],
+          "using": "((author_profile_id = current_profile_id()) OR is_admin())"
+        }
+      },
+      "checkConstraints": {
+        "feedback_body_check": {
+          "name": "feedback_body_check",
+          "value": "(char_length(body) >= 1) AND (char_length(body) <= 4000)"
+        }
+      },
+      "isRLSEnabled": true
+    },
+    "public.individual_coaching_sessions": {
+      "name": "individual_coaching_sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "profile_id": {
+          "name": "profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "session_at": {
+          "name": "session_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "coach_profile_id": {
+          "name": "coach_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "external_coach_name": {
+          "name": "external_coach_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "key_takeaways": {
+          "name": "key_takeaways",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "action_steps": {
+          "name": "action_steps",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "removed_at": {
+          "name": "removed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_by_profile_id": {
+          "name": "created_by_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_by_profile_id": {
+          "name": "updated_by_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "individual_coaching_sessions_profile_idx": {
+          "name": "individual_coaching_sessions_profile_idx",
+          "columns": [
+            {
+              "expression": "profile_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "uuid_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "individual_coaching_sessions_coach_idx": {
+          "name": "individual_coaching_sessions_coach_idx",
+          "columns": [
+            {
+              "expression": "coach_profile_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "uuid_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "individual_coaching_sessions_created_desc_idx": {
+          "name": "individual_coaching_sessions_created_desc_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "first",
+              "opclass": "timestamptz_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "individual_coaching_sessions_profile_id_fkey": {
+          "name": "individual_coaching_sessions_profile_id_fkey",
+          "tableFrom": "individual_coaching_sessions",
+          "tableTo": "profiles",
+          "columnsFrom": [
+            "profile_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "individual_coaching_sessions_coach_profile_id_fkey": {
+          "name": "individual_coaching_sessions_coach_profile_id_fkey",
+          "tableFrom": "individual_coaching_sessions",
+          "tableTo": "profiles",
+          "columnsFrom": [
+            "coach_profile_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "individual_coaching_sessions_created_by_profile_id_fkey": {
+          "name": "individual_coaching_sessions_created_by_profile_id_fkey",
+          "tableFrom": "individual_coaching_sessions",
+          "tableTo": "profiles",
+          "columnsFrom": [
+            "created_by_profile_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "individual_coaching_sessions_updated_by_profile_id_fkey": {
+          "name": "individual_coaching_sessions_updated_by_profile_id_fkey",
+          "tableFrom": "individual_coaching_sessions",
+          "tableTo": "profiles",
+          "columnsFrom": [
+            "updated_by_profile_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {
+        "Users can view their own coaching sessions": {
+          "name": "Users can view their own coaching sessions",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": [
+            "authenticated"
+          ],
+          "using": "(profile_id = current_profile_id())"
+        },
+        "Users can create their own coaching sessions": {
+          "name": "Users can create their own coaching sessions",
+          "as": "PERMISSIVE",
+          "for": "INSERT",
+          "to": [
+            "authenticated"
+          ],
+          "withCheck": "(profile_id = current_profile_id())"
+        },
+        "Users can update their own coaching sessions": {
+          "name": "Users can update their own coaching sessions",
+          "as": "PERMISSIVE",
+          "for": "UPDATE",
+          "to": [
+            "authenticated"
+          ],
+          "using": "(profile_id = current_profile_id())",
+          "withCheck": "(profile_id = current_profile_id())"
+        },
+        "Users can delete their own coaching sessions": {
+          "name": "Users can delete their own coaching sessions",
+          "as": "PERMISSIVE",
+          "for": "DELETE",
+          "to": [
+            "authenticated"
+          ],
+          "using": "(profile_id = current_profile_id())"
+        }
+      },
+      "checkConstraints": {
+        "individual_coaching_sessions_coach_xor": {
+          "name": "individual_coaching_sessions_coach_xor",
+          "value": "(coach_profile_id IS NOT NULL) <> (external_coach_name IS NOT NULL)"
+        }
+      },
+      "isRLSEnabled": true
+    },
+    "public.notification_preferences": {
+      "name": "notification_preferences",
+      "schema": "",
+      "columns": {
+        "profile_id": {
+          "name": "profile_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "essay_coach_read_email": {
+          "name": "essay_coach_read_email",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "essay_comment_email": {
+          "name": "essay_comment_email",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "essay_vote_email": {
+          "name": "essay_vote_email",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "book_submitted_email": {
+          "name": "book_submitted_email",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_by_profile_id": {
+          "name": "created_by_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_by_profile_id": {
+          "name": "updated_by_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "notification_preferences_profile_id_fkey": {
+          "name": "notification_preferences_profile_id_fkey",
+          "tableFrom": "notification_preferences",
+          "tableTo": "profiles",
+          "columnsFrom": [
+            "profile_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "notification_preferences_created_by_profile_id_fkey": {
+          "name": "notification_preferences_created_by_profile_id_fkey",
+          "tableFrom": "notification_preferences",
+          "tableTo": "profiles",
+          "columnsFrom": [
+            "created_by_profile_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "notification_preferences_updated_by_profile_id_fkey": {
+          "name": "notification_preferences_updated_by_profile_id_fkey",
+          "tableFrom": "notification_preferences",
+          "tableTo": "profiles",
+          "columnsFrom": [
+            "updated_by_profile_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {
+        "Users can view their own notification preferences": {
+          "name": "Users can view their own notification preferences",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": [
+            "authenticated"
+          ],
+          "using": "(profile_id = current_profile_id())"
+        },
+        "Users can insert their own notification preferences": {
+          "name": "Users can insert their own notification preferences",
+          "as": "PERMISSIVE",
+          "for": "INSERT",
+          "to": [
+            "authenticated"
+          ],
+          "withCheck": "(profile_id = current_profile_id())"
+        },
+        "Users can update their own notification preferences": {
+          "name": "Users can update their own notification preferences",
+          "as": "PERMISSIVE",
+          "for": "UPDATE",
+          "to": [
+            "authenticated"
+          ],
+          "using": "(profile_id = current_profile_id())",
+          "withCheck": "(profile_id = current_profile_id())"
+        }
+      },
+      "checkConstraints": {},
+      "isRLSEnabled": true
+    },
+    "public.personality_tests": {
+      "name": "personality_tests",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "profile_id": {
+          "name": "profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "test_type": {
+          "name": "test_type",
+          "type": "personality_test_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "test_type_other": {
+          "name": "test_type_other",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tested_on": {
+          "name": "tested_on",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "file_path": {
+          "name": "file_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "file_name": {
+          "name": "file_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "file_size": {
+          "name": "file_size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "removed_at": {
+          "name": "removed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_by_profile_id": {
+          "name": "created_by_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_by_profile_id": {
+          "name": "updated_by_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "personality_tests_profile_tested_on_idx": {
+          "name": "personality_tests_profile_tested_on_idx",
+          "columns": [
+            {
+              "expression": "profile_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "uuid_ops"
+            },
+            {
+              "expression": "tested_on",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "date_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "personality_tests_profile_id_fkey": {
+          "name": "personality_tests_profile_id_fkey",
+          "tableFrom": "personality_tests",
+          "tableTo": "profiles",
+          "columnsFrom": [
+            "profile_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "personality_tests_created_by_profile_id_fkey": {
+          "name": "personality_tests_created_by_profile_id_fkey",
+          "tableFrom": "personality_tests",
+          "tableTo": "profiles",
+          "columnsFrom": [
+            "created_by_profile_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "personality_tests_updated_by_profile_id_fkey": {
+          "name": "personality_tests_updated_by_profile_id_fkey",
+          "tableFrom": "personality_tests",
+          "tableTo": "profiles",
+          "columnsFrom": [
+            "updated_by_profile_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {
+        "Verified users can view personality tests": {
+          "name": "Verified users can view personality tests",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": [
+            "authenticated"
+          ],
+          "using": "(EXISTS (SELECT 1 FROM users WHERE (users.auth_user_id = (SELECT auth.uid()) AND users.verified_work_email IS NOT NULL)))"
+        },
+        "Users can create their own personality tests": {
+          "name": "Users can create their own personality tests",
+          "as": "PERMISSIVE",
+          "for": "INSERT",
+          "to": [
+            "authenticated"
+          ],
+          "withCheck": "(profile_id = current_profile_id())"
+        },
+        "Users can update their own personality tests": {
+          "name": "Users can update their own personality tests",
+          "as": "PERMISSIVE",
+          "for": "UPDATE",
+          "to": [
+            "authenticated"
+          ],
+          "using": "(profile_id = current_profile_id())",
+          "withCheck": "(profile_id = current_profile_id())"
+        },
+        "Users can delete their own personality tests": {
+          "name": "Users can delete their own personality tests",
+          "as": "PERMISSIVE",
+          "for": "DELETE",
+          "to": [
+            "authenticated"
+          ],
+          "using": "(profile_id = current_profile_id())"
+        }
+      },
+      "checkConstraints": {
+        "personality_tests_other_type_required": {
+          "name": "personality_tests_other_type_required",
+          "value": "(test_type <> 'other' OR (test_type_other IS NOT NULL AND length(trim(test_type_other)) > 0))"
+        }
+      },
+      "isRLSEnabled": true
+    },
+    "public.profiles": {
+      "name": "profiles",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "picture": {
+          "name": "picture",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "work_email": {
+          "name": "work_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "profile_role",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'student'"
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "phone_number": {
+          "name": "phone_number",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "personal_email": {
+          "name": "personal_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "date_of_birth": {
+          "name": "date_of_birth",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_removed_at": {
+          "name": "access_removed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_removed_by_profile_id": {
+          "name": "access_removed_by_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "beta_access_granted_at": {
+          "name": "beta_access_granted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_by_profile_id": {
+          "name": "created_by_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_by_profile_id": {
+          "name": "updated_by_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "profiles_team_id_idx": {
+          "name": "profiles_team_id_idx",
+          "columns": [
+            {
+              "expression": "team_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "uuid_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "profiles_team_id_user_id_idx": {
+          "name": "profiles_team_id_user_id_idx",
+          "columns": [
+            {
+              "expression": "team_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "uuid_ops"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "uuid_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "profiles_user_id_idx": {
+          "name": "profiles_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "uuid_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "profiles_work_email_idx": {
+          "name": "profiles_work_email_idx",
+          "columns": [
+            {
+              "expression": "work_email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "text_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "profiles_user_id_fkey": {
+          "name": "profiles_user_id_fkey",
+          "tableFrom": "profiles",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "profiles_team_id_fkey": {
+          "name": "profiles_team_id_fkey",
+          "tableFrom": "profiles",
+          "tableTo": "teams",
+          "columnsFrom": [
+            "team_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "profiles_access_removed_by_profile_id_fkey": {
+          "name": "profiles_access_removed_by_profile_id_fkey",
+          "tableFrom": "profiles",
+          "tableTo": "profiles",
+          "columnsFrom": [
+            "access_removed_by_profile_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "profiles_created_by_profile_id_fkey": {
+          "name": "profiles_created_by_profile_id_fkey",
+          "tableFrom": "profiles",
+          "tableTo": "profiles",
+          "columnsFrom": [
+            "created_by_profile_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "profiles_updated_by_profile_id_fkey": {
+          "name": "profiles_updated_by_profile_id_fkey",
+          "tableFrom": "profiles",
+          "tableTo": "profiles",
+          "columnsFrom": [
+            "updated_by_profile_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "profiles_user_id_key": {
+          "name": "profiles_user_id_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id"
+          ]
+        },
+        "profiles_work_email_key": {
+          "name": "profiles_work_email_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "work_email"
+          ]
+        }
+      },
+      "policies": {
+        "Verified users can view all profiles": {
+          "name": "Verified users can view all profiles",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": [
+            "authenticated"
+          ],
+          "using": "((access_removed_at IS NULL) AND (EXISTS ( SELECT 1\n   FROM users\n  WHERE ((users.auth_user_id = ( SELECT auth.uid() AS uid)) AND (users.verified_work_email IS NOT NULL)))))"
+        },
+        "Users can update their own profile picture": {
+          "name": "Users can update their own profile picture",
+          "as": "PERMISSIVE",
+          "for": "UPDATE",
+          "to": [
+            "authenticated"
+          ],
+          "using": "(user_id IN ( SELECT users.id\n   FROM users\n  WHERE (users.auth_user_id = ( SELECT auth.uid() AS uid))))",
+          "withCheck": "(user_id IN ( SELECT users.id\n   FROM users\n  WHERE (users.auth_user_id = ( SELECT auth.uid() AS uid))))"
+        }
+      },
+      "checkConstraints": {
+        "valid_czu_domain": {
+          "name": "valid_czu_domain",
+          "value": "(lower(split_part(work_email, '@'::text, 2)) = ANY (ARRAY['pef.czu.cz'::text, 'studenti.czu.cz'::text, 'rektorat.czu.cz'::text]))"
+        }
+      },
+      "isRLSEnabled": true
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "auth_user_id": {
+          "name": "auth_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "google_email": {
+          "name": "google_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "suggested_work_email": {
+          "name": "suggested_work_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "verified_work_email": {
+          "name": "verified_work_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "verified_work_email_at": {
+          "name": "verified_work_email_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_otp_sent_at": {
+          "name": "last_otp_sent_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "users_google_email_idx": {
+          "name": "users_google_email_idx",
+          "columns": [
+            {
+              "expression": "google_email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "text_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "users_suggested_work_email_idx": {
+          "name": "users_suggested_work_email_idx",
+          "columns": [
+            {
+              "expression": "suggested_work_email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "text_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "users_auth_user_id_fkey": {
+          "name": "users_auth_user_id_fkey",
+          "tableFrom": "users",
+          "tableTo": "users",
+          "schemaTo": "auth",
+          "columnsFrom": [
+            "auth_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_auth_user_id_key": {
+          "name": "users_auth_user_id_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "auth_user_id"
+          ]
+        },
+        "users_google_email_key": {
+          "name": "users_google_email_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "google_email"
+          ]
+        }
+      },
+      "policies": {
+        "Users can update only suggested_work_email": {
+          "name": "Users can update only suggested_work_email",
+          "as": "PERMISSIVE",
+          "for": "UPDATE",
+          "to": [
+            "authenticated"
+          ],
+          "using": "(( SELECT auth.uid() AS uid) = auth_user_id)",
+          "withCheck": "(( SELECT auth.uid() AS uid) = auth_user_id)"
+        },
+        "Users can insert their own user record": {
+          "name": "Users can insert their own user record",
+          "as": "PERMISSIVE",
+          "for": "INSERT",
+          "to": [
+            "authenticated"
+          ],
+          "withCheck": "(( SELECT auth.uid() AS uid) = auth_user_id)"
+        },
+        "Users can view their own user record": {
+          "name": "Users can view their own user record",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": [
+            "authenticated"
+          ],
+          "using": "(( SELECT auth.uid() AS uid) = auth_user_id)"
+        }
+      },
+      "checkConstraints": {},
+      "isRLSEnabled": true
+    },
+    "public.recurring_schedules": {
+      "name": "recurring_schedules",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "room_id": {
+          "name": "room_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "schedule_type": {
+          "name": "schedule_type",
+          "type": "schedule_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "day_of_week": {
+          "name": "day_of_week",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "start_time": {
+          "name": "start_time",
+          "type": "time",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "end_time": {
+          "name": "end_time",
+          "type": "time",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "valid_from": {
+          "name": "valid_from",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "valid_until": {
+          "name": "valid_until",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "removed_at": {
+          "name": "removed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_by_profile_id": {
+          "name": "created_by_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_by_profile_id": {
+          "name": "updated_by_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "idx_recurring_schedules_day": {
+          "name": "idx_recurring_schedules_day",
+          "columns": [
+            {
+              "expression": "day_of_week",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "int2_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_recurring_schedules_room": {
+          "name": "idx_recurring_schedules_room",
+          "columns": [
+            {
+              "expression": "room_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "uuid_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_recurring_schedules_team": {
+          "name": "idx_recurring_schedules_team",
+          "columns": [
+            {
+              "expression": "team_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "uuid_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_recurring_schedules_type": {
+          "name": "idx_recurring_schedules_type",
+          "columns": [
+            {
+              "expression": "schedule_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "enum_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_recurring_schedules_valid": {
+          "name": "idx_recurring_schedules_valid",
+          "columns": [
+            {
+              "expression": "valid_from",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "date_ops"
+            },
+            {
+              "expression": "valid_until",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "date_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "recurring_schedules_room_id_fkey": {
+          "name": "recurring_schedules_room_id_fkey",
+          "tableFrom": "recurring_schedules",
+          "tableTo": "rooms",
+          "columnsFrom": [
+            "room_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "recurring_schedules_team_id_fkey": {
+          "name": "recurring_schedules_team_id_fkey",
+          "tableFrom": "recurring_schedules",
+          "tableTo": "teams",
+          "columnsFrom": [
+            "team_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "recurring_schedules_created_by_profile_id_fkey": {
+          "name": "recurring_schedules_created_by_profile_id_fkey",
+          "tableFrom": "recurring_schedules",
+          "tableTo": "profiles",
+          "columnsFrom": [
+            "created_by_profile_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "recurring_schedules_updated_by_profile_id_fkey": {
+          "name": "recurring_schedules_updated_by_profile_id_fkey",
+          "tableFrom": "recurring_schedules",
+          "tableTo": "profiles",
+          "columnsFrom": [
+            "updated_by_profile_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {
+        "Coaches can manage recurring_schedules": {
+          "name": "Coaches can manage recurring_schedules",
+          "as": "PERMISSIVE",
+          "for": "ALL",
+          "to": [
+            "authenticated"
+          ],
+          "using": "(EXISTS ( SELECT 1\n   FROM profiles\n  WHERE ((profiles.user_id IN ( SELECT users.id\n           FROM users\n          WHERE (users.auth_user_id = ( SELECT auth.uid() AS uid)))) AND (profiles.role = ANY (ARRAY['coach'::profile_role, 'admin'::profile_role])))))",
+          "withCheck": "(EXISTS ( SELECT 1\n   FROM profiles\n  WHERE ((profiles.user_id IN ( SELECT users.id\n           FROM users\n          WHERE (users.auth_user_id = ( SELECT auth.uid() AS uid)))) AND (profiles.role = ANY (ARRAY['coach'::profile_role, 'admin'::profile_role])))))"
+        },
+        "Authenticated can read recurring_schedules": {
+          "name": "Authenticated can read recurring_schedules",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": [
+            "authenticated"
+          ],
+          "using": "true"
+        }
+      },
+      "checkConstraints": {
+        "recurring_schedules_day_of_week_check": {
+          "name": "recurring_schedules_day_of_week_check",
+          "value": "(day_of_week >= 0) AND (day_of_week <= 6)"
+        },
+        "valid_time_range": {
+          "name": "valid_time_range",
+          "value": "end_time > start_time"
+        },
+        "valid_schedule_dates": {
+          "name": "valid_schedule_dates",
+          "value": "(valid_until IS NULL) OR (valid_until >= valid_from)"
+        },
+        "recurring_schedules_team_for_ts": {
+          "name": "recurring_schedules_team_for_ts",
+          "value": "(schedule_type <> 'training_session'::schedule_type) OR (team_id IS NOT NULL)"
+        }
+      },
+      "isRLSEnabled": true
+    },
+    "public.reservations": {
+      "name": "reservations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "room_id": {
+          "name": "room_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "owner_profile_id": {
+          "name": "owner_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "person_count": {
+          "name": "person_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "start_at": {
+          "name": "start_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "end_at": {
+          "name": "end_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cancelled_at": {
+          "name": "cancelled_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cancelled_by_profile_id": {
+          "name": "cancelled_by_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_by_profile_id": {
+          "name": "created_by_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_by_profile_id": {
+          "name": "updated_by_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "idx_reservations_room_time": {
+          "name": "idx_reservations_room_time",
+          "columns": [
+            {
+              "expression": "room_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "uuid_ops"
+            },
+            {
+              "expression": "start_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "timestamptz_ops"
+            },
+            {
+              "expression": "end_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "timestamptz_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_reservations_start": {
+          "name": "idx_reservations_start",
+          "columns": [
+            {
+              "expression": "start_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "timestamptz_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_reservations_owner": {
+          "name": "idx_reservations_owner",
+          "columns": [
+            {
+              "expression": "owner_profile_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "uuid_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "reservations_room_id_fkey": {
+          "name": "reservations_room_id_fkey",
+          "tableFrom": "reservations",
+          "tableTo": "rooms",
+          "columnsFrom": [
+            "room_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "reservations_owner_profile_id_fkey": {
+          "name": "reservations_owner_profile_id_fkey",
+          "tableFrom": "reservations",
+          "tableTo": "profiles",
+          "columnsFrom": [
+            "owner_profile_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "reservations_cancelled_by_profile_id_fkey": {
+          "name": "reservations_cancelled_by_profile_id_fkey",
+          "tableFrom": "reservations",
+          "tableTo": "profiles",
+          "columnsFrom": [
+            "cancelled_by_profile_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "reservations_created_by_profile_id_fkey": {
+          "name": "reservations_created_by_profile_id_fkey",
+          "tableFrom": "reservations",
+          "tableTo": "profiles",
+          "columnsFrom": [
+            "created_by_profile_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "reservations_updated_by_profile_id_fkey": {
+          "name": "reservations_updated_by_profile_id_fkey",
+          "tableFrom": "reservations",
+          "tableTo": "profiles",
+          "columnsFrom": [
+            "updated_by_profile_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {
+        "Authenticated can read reservations": {
+          "name": "Authenticated can read reservations",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": [
+            "authenticated"
+          ],
+          "using": "true"
+        },
+        "Users can delete own reservations": {
+          "name": "Users can delete own reservations",
+          "as": "PERMISSIVE",
+          "for": "DELETE",
+          "to": [
+            "authenticated"
+          ],
+          "using": "(owner_profile_id IN ( SELECT profiles.id\n   FROM profiles\n  WHERE (profiles.user_id IN ( SELECT users.id\n           FROM users\n          WHERE (users.auth_user_id = ( SELECT auth.uid() AS uid))))))"
+        },
+        "Users can update own reservations": {
+          "name": "Users can update own reservations",
+          "as": "PERMISSIVE",
+          "for": "UPDATE",
+          "to": [
+            "authenticated"
+          ],
+          "using": "(owner_profile_id IN ( SELECT profiles.id\n   FROM profiles\n  WHERE (profiles.user_id IN ( SELECT users.id\n           FROM users\n          WHERE (users.auth_user_id = ( SELECT auth.uid() AS uid))))))",
+          "withCheck": "(owner_profile_id IN ( SELECT profiles.id\n   FROM profiles\n  WHERE (profiles.user_id IN ( SELECT users.id\n           FROM users\n          WHERE (users.auth_user_id = ( SELECT auth.uid() AS uid))))))"
+        },
+        "Users can create own reservations": {
+          "name": "Users can create own reservations",
+          "as": "PERMISSIVE",
+          "for": "INSERT",
+          "to": [
+            "authenticated"
+          ],
+          "withCheck": "(owner_profile_id IN ( SELECT profiles.id\n   FROM profiles\n  WHERE (profiles.user_id IN ( SELECT users.id\n           FROM users\n          WHERE (users.auth_user_id = ( SELECT auth.uid() AS uid))))))"
+        }
+      },
+      "checkConstraints": {
+        "valid_reservation_time": {
+          "name": "valid_reservation_time",
+          "value": "end_at > start_at"
+        }
+      },
+      "isRLSEnabled": true
+    },
+    "public.rooms": {
+      "name": "rooms",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "code": {
+          "name": "code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "available_days": {
+          "name": "available_days",
+          "type": "integer[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "can_have_ts": {
+          "name": "can_have_ts",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "removed_at": {
+          "name": "removed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_by_profile_id": {
+          "name": "created_by_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_by_profile_id": {
+          "name": "updated_by_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "idx_rooms_code": {
+          "name": "idx_rooms_code",
+          "columns": [
+            {
+              "expression": "code",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "text_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "rooms_created_by_profile_id_fkey": {
+          "name": "rooms_created_by_profile_id_fkey",
+          "tableFrom": "rooms",
+          "tableTo": "profiles",
+          "columnsFrom": [
+            "created_by_profile_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "rooms_updated_by_profile_id_fkey": {
+          "name": "rooms_updated_by_profile_id_fkey",
+          "tableFrom": "rooms",
+          "tableTo": "profiles",
+          "columnsFrom": [
+            "updated_by_profile_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "rooms_code_key": {
+          "name": "rooms_code_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "code"
+          ]
+        }
+      },
+      "policies": {
+        "Admins can manage rooms": {
+          "name": "Admins can manage rooms",
+          "as": "PERMISSIVE",
+          "for": "ALL",
+          "to": [
+            "authenticated"
+          ],
+          "using": "(EXISTS ( SELECT 1\n   FROM profiles\n  WHERE ((profiles.user_id IN ( SELECT users.id\n           FROM users\n          WHERE (users.auth_user_id = ( SELECT auth.uid() AS uid)))) AND (profiles.role = 'admin'::profile_role))))",
+          "withCheck": "(EXISTS ( SELECT 1\n   FROM profiles\n  WHERE ((profiles.user_id IN ( SELECT users.id\n           FROM users\n          WHERE (users.auth_user_id = ( SELECT auth.uid() AS uid)))) AND (profiles.role = 'admin'::profile_role))))"
+        },
+        "Authenticated can read rooms": {
+          "name": "Authenticated can read rooms",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": [
+            "authenticated"
+          ],
+          "using": "true"
+        }
+      },
+      "checkConstraints": {},
+      "isRLSEnabled": true
+    },
+    "public.schedule_breaks": {
+      "name": "schedule_breaks",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "start_date": {
+          "name": "start_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "end_date": {
+          "name": "end_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_by_profile_id": {
+          "name": "created_by_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_by_profile_id": {
+          "name": "updated_by_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "idx_schedule_breaks_dates": {
+          "name": "idx_schedule_breaks_dates",
+          "columns": [
+            {
+              "expression": "start_date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "date_ops"
+            },
+            {
+              "expression": "end_date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "date_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "schedule_breaks_created_by_profile_id_fkey": {
+          "name": "schedule_breaks_created_by_profile_id_fkey",
+          "tableFrom": "schedule_breaks",
+          "tableTo": "profiles",
+          "columnsFrom": [
+            "created_by_profile_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "schedule_breaks_updated_by_profile_id_fkey": {
+          "name": "schedule_breaks_updated_by_profile_id_fkey",
+          "tableFrom": "schedule_breaks",
+          "tableTo": "profiles",
+          "columnsFrom": [
+            "updated_by_profile_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {
+        "Coaches can manage schedule_breaks": {
+          "name": "Coaches can manage schedule_breaks",
+          "as": "PERMISSIVE",
+          "for": "ALL",
+          "to": [
+            "authenticated"
+          ],
+          "using": "(EXISTS ( SELECT 1\n   FROM profiles\n  WHERE ((profiles.user_id IN ( SELECT users.id\n           FROM users\n          WHERE (users.auth_user_id = ( SELECT auth.uid() AS uid)))) AND (profiles.role = ANY (ARRAY['coach'::profile_role, 'admin'::profile_role])))))",
+          "withCheck": "(EXISTS ( SELECT 1\n   FROM profiles\n  WHERE ((profiles.user_id IN ( SELECT users.id\n           FROM users\n          WHERE (users.auth_user_id = ( SELECT auth.uid() AS uid)))) AND (profiles.role = ANY (ARRAY['coach'::profile_role, 'admin'::profile_role])))))"
+        },
+        "Authenticated can read schedule_breaks": {
+          "name": "Authenticated can read schedule_breaks",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": [
+            "authenticated"
+          ],
+          "using": "true"
+        }
+      },
+      "checkConstraints": {
+        "valid_break_date_range": {
+          "name": "valid_break_date_range",
+          "value": "end_date >= start_date"
+        }
+      },
+      "isRLSEnabled": true
+    },
+    "public.team_activities": {
+      "name": "team_activities",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "occurred_at": {
+          "name": "occurred_at",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "activity_type": {
+          "name": "activity_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "participants": {
+          "name": "participants",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reflection": {
+          "name": "reflection",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "removed_at": {
+          "name": "removed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_by_profile_id": {
+          "name": "created_by_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_by_profile_id": {
+          "name": "updated_by_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "team_activities_team_occurred_at_idx": {
+          "name": "team_activities_team_occurred_at_idx",
+          "columns": [
+            {
+              "expression": "team_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "uuid_ops"
+            },
+            {
+              "expression": "occurred_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "date_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "team_activities_team_id_fkey": {
+          "name": "team_activities_team_id_fkey",
+          "tableFrom": "team_activities",
+          "tableTo": "teams",
+          "columnsFrom": [
+            "team_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "team_activities_created_by_profile_id_fkey": {
+          "name": "team_activities_created_by_profile_id_fkey",
+          "tableFrom": "team_activities",
+          "tableTo": "profiles",
+          "columnsFrom": [
+            "created_by_profile_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "team_activities_updated_by_profile_id_fkey": {
+          "name": "team_activities_updated_by_profile_id_fkey",
+          "tableFrom": "team_activities",
+          "tableTo": "profiles",
+          "columnsFrom": [
+            "updated_by_profile_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {
+        "Team members can view activities": {
+          "name": "Team members can view activities",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": [
+            "authenticated"
+          ],
+          "using": "team_id IN (SELECT team_id FROM profiles WHERE id = current_profile_id() AND access_removed_at IS NULL)"
+        },
+        "Team members can create activities": {
+          "name": "Team members can create activities",
+          "as": "PERMISSIVE",
+          "for": "INSERT",
+          "to": [
+            "authenticated"
+          ],
+          "withCheck": "team_id IN (SELECT team_id FROM profiles WHERE id = current_profile_id() AND access_removed_at IS NULL)"
+        },
+        "Team members can update activities": {
+          "name": "Team members can update activities",
+          "as": "PERMISSIVE",
+          "for": "UPDATE",
+          "to": [
+            "authenticated"
+          ],
+          "using": "team_id IN (SELECT team_id FROM profiles WHERE id = current_profile_id() AND access_removed_at IS NULL)",
+          "withCheck": "team_id IN (SELECT team_id FROM profiles WHERE id = current_profile_id() AND access_removed_at IS NULL)"
+        },
+        "Team members can delete activities": {
+          "name": "Team members can delete activities",
+          "as": "PERMISSIVE",
+          "for": "DELETE",
+          "to": [
+            "authenticated"
+          ],
+          "using": "team_id IN (SELECT team_id FROM profiles WHERE id = current_profile_id() AND access_removed_at IS NULL)"
+        }
+      },
+      "checkConstraints": {},
+      "isRLSEnabled": true
+    },
+    "public.team_reflections": {
+      "name": "team_reflections",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "month": {
+          "name": "month",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "what_went_well": {
+          "name": "what_went_well",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "what_didnt_go_well": {
+          "name": "what_didnt_go_well",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "what_we_do_differently": {
+          "name": "what_we_do_differently",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "planned_action_steps": {
+          "name": "planned_action_steps",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "responsible_person": {
+          "name": "responsible_person",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "removed_at": {
+          "name": "removed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_by_profile_id": {
+          "name": "created_by_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_by_profile_id": {
+          "name": "updated_by_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "team_reflections_team_month_idx": {
+          "name": "team_reflections_team_month_idx",
+          "columns": [
+            {
+              "expression": "team_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "uuid_ops"
+            },
+            {
+              "expression": "month",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "date_ops"
+            }
+          ],
+          "isUnique": true,
+          "where": "(removed_at IS NULL)",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "team_reflections_team_id_fkey": {
+          "name": "team_reflections_team_id_fkey",
+          "tableFrom": "team_reflections",
+          "tableTo": "teams",
+          "columnsFrom": [
+            "team_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "team_reflections_created_by_profile_id_fkey": {
+          "name": "team_reflections_created_by_profile_id_fkey",
+          "tableFrom": "team_reflections",
+          "tableTo": "profiles",
+          "columnsFrom": [
+            "created_by_profile_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "team_reflections_updated_by_profile_id_fkey": {
+          "name": "team_reflections_updated_by_profile_id_fkey",
+          "tableFrom": "team_reflections",
+          "tableTo": "profiles",
+          "columnsFrom": [
+            "updated_by_profile_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {
+        "Team members can view reflections": {
+          "name": "Team members can view reflections",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": [
+            "authenticated"
+          ],
+          "using": "team_id IN (SELECT team_id FROM profiles WHERE id = current_profile_id() AND access_removed_at IS NULL)"
+        },
+        "Team members can create reflections": {
+          "name": "Team members can create reflections",
+          "as": "PERMISSIVE",
+          "for": "INSERT",
+          "to": [
+            "authenticated"
+          ],
+          "withCheck": "team_id IN (SELECT team_id FROM profiles WHERE id = current_profile_id() AND access_removed_at IS NULL)"
+        },
+        "Team members can update reflections": {
+          "name": "Team members can update reflections",
+          "as": "PERMISSIVE",
+          "for": "UPDATE",
+          "to": [
+            "authenticated"
+          ],
+          "using": "team_id IN (SELECT team_id FROM profiles WHERE id = current_profile_id() AND access_removed_at IS NULL)",
+          "withCheck": "team_id IN (SELECT team_id FROM profiles WHERE id = current_profile_id() AND access_removed_at IS NULL)"
+        },
+        "Team members can delete reflections": {
+          "name": "Team members can delete reflections",
+          "as": "PERMISSIVE",
+          "for": "DELETE",
+          "to": [
+            "authenticated"
+          ],
+          "using": "team_id IN (SELECT team_id FROM profiles WHERE id = current_profile_id() AND access_removed_at IS NULL)"
+        }
+      },
+      "checkConstraints": {},
+      "isRLSEnabled": true
+    },
+    "public.team_semester_reflection_entries": {
+      "name": "team_semester_reflection_entries",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "semester_reflection_id": {
+          "name": "semester_reflection_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "topic": {
+          "name": "topic",
+          "type": "semester_reflection_topic",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "what_went_well": {
+          "name": "what_went_well",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "what_didnt_go_well": {
+          "name": "what_didnt_go_well",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "what_next_time": {
+          "name": "what_next_time",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_by_profile_id": {
+          "name": "updated_by_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "team_semester_reflection_entries_reflection_topic_idx": {
+          "name": "team_semester_reflection_entries_reflection_topic_idx",
+          "columns": [
+            {
+              "expression": "semester_reflection_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "uuid_ops"
+            },
+            {
+              "expression": "topic",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "enum_ops"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "team_semester_reflection_entries_reflection_idx": {
+          "name": "team_semester_reflection_entries_reflection_idx",
+          "columns": [
+            {
+              "expression": "semester_reflection_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "uuid_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "team_semester_reflection_entries_semester_reflection_id_fkey": {
+          "name": "team_semester_reflection_entries_semester_reflection_id_fkey",
+          "tableFrom": "team_semester_reflection_entries",
+          "tableTo": "team_semester_reflections",
+          "columnsFrom": [
+            "semester_reflection_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "team_semester_reflection_entries_updated_by_profile_id_fkey": {
+          "name": "team_semester_reflection_entries_updated_by_profile_id_fkey",
+          "tableFrom": "team_semester_reflection_entries",
+          "tableTo": "profiles",
+          "columnsFrom": [
+            "updated_by_profile_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {
+        "Team members can view semester reflection entries": {
+          "name": "Team members can view semester reflection entries",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": [
+            "authenticated"
+          ],
+          "using": "EXISTS (SELECT 1 FROM team_semester_reflections tsr WHERE tsr.id = team_semester_reflection_entries.semester_reflection_id AND tsr.team_id IN (SELECT team_id FROM profiles WHERE id = current_profile_id() AND access_removed_at IS NULL))"
+        },
+        "Team members can create semester reflection entries": {
+          "name": "Team members can create semester reflection entries",
+          "as": "PERMISSIVE",
+          "for": "INSERT",
+          "to": [
+            "authenticated"
+          ],
+          "withCheck": "EXISTS (SELECT 1 FROM team_semester_reflections tsr WHERE tsr.id = team_semester_reflection_entries.semester_reflection_id AND tsr.team_id IN (SELECT team_id FROM profiles WHERE id = current_profile_id() AND access_removed_at IS NULL))"
+        },
+        "Team members can update semester reflection entries": {
+          "name": "Team members can update semester reflection entries",
+          "as": "PERMISSIVE",
+          "for": "UPDATE",
+          "to": [
+            "authenticated"
+          ],
+          "using": "EXISTS (SELECT 1 FROM team_semester_reflections tsr WHERE tsr.id = team_semester_reflection_entries.semester_reflection_id AND tsr.team_id IN (SELECT team_id FROM profiles WHERE id = current_profile_id() AND access_removed_at IS NULL))",
+          "withCheck": "EXISTS (SELECT 1 FROM team_semester_reflections tsr WHERE tsr.id = team_semester_reflection_entries.semester_reflection_id AND tsr.team_id IN (SELECT team_id FROM profiles WHERE id = current_profile_id() AND access_removed_at IS NULL))"
+        }
+      },
+      "checkConstraints": {},
+      "isRLSEnabled": true
+    },
+    "public.team_semester_reflections": {
+      "name": "team_semester_reflections",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "semester_month": {
+          "name": "semester_month",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "removed_at": {
+          "name": "removed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_by_profile_id": {
+          "name": "created_by_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_by_profile_id": {
+          "name": "updated_by_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "team_semester_reflections_team_month_idx": {
+          "name": "team_semester_reflections_team_month_idx",
+          "columns": [
+            {
+              "expression": "team_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "uuid_ops"
+            },
+            {
+              "expression": "semester_month",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "date_ops"
+            }
+          ],
+          "isUnique": true,
+          "where": "(removed_at IS NULL)",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "team_semester_reflections_team_id_fkey": {
+          "name": "team_semester_reflections_team_id_fkey",
+          "tableFrom": "team_semester_reflections",
+          "tableTo": "teams",
+          "columnsFrom": [
+            "team_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "team_semester_reflections_created_by_profile_id_fkey": {
+          "name": "team_semester_reflections_created_by_profile_id_fkey",
+          "tableFrom": "team_semester_reflections",
+          "tableTo": "profiles",
+          "columnsFrom": [
+            "created_by_profile_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "team_semester_reflections_updated_by_profile_id_fkey": {
+          "name": "team_semester_reflections_updated_by_profile_id_fkey",
+          "tableFrom": "team_semester_reflections",
+          "tableTo": "profiles",
+          "columnsFrom": [
+            "updated_by_profile_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {
+        "Team members can view semester reflections": {
+          "name": "Team members can view semester reflections",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": [
+            "authenticated"
+          ],
+          "using": "team_id IN (SELECT team_id FROM profiles WHERE id = current_profile_id() AND access_removed_at IS NULL)"
+        },
+        "Team members can create semester reflections": {
+          "name": "Team members can create semester reflections",
+          "as": "PERMISSIVE",
+          "for": "INSERT",
+          "to": [
+            "authenticated"
+          ],
+          "withCheck": "team_id IN (SELECT team_id FROM profiles WHERE id = current_profile_id() AND access_removed_at IS NULL)"
+        },
+        "Team members can update semester reflections": {
+          "name": "Team members can update semester reflections",
+          "as": "PERMISSIVE",
+          "for": "UPDATE",
+          "to": [
+            "authenticated"
+          ],
+          "using": "team_id IN (SELECT team_id FROM profiles WHERE id = current_profile_id() AND access_removed_at IS NULL)",
+          "withCheck": "team_id IN (SELECT team_id FROM profiles WHERE id = current_profile_id() AND access_removed_at IS NULL)"
+        },
+        "Team members can delete semester reflections": {
+          "name": "Team members can delete semester reflections",
+          "as": "PERMISSIVE",
+          "for": "DELETE",
+          "to": [
+            "authenticated"
+          ],
+          "using": "team_id IN (SELECT team_id FROM profiles WHERE id = current_profile_id() AND access_removed_at IS NULL)"
+        }
+      },
+      "checkConstraints": {
+        "team_semester_reflections_month_check": {
+          "name": "team_semester_reflections_month_check",
+          "value": "EXTRACT(MONTH FROM semester_month) IN (1, 5)"
+        }
+      },
+      "isRLSEnabled": true
+    },
+    "public.teams": {
+      "name": "teams",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "picture": {
+          "name": "picture",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "color": {
+          "name": "color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "onboardingYear": {
+          "name": "onboardingYear",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "removed_at": {
+          "name": "removed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_by_profile_id": {
+          "name": "created_by_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_by_profile_id": {
+          "name": "updated_by_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {
+        "Authenticated users can read teams": {
+          "name": "Authenticated users can read teams",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": [
+            "authenticated"
+          ],
+          "using": "true"
+        }
+      },
+      "checkConstraints": {},
+      "isRLSEnabled": true
+    },
+    "public.tools_techniques": {
+      "name": "tools_techniques",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "profile_id": {
+          "name": "profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tool_type": {
+          "name": "tool_type",
+          "type": "tool_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reflection": {
+          "name": "reflection",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "removed_at": {
+          "name": "removed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_by_profile_id": {
+          "name": "created_by_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_by_profile_id": {
+          "name": "updated_by_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "tools_techniques_profile_idx": {
+          "name": "tools_techniques_profile_idx",
+          "columns": [
+            {
+              "expression": "profile_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "uuid_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "tools_techniques_profile_id_fkey": {
+          "name": "tools_techniques_profile_id_fkey",
+          "tableFrom": "tools_techniques",
+          "tableTo": "profiles",
+          "columnsFrom": [
+            "profile_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "tools_techniques_created_by_profile_id_fkey": {
+          "name": "tools_techniques_created_by_profile_id_fkey",
+          "tableFrom": "tools_techniques",
+          "tableTo": "profiles",
+          "columnsFrom": [
+            "created_by_profile_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "tools_techniques_updated_by_profile_id_fkey": {
+          "name": "tools_techniques_updated_by_profile_id_fkey",
+          "tableFrom": "tools_techniques",
+          "tableTo": "profiles",
+          "columnsFrom": [
+            "updated_by_profile_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {
+        "Users can view their own tools and techniques": {
+          "name": "Users can view their own tools and techniques",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": [
+            "authenticated"
+          ],
+          "using": "(profile_id = current_profile_id())"
+        },
+        "Users can create their own tools and techniques": {
+          "name": "Users can create their own tools and techniques",
+          "as": "PERMISSIVE",
+          "for": "INSERT",
+          "to": [
+            "authenticated"
+          ],
+          "withCheck": "(profile_id = current_profile_id())"
+        },
+        "Users can update their own tools and techniques": {
+          "name": "Users can update their own tools and techniques",
+          "as": "PERMISSIVE",
+          "for": "UPDATE",
+          "to": [
+            "authenticated"
+          ],
+          "using": "(profile_id = current_profile_id())",
+          "withCheck": "(profile_id = current_profile_id())"
+        },
+        "Users can delete their own tools and techniques": {
+          "name": "Users can delete their own tools and techniques",
+          "as": "PERMISSIVE",
+          "for": "DELETE",
+          "to": [
+            "authenticated"
+          ],
+          "using": "(profile_id = current_profile_id())"
+        }
+      },
+      "checkConstraints": {},
+      "isRLSEnabled": true
+    }
+  },
+  "enums": {
+    "public.book_list_status": {
+      "name": "book_list_status",
+      "schema": "public",
+      "values": [
+        "processing",
+        "shortlist",
+        "longlist",
+        "archived"
+      ]
+    },
+    "public.book_source": {
+      "name": "book_source",
+      "schema": "public",
+      "values": [
+        "manual",
+        "google_books",
+        "open_library"
+      ]
+    },
+    "public.personality_test_type": {
+      "name": "personality_test_type",
+      "schema": "public",
+      "values": [
+        "gallup",
+        "mbti",
+        "disc",
+        "big_five",
+        "enneagram",
+        "belbin",
+        "other"
+      ]
+    },
+    "public.profile_role": {
+      "name": "profile_role",
+      "schema": "public",
+      "values": [
+        "student",
+        "mentor",
+        "coach",
+        "admin"
+      ]
+    },
+    "public.schedule_type": {
+      "name": "schedule_type",
+      "schema": "public",
+      "values": [
+        "training_session",
+        "houston_calling"
+      ]
+    },
+    "public.semester_reflection_topic": {
+      "name": "semester_reflection_topic",
+      "schema": "public",
+      "values": [
+        "predmety_zkousky_vyucujici",
+        "metodika_a_metriky",
+        "kouci_a_mentori",
+        "tymy_a_tymove_spolecnosti",
+        "individualni_prinos",
+        "komunita",
+        "komunitni_role",
+        "komunitni_akce",
+        "komunitni_a_cross_projekty",
+        "zacleneni_tucnaku",
+        "dalsi"
+      ]
+    },
+    "public.tool_type": {
+      "name": "tool_type",
+      "schema": "public",
+      "values": [
+        "model",
+        "technique",
+        "tool"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {
+    "public.books_with_essay_count": {
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "title_cs": {
+          "name": "title_cs",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "title_en": {
+          "name": "title_en",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "author": {
+          "name": "author",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "isbn_13": {
+          "name": "isbn_13",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "google_books_cover_url": {
+          "name": "google_books_cover_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "book_points": {
+          "name": "book_points",
+          "type": "numeric(3, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "page_count": {
+          "name": "page_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "preview_link": {
+          "name": "preview_link",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source": {
+          "name": "source",
+          "type": "book_source",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "external_id": {
+          "name": "external_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "list_status": {
+          "name": "list_status",
+          "type": "book_list_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "list_status_changed_at": {
+          "name": "list_status_changed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "list_status_changed_by_profile_id": {
+          "name": "list_status_changed_by_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "list_status_reason": {
+          "name": "list_status_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "highlight_category_id": {
+          "name": "highlight_category_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_rocket_model": {
+          "name": "is_rocket_model",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by_profile_id": {
+          "name": "created_by_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_by_profile_id": {
+          "name": "updated_by_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "essay_count": {
+          "name": "essay_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "definition": "SELECT b.id, b.title_cs, b.title_en, b.author, b.isbn_13, b.description, b.google_books_cover_url, b.book_points, b.page_count, b.preview_link, b.source, b.external_id, b.list_status, b.list_status_changed_at, b.list_status_changed_by_profile_id, b.list_status_reason, b.highlight_category_id, b.is_rocket_model, b.created_at, b.updated_at, b.created_by_profile_id, b.updated_by_profile_id, COALESCE(ec.essay_count, 0) AS essay_count FROM books b LEFT JOIN ( SELECT essays.book_id, count(*)::integer AS essay_count FROM essays WHERE essays.book_id IS NOT NULL AND essays.published_at IS NOT NULL AND essays.removed_at IS NULL GROUP BY essays.book_id) ec ON ec.book_id = b.id",
+      "name": "books_with_essay_count",
+      "schema": "public",
+      "isExisting": false,
+      "materialized": false
+    }
+  },
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/supabase/migrations/meta/_journal.json
+++ b/supabase/migrations/meta/_journal.json
@@ -330,6 +330,13 @@
       "when": 1787076997140,
       "tag": "20260818181637_lazy_preak",
       "breakpoints": true
+    },
+    {
+      "idx": 47,
+      "version": "7",
+      "when": 1787080277879,
+      "tag": "20260818191117_gorgeous_cammi",
+      "breakpoints": true
     }
   ]
 }

--- a/supabase/migrations/meta/_journal.json
+++ b/supabase/migrations/meta/_journal.json
@@ -316,6 +316,20 @@
       "when": 1787070011521,
       "tag": "20260818162011_redundant_tinkerer",
       "breakpoints": true
+    },
+    {
+      "idx": 45,
+      "version": "7",
+      "when": 1787076991193,
+      "tag": "20260818181631_broad_angel",
+      "breakpoints": true
+    },
+    {
+      "idx": 46,
+      "version": "7",
+      "when": 1787076997140,
+      "tag": "20260818181637_lazy_preak",
+      "breakpoints": true
     }
   ]
 }

--- a/tests/e2e/fixtures/auth.ts
+++ b/tests/e2e/fixtures/auth.ts
@@ -247,6 +247,23 @@ export async function createTestTeam(onboardingYear?: number): Promise<string> {
   return id;
 }
 
+/** Deletes a single storage object using the service role (used by cleanupTestData). */
+async function storageRemoveFile(bucket: string, key: string): Promise<void> {
+  const res = await fetch(
+    `${SUPABASE_URL}/storage/v1/object/${bucket}/${key.split("/").map(encodeURIComponent).join("/")}`,
+    {
+      method: "DELETE",
+      headers: {
+        apikey: SERVICE_ROLE_KEY,
+        Authorization: `Bearer ${SERVICE_ROLE_KEY}`,
+      },
+    },
+  );
+  if (!res.ok && res.status !== 404) {
+    throw new Error(`storage remove ${bucket}/${key} failed: ${res.status}`);
+  }
+}
+
 /** Deletes all data created by the current worker's E2E tests.
  *
  *  Must be called from test.afterAll (or a global teardown). Safe to call
@@ -267,6 +284,20 @@ export async function cleanupTestData(): Promise<void> {
     restFetch(`/essays?author_profile_id=eq.${pid}`, "DELETE").catch(() => {}),
     restFetch(`/books?created_by_profile_id=eq.${pid}`, "DELETE").catch(() => {}),
   ]));
+
+  // Delete personality tests together with their files — the created_by /
+  // updated_by FKs are RESTRICT, so any leftover row (including soft-deleted
+  // `removed_at` ones) blocks the profile DELETE in phase 3.
+  await Promise.all(profileIds.map(async (pid) => {
+    const rows = (await restFetch(
+      `/personality_tests?profile_id=eq.${pid}&select=file_path`,
+      "GET",
+    ).catch(() => [] as { file_path: string }[])) as { file_path: string }[];
+    await Promise.all(rows.map(({ file_path: key }) =>
+      storageRemoveFile("documents", key).catch(() => {})
+    ));
+    await restFetch(`/personality_tests?profile_id=eq.${pid}`, "DELETE").catch(() => {});
+  }));
 
   // Phase 2 — delete team-scoped data
   await Promise.all(teamIds.flatMap((tid) => [

--- a/tests/e2e/fixtures/auth.ts
+++ b/tests/e2e/fixtures/auth.ts
@@ -259,7 +259,7 @@ async function storageRemoveFile(bucket: string, key: string): Promise<void> {
       },
     },
   );
-  if (!res.ok && res.status !== 404) {
+  if (!res.ok && res.status !== 404 && res.status !== 400) {
     throw new Error(`storage remove ${bucket}/${key} failed: ${res.status}`);
   }
 }
@@ -294,7 +294,9 @@ export async function cleanupTestData(): Promise<void> {
       "GET",
     ).catch(() => [] as { file_path: string }[])) as { file_path: string }[];
     await Promise.all(rows.map(({ file_path: key }) =>
-      storageRemoveFile("documents", key).catch(() => {})
+      storageRemoveFile("documents", key).catch((err) => {
+        console.error(`E2E cleanup: failed to remove storage file ${key}`, err);
+      })
     ));
     await restFetch(`/personality_tests?profile_id=eq.${pid}`, "DELETE").catch(() => {});
   }));

--- a/tests/e2e/personality-tests.spec.ts
+++ b/tests/e2e/personality-tests.spec.ts
@@ -12,16 +12,6 @@ const TEST_PDF = {
   buffer: Buffer.from("%PDF-1.4 test"),
 };
 
-async function uploadTest(page: import("@playwright/test").Page, typeLabel: string) {
-  await page.getByRole("button", { name: /Nahrát test/i }).first().click();
-  const dialog = page.getByRole("dialog");
-  await dialog.getByRole("combobox").click();
-  await page.getByRole("option", { name: typeLabel }).click();
-  await dialog.getByLabel("Soubor s výsledky").setInputFiles(TEST_PDF);
-  await dialog.getByRole("button", { name: "Nahrát test" }).click();
-  await expect(dialog).toHaveCount(0);
-}
-
 async function uploadCustomTest(page: import("@playwright/test").Page, testName: string) {
   await page.getByRole("button", { name: /Nahrát test/i }).first().click();
   const dialog = page.getByRole("dialog");
@@ -159,14 +149,11 @@ test.describe("osobnostní testy - two users", () => {
     await expect(page.getByText(testName)).toBeVisible();
     await expect(page.getByText("mbti-vysledky.pdf")).toBeVisible();
 
-    const popupPromise = page.waitForEvent("popup");
-    const downloadPromise = page.waitForEvent("download");
+    const downloadPromise = context.waitForEvent("download");
     await page.getByRole("link", { name: /Otevřít/ }).click();
-    const popup = await popupPromise;
     const download = await downloadPromise;
-    await expect
-      .poll(() => download.url(), { timeout: 15000 })
-      .toMatch(/\/storage\/v1\/object\/sign\//);
-    popup.close();
+    expect(await download.failure()).toBeNull();
+    expect(download.url()).toMatch(/\/storage\/v1\/object\/sign\//);
+    expect(download.suggestedFilename()).toMatch(/\.pdf$/);
   });
 });

--- a/tests/e2e/personality-tests.spec.ts
+++ b/tests/e2e/personality-tests.spec.ts
@@ -1,0 +1,170 @@
+import { expect, test } from "@playwright/test";
+import {
+  cleanupTestData,
+  createTestTeam,
+  getSetupSessionCookie,
+  setAuthCookie,
+} from "./fixtures/auth";
+
+const TEST_PDF = {
+  name: "mbti-vysledky.pdf",
+  mimeType: "application/pdf",
+  buffer: Buffer.from("%PDF-1.4 test"),
+};
+
+async function uploadTest(page: import("@playwright/test").Page, typeLabel: string) {
+  await page.getByRole("button", { name: /Nahrát test/i }).first().click();
+  const dialog = page.getByRole("dialog");
+  await dialog.getByRole("combobox").click();
+  await page.getByRole("option", { name: typeLabel }).click();
+  await dialog.getByLabel("Soubor s výsledky").setInputFiles(TEST_PDF);
+  await dialog.getByRole("button", { name: "Nahrát test" }).click();
+  await expect(dialog).toHaveCount(0);
+}
+
+async function uploadCustomTest(page: import("@playwright/test").Page, testName: string) {
+  await page.getByRole("button", { name: /Nahrát test/i }).first().click();
+  const dialog = page.getByRole("dialog");
+  await dialog.getByRole("combobox").click();
+  await page.getByRole("option", { name: "Jiný test" }).click();
+  await dialog.getByLabel("Název testu").fill(testName);
+  await dialog.getByLabel("Soubor s výsledky").setInputFiles(TEST_PDF);
+  await dialog.getByRole("button", { name: "Nahrát test" }).click();
+  await expect(dialog).toHaveCount(0);
+}
+
+async function deleteOnlyTest(page: import("@playwright/test").Page) {
+  await page.getByRole("button", { name: "Smazat test" }).click();
+  await page.getByRole("button", { name: "Odstranit" }).click();
+  await expect(page.getByRole("button", { name: "Smazat test" })).toHaveCount(0);
+}
+
+test.describe("osobnostní testy - single user", () => {
+  let cookieValue: string;
+  let profileId: string;
+
+  test.beforeAll(async () => {
+    const teamId = await createTestTeam();
+    const user = await getSetupSessionCookie(teamId);
+    cookieValue = user.cookie;
+    profileId = user.profileId;
+  });
+
+  test.beforeEach(async ({ context }) => {
+    await setAuthCookie(context, cookieValue);
+  });
+
+  test.afterAll(async () => {
+    await cleanupTestData();
+  });
+
+  test("profile shows empty state on the personality tests tab", async ({ page }) => {
+    await page.goto(`/komunita/profil/${profileId}?tab=osobnostni-testy`);
+    await expect(page.getByRole("tab", { name: /Osobnostní testy/ })).toBeVisible();
+    await expect(page.getByText("Zatím nemáš nahraný žádný osobnostní test")).toBeVisible();
+  });
+
+  test("uploading a test adds it to the timeline", async ({ page }) => {
+    const testName = `E2E test ${Date.now()}`;
+    await page.goto(`/komunita/profil/${profileId}?tab=osobnostni-testy`);
+
+    await page.getByRole("button", { name: /Nahrát test/i }).first().click();
+    const dialog = page.getByRole("dialog");
+    await dialog.getByRole("combobox").click();
+    await page.getByRole("option", { name: "Jiný test" }).click();
+    await dialog.getByLabel("Název testu").fill(testName);
+    await dialog.getByLabel("Soubor s výsledky").setInputFiles(TEST_PDF);
+    await dialog.getByRole("button", { name: "Nahrát test" }).click();
+
+    await expect(dialog).toHaveCount(0);
+    await expect(page.getByText(testName)).toBeVisible();
+    await expect(page.getByText("mbti-vysledky.pdf")).toBeVisible();
+
+    await deleteOnlyTest(page);
+  });
+
+  test("editing a test changes its type", async ({ page }) => {
+    const testName = `E2E uprava ${Date.now()}`;
+    await page.goto(`/komunita/profil/${profileId}?tab=osobnostni-testy`);
+
+    await page.getByRole("button", { name: /Nahrát test/i }).first().click();
+    const dialog = page.getByRole("dialog");
+    await dialog.getByRole("combobox").click();
+    await page.getByRole("option", { name: "Jiný test" }).click();
+    await dialog.getByLabel("Název testu").fill(testName);
+    await dialog.getByLabel("Soubor s výsledky").setInputFiles(TEST_PDF);
+    await dialog.getByRole("button", { name: "Nahrát test" }).click();
+    await expect(dialog).toHaveCount(0);
+
+    await page.getByRole("button", { name: "Upravit test" }).click();
+    const editDialog = page.getByRole("dialog");
+    await editDialog.getByRole("combobox").click();
+    await page.getByRole("option", { name: "DISC" }).click();
+    await editDialog.getByRole("button", { name: "Uložit změny" }).click();
+
+    await expect(editDialog).toHaveCount(0);
+    await expect(page.getByText("DISC")).toBeVisible();
+    await expect(page.getByText(testName)).toHaveCount(0);
+
+    await deleteOnlyTest(page);
+  });
+
+  test("deleting a test removes it from the timeline", async ({ page }) => {
+    const testName = `E2E smazat ${Date.now()}`;
+    await page.goto(`/komunita/profil/${profileId}?tab=osobnostni-testy`);
+
+    await uploadCustomTest(page, testName);
+    await expect(page.getByText(testName)).toBeVisible();
+
+    await page.getByRole("button", { name: "Smazat test" }).click();
+    await page.getByRole("button", { name: "Odstranit" }).click();
+
+    await expect(page.getByText(testName)).toHaveCount(0);
+    await expect(page.getByText("Zatím nemáš nahraný žádný osobnostní test")).toBeVisible();
+  });
+});
+
+test.describe("osobnostní testy - two users", () => {
+  let ownerCookie: string;
+  let ownerProfileId: string;
+  let viewerCookie: string;
+
+  test.beforeAll(async () => {
+    const teamId = await createTestTeam();
+    const owner = await getSetupSessionCookie(teamId);
+    const viewer = await getSetupSessionCookie(teamId);
+    ownerCookie = owner.cookie;
+    ownerProfileId = owner.profileId;
+    viewerCookie = viewer.cookie;
+  });
+
+  test.afterAll(async () => {
+    await cleanupTestData();
+  });
+
+  test("another verified user sees the test and can open the file", async ({ context, page }) => {
+    const testName = `E2E sdileni ${Date.now()}`;
+
+    await setAuthCookie(context, ownerCookie);
+    await page.goto(`/komunita/profil/${ownerProfileId}?tab=osobnostni-testy`);
+    await uploadCustomTest(page, testName);
+    await expect(page.getByText(testName)).toBeVisible();
+
+    await context.clearCookies();
+    await setAuthCookie(context, viewerCookie);
+    await page.goto(`/komunita/profil/${ownerProfileId}?tab=osobnostni-testy`);
+
+    await expect(page.getByText(testName)).toBeVisible();
+    await expect(page.getByText("mbti-vysledky.pdf")).toBeVisible();
+
+    const popupPromise = page.waitForEvent("popup");
+    const downloadPromise = page.waitForEvent("download");
+    await page.getByRole("link", { name: /Otevřít/ }).click();
+    const popup = await popupPromise;
+    const download = await downloadPromise;
+    await expect
+      .poll(() => download.url(), { timeout: 15000 })
+      .toMatch(/\/storage\/v1\/object\/sign\//);
+    popup.close();
+  });
+});

--- a/tests/e2e/personality-tests.spec.ts
+++ b/tests/e2e/personality-tests.spec.ts
@@ -40,6 +40,8 @@ async function deleteOnlyTest(page: import("@playwright/test").Page) {
 }
 
 test.describe("osobnostní testy - single user", () => {
+  test.describe.configure({ mode: "serial" });
+
   let cookieValue: string;
   let profileId: string;
 

--- a/tests/integration/personality-tests.int.test.ts
+++ b/tests/integration/personality-tests.int.test.ts
@@ -102,7 +102,7 @@ describe("personality_tests RLS", () => {
 
   it("does not let another user insert a test for someone else", async () => {
     await withRollback(async (client) => {
-      const { ownerProfileId, otherAuthId } = await seed(client);
+      const { ownerProfileId, otherProfileId, otherAuthId } = await seed(client);
 
       await asClaims(client, { sub: otherAuthId });
       await expect(
@@ -110,7 +110,7 @@ describe("personality_tests RLS", () => {
           `insert into public.personality_tests
              (profile_id, test_type, tested_on, file_path, file_name, file_size, created_by_profile_id, updated_by_profile_id)
            values ($1, 'mbti', '2026-03-10', 'personality-test/p1/x.pdf', 'x.pdf', 1024, $2, $2)`,
-          [ownerProfileId, otherAuthId],
+          [ownerProfileId, otherProfileId],
         ),
       ).rejects.toThrow();
     });

--- a/tests/integration/personality-tests.int.test.ts
+++ b/tests/integration/personality-tests.int.test.ts
@@ -1,0 +1,199 @@
+import { describe, expect, it } from "vitest";
+import { withRollback } from "@/tests/setup/tx";
+import { insertAuthUser } from "@/tests/setup/factories";
+import { asClaims } from "@/tests/setup/rls";
+import type { PoolClient } from "pg";
+
+async function seed(client: PoolClient) {
+  const ownerAuth = await insertAuthUser(client);
+  const otherAuth = await insertAuthUser(client);
+  const unverifiedAuth = await insertAuthUser(client);
+
+  const { rows: ownerUserRows } = await client.query(
+    "select id from public.users where auth_user_id = $1",
+    [ownerAuth.id],
+  );
+  const { rows: otherUserRows } = await client.query(
+    "select id from public.users where auth_user_id = $1",
+    [otherAuth.id],
+  );
+  const { rows: unverifiedUserRows } = await client.query(
+    "select id from public.users where auth_user_id = $1",
+    [unverifiedAuth.id],
+  );
+
+  await client.query(
+    "update public.users set verified_work_email = google_email, verified_work_email_at = now() where id = any($1)",
+    [[ownerUserRows[0].id, otherUserRows[0].id]],
+  );
+
+  const profile = async (name: string, email: string, userId: string) => {
+    const { rows } = await client.query(
+      `insert into public.profiles (name, work_email, user_id, role)
+       values ($1, $2, $3, 'student') returning id`,
+      [name, email, userId],
+    );
+    return rows[0].id as string;
+  };
+
+  const ownerProfileId = await profile("Owner", "pt-owner@studenti.czu.cz", ownerUserRows[0].id);
+  const otherProfileId = await profile("Other", "pt-other@studenti.czu.cz", otherUserRows[0].id);
+  const unverifiedProfileId = await profile("Unverified", "pt-unverified@studenti.czu.cz", unverifiedUserRows[0].id);
+
+  return {
+    ownerProfileId,
+    otherProfileId,
+    unverifiedProfileId,
+    ownerAuthId: ownerAuth.id as string,
+    otherAuthId: otherAuth.id as string,
+    unverifiedAuthId: unverifiedAuth.id as string,
+  };
+}
+
+async function insertTest(
+  client: PoolClient,
+  profileId: string,
+  testType = "mbti",
+  overrides: { testTypeOther?: string | null } = {},
+) {
+  const { rows } = await client.query(
+    `insert into public.personality_tests
+       (profile_id, test_type, test_type_other, tested_on, file_path, file_name, file_size, created_by_profile_id, updated_by_profile_id)
+     values ($1, $2, $3, '2026-03-10', 'personality-test/p1/x.pdf', 'x.pdf', 1024, $4, $4)
+     returning id`,
+    [profileId, testType, overrides.testTypeOther ?? null, profileId],
+  );
+  return rows[0].id as string;
+}
+
+describe("personality_tests RLS", () => {
+  it("lets the owner insert and another verified user select their tests", async () => {
+    await withRollback(async (client) => {
+      const { ownerProfileId, ownerAuthId, otherAuthId } = await seed(client);
+
+      await asClaims(client, { sub: ownerAuthId });
+      await insertTest(client, ownerProfileId);
+
+      await asClaims(client, { sub: otherAuthId });
+      const { rows } = await client.query(
+        "select test_type from public.personality_tests where profile_id = $1",
+        [ownerProfileId],
+      );
+      expect(rows).toHaveLength(1);
+      expect(rows[0].test_type).toBe("mbti");
+    });
+  });
+
+  it("does not let an unverified user select tests", async () => {
+    await withRollback(async (client) => {
+      const { ownerProfileId, ownerAuthId, unverifiedAuthId } = await seed(client);
+
+      await asClaims(client, { sub: ownerAuthId });
+      await insertTest(client, ownerProfileId);
+
+      await asClaims(client, { sub: unverifiedAuthId });
+      const { rows } = await client.query(
+        "select id from public.personality_tests where profile_id = $1",
+        [ownerProfileId],
+      );
+      expect(rows).toHaveLength(0); // RLS filters it out silently
+    });
+  });
+
+  it("does not let another user insert a test for someone else", async () => {
+    await withRollback(async (client) => {
+      const { ownerProfileId, otherAuthId } = await seed(client);
+
+      await asClaims(client, { sub: otherAuthId });
+      await expect(
+        client.query(
+          `insert into public.personality_tests
+             (profile_id, test_type, tested_on, file_path, file_name, file_size, created_by_profile_id, updated_by_profile_id)
+           values ($1, 'mbti', '2026-03-10', 'personality-test/p1/x.pdf', 'x.pdf', 1024, $2, $2)`,
+          [ownerProfileId, otherAuthId],
+        ),
+      ).rejects.toThrow();
+    });
+  });
+
+  it("lets the owner update and soft-delete their test; other users cannot", async () => {
+    await withRollback(async (client) => {
+      const { ownerProfileId, ownerAuthId, otherAuthId } = await seed(client);
+      const testId = await insertTest(client, ownerProfileId);
+
+      await asClaims(client, { sub: ownerAuthId });
+      await client.query(
+        `update public.personality_tests
+           set tested_on = '2026-04-01', updated_by_profile_id = $2
+         where id = $1`,
+        [testId, ownerProfileId],
+      );
+      await client.query(
+        `update public.personality_tests
+           set removed_at = now(), updated_by_profile_id = $2
+         where id = $1`,
+        [testId, ownerProfileId],
+      );
+
+      const { rows } = await client.query(
+        "select tested_on, removed_at from public.personality_tests where id = $1",
+        [testId],
+      );
+      expect(rows[0].tested_on).toBe("2026-04-01");
+      expect(rows[0].removed_at).not.toBeNull();
+
+      const { rows: activeRows } = await client.query(
+        "select id from public.personality_tests where profile_id = $1 and removed_at is null",
+        [ownerProfileId],
+      );
+      expect(activeRows).toHaveLength(0); // soft-deleted rows are filtered by the app query
+
+      await asClaims(client, { sub: otherAuthId });
+      const updateResult = await client.query(
+        "update public.personality_tests set test_type = 'disc' where id = $1",
+        [testId],
+      );
+      expect(updateResult.rowCount).toBe(0); // RLS filters the row out
+
+      const deleteResult = await client.query(
+        "delete from public.personality_tests where id = $1",
+        [testId],
+      );
+      expect(deleteResult.rowCount).toBe(0);
+    });
+  });
+
+  it("rejects 'other' test type without a custom name", async () => {
+    await withRollback(async (client) => {
+      const { ownerProfileId, ownerAuthId } = await seed(client);
+
+      await asClaims(client, { sub: ownerAuthId });
+      await expect(
+        client.query(
+          `insert into public.personality_tests
+             (profile_id, test_type, tested_on, file_path, file_name, file_size, created_by_profile_id, updated_by_profile_id)
+           values ($1, 'other', '2026-03-10', 'personality-test/p1/x.pdf', 'x.pdf', 1024, $2, $2)`,
+          [ownerProfileId, ownerAuthId],
+        ),
+      ).rejects.toThrow();
+    });
+  });
+
+  it("cascades delete when the profile is removed", async () => {
+    await withRollback(async (client) => {
+      const { ownerProfileId, ownerAuthId } = await seed(client);
+
+      await asClaims(client, { sub: ownerAuthId });
+      await insertTest(client, ownerProfileId);
+
+      await client.query("set local role service_role");
+      await client.query("delete from public.profiles where id = $1", [ownerProfileId]);
+
+      const { rows } = await client.query(
+        "select count(*)::int as cnt from public.personality_tests where profile_id = $1",
+        [ownerProfileId],
+      );
+      expect(rows[0].cnt).toBe(0);
+    });
+  });
+});

--- a/tests/integration/personality-tests.int.test.ts
+++ b/tests/integration/personality-tests.int.test.ts
@@ -136,7 +136,7 @@ describe("personality_tests RLS", () => {
       );
 
       const { rows } = await client.query(
-        "select tested_on, removed_at from public.personality_tests where id = $1",
+        "select to_char(tested_on, 'YYYY-MM-DD') as tested_on, removed_at from public.personality_tests where id = $1",
         [testId],
       );
       expect(rows[0].tested_on).toBe("2026-04-01");


### PR DESCRIPTION
## Summary
- **Nová tabulka `personality_tests`** (Drizzle, RLS: vlastník zapisuje, ověření uživatelé čtou) + `personality_test_type` enum + updated_at trigger
- **Upload souborů** výsledků testů (PDF/PNG/JPEG/WebP, max 20 MB) přes presign → PUT do private bucketu `documents`, cheap read přes podepsané URL
- **Vertikální timeline** na profilu v komunitě — nové taby `Přehled / Eseje / Osobnostní testy`, typ testu + datum vyplnění, otevření souboru kýmkoli ověřeným
- **Správa záznamů** (přidat/upravit i výměna souboru/smazat, soft-delete + smazání objektu)
- **Sidebar zkratka** „Osobnostní testy" (beta-gate) → vlastní profil s `?tab=osobnostni-testy`
- Žádná pole Výsledek/Reflexe/Aplikace v praxi — výsledek je sám soubor (popis issue byl nepřesný)

## Design
`docs/plans/2026-08-18-osobnostni-testy-design.md` (vč. UX analýzy) a `docs/plans/2026-08-18-osobnostni-testy-plan.md`.

## Test Plan
- [x] `pnpm test` — 454 tests (unit + component, nově 13)
- [x] `pnpm vitest run --project integration tests/integration/personality-tests.int.test.ts` — 6 RLS testů (vlastník/ověřený/neověřený, soft-delete, check constraint, cascade)
- [x] `pnpm test:e2e personality-tests.spec.ts` — 5 testů (upload, edit, delete, sdílení mezi uživateli, otevření souboru přes signed URL)
- [x] `pnpm typecheck`, `pnpm lint`, `pnpm db:doctor`
- [ ] Manuální QA (obě témata, mobil, otevření PDF)

## Poznámky k migraci
3 nové migrace: tabulka + enum, updated_at trigger, ALTER POLICY (select policy bez `removed_at IS NULL` — rozbil by soft-delete; viz design doc).