### PR TITLE
feat: add versioned team document library

### DIFF
--- a/db/schema/team-documents.ts
+++ b/db/schema/team-documents.ts
@@ -1,0 +1,132 @@
+// Schema source of truth (drizzle-kit only; NOT imported at runtime — app uses supabase-js).
+// Please look at CONTRIBUTING.md for more information on how to change the schema.
+import { sql } from "drizzle-orm"
+import {
+	check,
+	date,
+	foreignKey,
+	integer,
+	pgEnum,
+	pgPolicy,
+	pgTable,
+	text,
+	timestamp,
+	uniqueIndex,
+	uuid,
+} from "drizzle-orm/pg-core"
+
+import { profiles } from "./profiles"
+import { teams } from "./teams"
+
+export const teamDocumentType = pgEnum("team_document_type", [
+	"team_contract",
+	"financial_policy",
+	"other",
+])
+
+export const teamDocuments = pgTable("team_documents", {
+	id: uuid().defaultRandom().primaryKey().notNull(),
+	teamId: uuid("team_id").notNull(),
+	docType: teamDocumentType("doc_type").notNull(),
+	title: text(),
+	removedAt: timestamp("removed_at", { withTimezone: true, mode: "string" }),
+	createdAt: timestamp("created_at", { withTimezone: true, mode: "string" }).defaultNow().notNull(),
+	updatedAt: timestamp("updated_at", { withTimezone: true, mode: "string" }).defaultNow().notNull(),
+	createdByProfileId: uuid("created_by_profile_id").notNull(),
+	updatedByProfileId: uuid("updated_by_profile_id").notNull(),
+}, (table) => [
+	uniqueIndex("team_documents_featured_team_type_idx")
+		.using("btree", table.teamId.asc().nullsLast().op("uuid_ops"), table.docType.asc().nullsLast().op("enum_ops"))
+		.where(sql`doc_type IN ('team_contract', 'financial_policy') AND removed_at IS NULL`),
+	foreignKey({
+		columns: [table.teamId],
+		foreignColumns: [teams.id],
+		name: "team_documents_team_id_fkey",
+	}).onDelete("cascade"),
+	foreignKey({
+		columns: [table.createdByProfileId],
+		foreignColumns: [profiles.id],
+		name: "team_documents_created_by_profile_id_fkey",
+	}).onDelete("restrict"),
+	foreignKey({
+		columns: [table.updatedByProfileId],
+		foreignColumns: [profiles.id],
+		name: "team_documents_updated_by_profile_id_fkey",
+	}).onDelete("restrict"),
+	check("team_documents_title_matches_type", sql`(
+		(doc_type = 'other' AND title IS NOT NULL AND length(trim(title)) > 0)
+		OR (doc_type <> 'other' AND title IS NULL)
+	)`),
+	pgPolicy("Team members can view documents", {
+		as: "permissive",
+		for: "select",
+		to: ["authenticated"],
+		using: sql`team_id IN (SELECT team_id FROM profiles WHERE id = current_profile_id() AND access_removed_at IS NULL)`,
+	}),
+	pgPolicy("Team members can create documents", {
+		as: "permissive",
+		for: "insert",
+		to: ["authenticated"],
+		withCheck: sql`team_id IN (SELECT team_id FROM profiles WHERE id = current_profile_id() AND access_removed_at IS NULL) AND created_by_profile_id = current_profile_id() AND updated_by_profile_id = current_profile_id()`,
+	}),
+	pgPolicy("Team members can update custom documents", {
+		as: "permissive",
+		for: "update",
+		to: ["authenticated"],
+		using: sql`doc_type = 'other' AND team_id IN (SELECT team_id FROM profiles WHERE id = current_profile_id() AND access_removed_at IS NULL)`,
+		withCheck: sql`doc_type = 'other' AND team_id IN (SELECT team_id FROM profiles WHERE id = current_profile_id() AND access_removed_at IS NULL) AND updated_by_profile_id = current_profile_id()`,
+	}),
+]).enableRLS()
+
+export const teamDocumentVersions = pgTable("team_document_versions", {
+	id: uuid().defaultRandom().primaryKey().notNull(),
+	documentId: uuid("document_id").notNull(),
+	versionNo: integer("version_no").notNull(),
+	filePath: text("file_path").notNull(),
+	fileName: text("file_name").notNull(),
+	fileSize: integer("file_size").notNull(),
+	effectiveFrom: date("effective_from"),
+	changeNote: text("change_note"),
+	createdAt: timestamp("created_at", { withTimezone: true, mode: "string" }).defaultNow().notNull(),
+	createdByProfileId: uuid("created_by_profile_id").notNull(),
+}, (table) => [
+	uniqueIndex("team_document_versions_document_version_idx")
+		.using("btree", table.documentId.asc().nullsLast().op("uuid_ops"), table.versionNo.asc().nullsLast().op("int4_ops")),
+	foreignKey({
+		columns: [table.documentId],
+		foreignColumns: [teamDocuments.id],
+		name: "team_document_versions_document_id_fkey",
+	}).onDelete("cascade"),
+	foreignKey({
+		columns: [table.createdByProfileId],
+		foreignColumns: [profiles.id],
+		name: "team_document_versions_created_by_profile_id_fkey",
+	}).onDelete("restrict"),
+	check("team_document_versions_version_positive", sql`version_no > 0`),
+	check("team_document_versions_file_size_positive", sql`file_size > 0`),
+	pgPolicy("Team members can view document versions", {
+		as: "permissive",
+		for: "select",
+		to: ["authenticated"],
+		using: sql`document_id IN (
+			SELECT team_documents.id
+			FROM team_documents
+			WHERE team_documents.team_id IN (
+				SELECT team_id FROM profiles WHERE id = current_profile_id() AND access_removed_at IS NULL
+			)
+		)`,
+	}),
+	pgPolicy("Team members can create document versions", {
+		as: "permissive",
+		for: "insert",
+		to: ["authenticated"],
+		withCheck: sql`created_by_profile_id = current_profile_id() AND document_id IN (
+			SELECT team_documents.id
+			FROM team_documents
+			WHERE team_documents.removed_at IS NULL
+				AND team_documents.team_id IN (
+					SELECT team_id FROM profiles WHERE id = current_profile_id() AND access_removed_at IS NULL
+				)
+		)`,
+	}),
+]).enableRLS()

--- a/docs/plans/2026-08-19-tymove-dokumenty-design.md
+++ b/docs/plans/2026-08-19-tymove-dokumenty-design.md
@@ -1,0 +1,143 @@
+# Týmové dokumenty — Design
+
+> Feature #51 (Team Contract a Leading Thoughts) a #52 (Finanční směrnice) se řeší jako jeden
+> sdílený modul: **Týmové dokumenty**. Otázka právního/e-podpisu je odložena — první verze pracuje
+> pouze s nahráváním hotových PDF souborů (typicky ručně podepsaných) a verzováním.
+
+**Datum:** 2026-08-19
+**Status:** validováno brainstormingem
+
+---
+
+## 1. Proč to děláme
+
+Týmy si drží týmovou smlouvu („Team Contract") a finanční směrnice („Financial Policies") jako
+dokumenty. Dnes jsou „pouze v tymove.xlsx". Chceme je mít v aplikaci, verzované, s historií, a
+volně dostupné členům týmu. Navíc chceme uživatelům dát svobodu nahrát i další týmové dokumenty
+(např. interní pravidla, zápisy).
+
+## 2. Rozhodnutí z brainstormingu
+
+| Rozhodnutí | Volba |
+| --- | --- |
+| Formát obsahu | **PDF upload** (soubor je zdroj pravdy). Bez inline editoru, bez e-podpisu — viz Odložené. |
+| Verzování | Každé nahrání = **nový immutable version**; historie zůstává, každou verzi lze stáhnout/otevřít. |
+| Typy dokumentů | `team_contract` (1/tým), `financial_policy` (1/tým), `other` (neomezeně, uživatelský název). |
+| Práva | **Všichni aktivní členové týmu** mohou nahrát novou verzi, vytvořit `other` dokument, přejmenovat a archivovat `other` dokumenty. |
+| Metadata verze | Dobrovolné: `change_note`, `effective_from`. Zbytek (schválil, schváleno dne, účinnost) zůstává v PDF. |
+| Aktivní verze | Žádná explicitní „aktuální verze" — aktuální = **nejvyšší `version_no`**. |
+| Featured dokumenty | Nejde přejmenovat ani archivovat — jen přibývají verze. |
+| Úložiště | Privátní bucket `documents`, přístup přes presign upload + signed URL (vzor personality-tests). |
+| Umístění v UI | Nová sekce `/tymove-dokumenty`, beta-only (stejně jako Týmový deník). |
+| Migrace | Dle AGENTS.md — uživatel spouští `pnpm db:migrate`, kontroluje migrace na drops. |
+
+## 3. Data model (Drizzle, `db/schema/`)
+
+### `team_documents`
+
+| Sloupec | Typ | Poznámka |
+| --- | --- | --- |
+| `id` | uuid PK | defaultRandom |
+| `team_id` | uuid FK → teams (cascade) | |
+| `doc_type` | enum `team_document_type` (`team_contract`,`financial_policy`,`other`) | |
+| `title` | text null | Povinné pro `other` (check), null pro featured |
+| `removed_at` | timestamp null | Soft-delete (jen `other`) |
+| `created_at` / `updated_at` | timestamp | + trigger |
+| `created_by_profile_id` / `updated_by_profile_id` | uuid FK → profiles (restrict) | |
+
+**Omezení:**
+- `check` — `doc_type <> 'other' OR (title IS NOT NULL AND length(trim(title)) > 0)`
+- **partial unique** na `(team_id, doc_type)` kde `doc_type IN ('team_contract','financial_policy') AND removed_at IS NULL` → max 1 featured dokument daného typu na tým.
+
+### `team_document_versions`
+
+| Sloupec | Typ | Poznámka |
+| --- | --- | --- |
+| `id` | uuid PK | defaultRandom |
+| `document_id` | uuid FK → team_documents (cascade) | |
+| `version_no` | int | Rostoucí per dokument (1,2,3…) — počítá server |
+| `file_path` | text | Klíč v bucketu `documents` |
+| `file_name` | text | Původní název souboru |
+| `file_size` | int | |
+| `effective_from` | date null | Dobrovolné |
+| `change_note` | text null | Dobrovolné |
+| `created_at` | timestamp | |
+| `created_by_profile_id` | uuid FK → profiles (restrict) | |
+
+**Omezení:** `unique (document_id, version_no)`.
+
+**Imutabilita:** žádné update/delete policy → verze nelze měnit ani mazat.
+
+### RLS
+
+- `team_documents` — select/insert/update/delete: člen týmu
+  (`team_id IN (SELECT team_id FROM profiles WHERE id = current_profile_id() AND access_removed_at IS NULL)`),
+  vzor `team_reflections`.
+- `team_document_versions` — select/insert: člen týmu (přes `document_id` → `team_documents`).
+  Žádné update/delete policy.
+
+## 4. Storage
+
+- Nový kontext `team-document` → bucket `documents` (privátní).
+- Klíč: `team-document/{documentId}/{ts}-{uuid}.pdf` (vzor `generateFileKey`).
+- **Jen PDF** (`application/pdf`, max `MAX_DOCUMENT_SIZE` 20MB) — nová `validateTeamDocumentUpload`.
+- Autorizace v `presign-upload` route: entityId = `document_id`, ověřit, že dokument patří do týmu uživatele.
+
+## 5. API routes (vzor personality-tests)
+
+| Route | Metoda | Účel |
+| --- | --- | --- |
+| `/api/storage/presign-upload` | POST | Rozšířit o kontext `team-document` |
+| `/api/team-documents` | POST | Vytvořit dokument (`doc_type`, `title` pro `other`) |
+| `/api/team-documents/[id]` | PATCH | Přejmenovat `other` dokument |
+| `/api/team-documents/[id]` | DELETE | Archivovat (`removed_at`) jen `other` |
+| `/api/team-documents/[id]/versions` | POST | Nahrát novou verzi (`key`, `fileName`, `fileSize`, `changeNote?`, `effectiveFrom?`); `version_no = max+1` |
+| `/api/team-documents/versions/[versionId]/open` | GET | Redirect na signed URL |
+
+Ověřování oprávnění: člen týmu + dokument patří do uživatelova týmu. `version_no` počítá server
+(`max(version_no)+1` per dokument) v rámci insertu; unikátní index chrání před kolizemi.
+
+## 6. UI (`/tymove-dokumenty`)
+
+- Serverová page: auth/beta/team gate (vzor `tymovy-denik/page.tsx`), dotazy na dokumenty + poslední verzi.
+- **Client komponenta** `TeamDocuments`:
+  - Dva zvýrazněné karty: „Týmová smlouva" a „Finanční směrnice" (typu featured).
+  - Sekce „Další dokumenty" s tlačítkem „Přidat dokument".
+  - Každý dokument: název, informace o poslední verzi (verze, název souboru, velikost, datum, kdo nahrál),
+    tlačítka „Nahrát novou verzi", „Otevřít", u `other` i „Přejmenovat" a „Archivovat".
+  - Verze → modal/dialog „Historie verzí" se seznamem + odkazem „Otevřít" (signed URL) pro každou verzi.
+- Dialogy: `UploadVersionDialog` (soubor, change note, effective from), `CreateDocumentDialog` (title + první verze), `RenameDialog`, archivační `AlertDialog`.
+- Použití sdílených primitiv: `Button`, responzivní `AlertDialog`, `Empty*`, `PageHeader`/`PageShell`, sonner `toast`.
+
+### České copy (gender-neutral, dle DESIGN.md)
+
+- „Týmová smlouva", „Finanční směrnice", „Další dokumenty", „Přidat dokument", „Nahrát novou verzi",
+  „Počet verzí", „Verze {n}", „Účinnost od", „Poznámka ke změně", „Nahráno {datum}",
+  „Nahrál:a" → používat neutrální tvary („poslední verzi nahrál člen týmu" / přímá vazba jméno).
+  Vše ověřit dle `inclusive-czech-writing` skillu.
+
+## 7. Testování
+
+- **Integrační RLS** `tests/integration/team-documents.int.test.ts`:
+  člen týmu select/insert; cizí tým 0 řádků/403; soft-delete jen `other`; featured unikátnost;
+  verze: insert člena týmu, žádný update/delete; cascade via team delete.
+- **Komponenta** `team-documents.test.tsx`: prázdný stav, výpis dokumentů, upload dialog (validace PDF),
+  rename/archive, chybové stavy.
+- **Unit** (pokud vznikne formátovací helper).
+- `pnpm test`, `pnpm typecheck`, `pnpm lint`.
+
+## 8. Odložené / YAGNI
+
+- **Právní e-podpis / Signi / BankID** — samostatná budoucí práce na stejném verzovacím modelu
+  (frozen version → PDF → podpis). Záměrně NENÍ součástí.
+- Externí PDF export/preview, tagy, hledání, notifikace členů.
+- Datumy „schválil/schváleno dne" jako pole — zůstávají v PDF.
+- Strukturovaná „Leading Thoughts" data (issue #51 mluví i o nich) — první verze řeší jen dokument jako celek.
+
+## 9. Zdroje / reference
+
+- Issue #51: <https://github.com/spirit-of-tap/Tappka/issues/51>
+- Issue #52: <https://github.com/spirit-of-tap/Tappka/issues/52>
+- Vzor implementace: `docs/plans/2026-08-18-osobnostni-testy-plan.md`, `src/lib/personality-tests/*`,
+  `src/components/personality-tests/*`, `src/app/api/personality-tests/*`, `db/schema/personality-tests.ts`,
+  `tests/integration/team-activities.int.test.ts`.

--- a/docs/plans/2026-08-19-tymove-dokumenty-plan.md
+++ b/docs/plans/2026-08-19-tymove-dokumenty-plan.md
@@ -1,0 +1,355 @@
+# Týmové dokumenty Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Give every team a private, versioned PDF library with featured Team Contract and Financial Policy documents plus unlimited custom documents.
+
+**Architecture:** Store logical documents separately from immutable PDF versions. Team-scoped RLS protects both tables, the existing private `documents` bucket stores files, and authenticated API routes coordinate presigned uploads, metadata changes, and signed downloads. A beta-gated `/tymove-dokumenty` page presents the two featured slots first and custom documents below them.
+
+**Tech Stack:** Next.js 16, React 19, Supabase, Drizzle schema, Supabase Storage, shadcn/ui, Tailwind CSS 4, Vitest, Testcontainers, Playwright
+
+**Design:** `docs/plans/2026-08-19-tymove-dokumenty-design.md`
+
+---
+
+### Task 1: Database behavior and schema
+
+**Files:**
+- Test: `tests/integration/team-documents.int.test.ts`
+- Create: `db/schema/team-documents.ts`
+- Create via `pnpm db:migrate`: `supabase/migrations/<timestamp>_*.sql`
+- Modify via `pnpm db:migrate`: `src/lib/supabase/database.types.ts`
+
+**Step 1: Write the failing integration tests**
+
+Cover these independent behaviors:
+
+- A member can insert and read a document belonging to their team.
+- A member of another team cannot read, insert, or update that document.
+- A team can have only one active `team_contract` and one active `financial_policy`.
+- A team can create multiple `other` documents with non-empty titles.
+- A member can insert and read immutable versions belonging to their team.
+- Updates and deletes of `team_document_versions` are denied.
+- Deleting a team cascades to documents and versions.
+
+Use `withRollback`, `insertAuthUser`, and `asClaims`, following `tests/integration/team-activities.int.test.ts`.
+
+**Step 2: Run the test to verify RED**
+
+Run: `pnpm vitest run --project integration tests/integration/team-documents.int.test.ts`
+
+Expected: FAIL because `team_documents` and `team_document_versions` do not exist.
+
+**Step 3: Add the Drizzle schema**
+
+Create `team_document_type` with `team_contract`, `financial_policy`, and `other`.
+
+Create `team_documents` with:
+
+- `id`, `team_id`, `doc_type`, optional `title`, `removed_at`
+- `created_at`, `updated_at`, `created_by_profile_id`, `updated_by_profile_id`
+- team and profile foreign keys
+- title check for `other`
+- partial unique index on `(team_id, doc_type)` for active featured documents
+- team-member select/insert policies
+- team-member update policy restricted to `other` documents
+- no hard-delete policy
+- RLS enabled
+
+Create `team_document_versions` with:
+
+- `id`, `document_id`, `version_no`
+- `file_path`, `file_name`, `file_size`
+- optional `effective_from`, optional `change_note`
+- `created_at`, `created_by_profile_id`
+- unique index on `(document_id, version_no)`
+- team-member select/insert policies through the parent document
+- no update/delete policies
+- RLS enabled
+
+Keep full `using` and `withCheck` expressions in every policy.
+
+**Step 4: Ask the user to migrate**
+
+Ask the user to run:
+
+```bash
+pnpm db:migrate
+```
+
+Ask them to inspect every generated migration for unexpected `DROP` statements. Do not continue typed application work until `src/lib/supabase/database.types.ts` contains both tables and the enum.
+
+**Step 5: Add the updated_at trigger if needed**
+
+If `db:migrate` does not create a trigger for `team_documents`, run `pnpm db:generate:custom`, add a trigger invoking `public.handle_updated_at()`, then follow the repository custom-migration workflow. Do not add an `updated_at` column to immutable versions.
+
+**Step 6: Verify GREEN and commit**
+
+Run: `pnpm vitest run --project integration tests/integration/team-documents.int.test.ts`
+
+Expected: PASS.
+
+Commit:
+
+```bash
+git add db/schema/team-documents.ts supabase/migrations src/lib/supabase/database.types.ts tests/integration/team-documents.int.test.ts
+git commit -m "feat(db): add versioned team documents"
+```
+
+---
+
+### Task 2: Storage validation and authorization
+
+**Files:**
+- Test: `src/lib/storage/validation.test.ts`
+- Modify: `src/lib/storage/types.ts`
+- Modify: `src/lib/storage/buckets.ts`
+- Modify: `src/lib/storage/authorization.ts`
+- Modify: `src/lib/storage/validation.ts`
+- Modify: `src/app/api/storage/presign-upload/route.ts`
+
+**Step 1: Write failing unit tests**
+
+Add tests proving team-document uploads accept `application/pdf`, reject image and Office MIME types, reject empty/invalid sizes, and enforce `MAX_DOCUMENT_SIZE`.
+
+**Step 2: Run the tests to verify RED**
+
+Run: `pnpm vitest run --project unit src/lib/storage/validation.test.ts`
+
+Expected: FAIL because `validateTeamDocumentUpload` does not exist.
+
+**Step 3: Implement minimal storage support**
+
+- Add `team-document` to `StorageContext`.
+- Map it to the private `documents` bucket.
+- Add `validateTeamDocumentUpload` for PDF files up to 20 MB.
+- In the presign route, load the target document and allow the upload only when its active `team_id` equals the current profile's `team_id`.
+- Generate keys under `team-document/{documentId}/`.
+- Keep the API key and service-role behavior server-only.
+
+**Step 4: Verify and commit**
+
+Run: `pnpm vitest run --project unit src/lib/storage/validation.test.ts`
+
+Expected: PASS.
+
+Commit:
+
+```bash
+git add src/lib/storage src/app/api/storage/presign-upload/route.ts
+git commit -m "feat: support team document uploads"
+```
+
+---
+
+### Task 3: Types, queries, and formatting
+
+**Files:**
+- Create: `src/lib/team-documents/types.ts`
+- Create: `src/lib/team-documents/queries.ts`
+- Test: `src/lib/team-documents/format.test.ts`
+- Create: `src/lib/team-documents/format.ts`
+
+**Step 1: Write failing format tests**
+
+Test Czech date formatting, file-size formatting, built-in document labels, and version labels.
+
+**Step 2: Verify RED**
+
+Run: `pnpm vitest run --project unit src/lib/team-documents/format.test.ts`
+
+Expected: FAIL because the module does not exist.
+
+**Step 3: Implement derived types and queries**
+
+- Derive rows with `Tables<'team_documents'>` and `Tables<'team_document_versions'>`.
+- Define the joined creator shape without hand-writing database row types.
+- Query active team documents and their versions ordered by `version_no DESC`.
+- Compose documents with versions in TypeScript; the first version is current.
+- Implement only the format helpers exercised by tests.
+
+**Step 4: Verify and commit**
+
+Run: `pnpm vitest run --project unit src/lib/team-documents/format.test.ts`
+
+Expected: PASS.
+
+Commit:
+
+```bash
+git add src/lib/team-documents
+git commit -m "feat: add team document queries and formatting"
+```
+
+---
+
+### Task 4: Document and version API routes
+
+**Files:**
+- Create: `src/app/api/team-documents/route.ts`
+- Create: `src/app/api/team-documents/[id]/route.ts`
+- Create: `src/app/api/team-documents/[id]/versions/route.ts`
+- Create: `src/app/api/team-documents/versions/[versionId]/open/route.ts`
+
+**Step 1: Extend the component/API behavior tests before each route**
+
+Add one failing test per visible behavior in Task 6 before implementing its route contract. Keep route validation small and explicit:
+
+- document type must be known
+- custom title must be trimmed and non-empty
+- featured title must remain null
+- file key must begin with `team-document/{documentId}/`
+- PDF file name and size must be valid
+- `effectiveFrom` must be empty or `YYYY-MM-DD`
+- `changeNote` must be trimmed and length-limited
+
+**Step 2: Implement authenticated routes**
+
+- Use `createClient`, `getCurrentUserProfile`, and typed `Insertable`/`Updatable` payloads.
+- Rely on RLS and also verify profile team membership for clear errors.
+- Return `409` for duplicate featured documents.
+- Compute `version_no` from the current maximum; retry once on unique-conflict races.
+- Archive custom documents by setting `removed_at`; never delete version files.
+- Open versions through `getSignedStorageUrl('documents', file_path)`.
+
+**Step 3: Verify and commit**
+
+Run: `pnpm typecheck`
+
+Expected: PASS.
+
+Commit:
+
+```bash
+git add src/app/api/team-documents
+git commit -m "feat: add team document API routes"
+```
+
+---
+
+### Task 5: Team documents UI with TDD
+
+**Files:**
+- Test: `src/components/team-documents/team-documents.test.tsx`
+- Create: `src/components/team-documents/team-documents.tsx`
+- Create: `src/components/team-documents/team-document-card.tsx`
+- Create: `src/components/team-documents/document-upload-form.tsx`
+- Create: `src/components/team-documents/document-create-form.tsx`
+
+**Step 1: Write failing component tests**
+
+Cover:
+
+- Both featured cards render even when no rows exist.
+- Featured cards show first-version CTAs and cannot be renamed or archived.
+- Custom documents render below the featured cards.
+- Version history is newest-first and each version links to its open route.
+- The upload form rejects non-PDF files before requesting a presigned URL.
+- Successful upload executes presign, PUT, and version metadata calls in order.
+- A custom document can be renamed and archived after confirmation.
+- Failed requests keep dialogs open and show a toast.
+
+Use responsive dialogs, shared `AlertDialog`, shared `Empty*`, `Button`, and sonner. Keep Czech copy neutral, preferably present tense or passive forms such as `Nahráno`.
+
+**Step 2: Verify RED**
+
+Run: `pnpm vitest run --project component src/components/team-documents/team-documents.test.tsx`
+
+Expected: FAIL because the components do not exist.
+
+**Step 3: Implement minimal UI**
+
+- Render two visually prominent featured cards.
+- Render custom documents as a separate collection.
+- Use one reusable upload form for first and later versions.
+- Keep versions immutable and show all historical downloads.
+- Update local component state only after successful API responses.
+- Ensure desktop/mobile layouts and light/dark token usage follow `DESIGN.md`.
+
+**Step 4: Verify and commit**
+
+Run: `pnpm vitest run --project component src/components/team-documents/team-documents.test.tsx`
+
+Expected: PASS.
+
+Commit:
+
+```bash
+git add src/components/team-documents
+git commit -m "feat: add team documents interface"
+```
+
+---
+
+### Task 6: Page and navigation
+
+**Files:**
+- Create: `src/app/(main)/tymove-dokumenty/page.tsx`
+- Modify: `src/components/app-sidebar.tsx`
+
+**Step 1: Add the page**
+
+- Authenticate and load the session profile.
+- Redirect without beta access or a team, matching other team pages.
+- Fetch documents with versions.
+- Render `PageShell`, `PageHeader`, an explanatory introduction, and `TeamDocuments`.
+
+**Step 2: Add beta navigation**
+
+Add `Týmové dokumenty` at `/tymove-dokumenty` with a document icon, active-state handling, mobile close behavior, and the existing Beta badge pattern.
+
+**Step 3: Verify and commit**
+
+Run: `pnpm typecheck && pnpm lint`
+
+Expected: PASS.
+
+Commit:
+
+```bash
+git add 'src/app/(main)/tymove-dokumenty/page.tsx' src/components/app-sidebar.tsx
+git commit -m "feat: expose team documents page"
+```
+
+---
+
+### Task 7: End-to-end flow and final verification
+
+**Files:**
+- Test: `tests/e2e/team-documents.spec.ts`
+- Add only if needed: `tests/e2e/fixtures/team-document.pdf`
+
+**Step 1: Write the E2E test**
+
+Cover authentication redirect, beta/team gating, empty featured slots, creating a custom document with a small PDF, and adding a second immutable version.
+
+**Step 2: Verify RED, then GREEN**
+
+Run: `pnpm test:e2e tests/e2e/team-documents.spec.ts`
+
+Expected before final fixes: FAIL for the missing/incorrect flow. Expected after fixes: PASS.
+
+**Step 3: Run full verification**
+
+Run:
+
+```bash
+pnpm test
+pnpm test:integration
+pnpm typecheck
+pnpm lint
+pnpm build
+```
+
+Expected: all commands PASS with no new warnings.
+
+**Step 4: Review scope and commit**
+
+Confirm there is no inline editor, e-signing integration, search, tagging, notification workflow, or hard deletion of historical files.
+
+Commit:
+
+```bash
+git add tests/e2e/team-documents.spec.ts tests/e2e/fixtures/team-document.pdf
+git commit -m "test: cover team document workflow"
+```

--- a/package.json
+++ b/package.json
@@ -93,6 +93,7 @@
     "lucide-react": "^0.511.0",
     "next": "^16.3.1",
     "next-themes": "^0.4.6",
+    "nextjs-toploader": "^3.9.17",
     "posthog-js": "^1.418.1",
     "posthog-node": "^5.26.1",
     "react": "^19.2.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -184,6 +184,9 @@ importers:
       next-themes:
         specifier: ^0.4.6
         version: 0.4.6(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      nextjs-toploader:
+        specifier: ^3.9.17
+        version: 3.9.17(next@16.3.1(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.61.1)(@types/node@24.10.9)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       posthog-js:
         specifier: ^1.418.1
         version: 1.418.1
@@ -322,7 +325,7 @@ importers:
         version: 5.9.3
       vitepress:
         specifier: 2.0.0-alpha.18
-        version: 2.0.0-alpha.18(@types/node@24.10.9)(esbuild@0.28.1)(jiti@2.6.1)(postcss@8.5.6)(qrcode@1.5.4)(tsx@4.22.4)(typescript@5.9.3)(yaml@2.9.0)
+        version: 2.0.0-alpha.18(@types/node@24.10.9)(esbuild@0.28.1)(jiti@2.6.1)(nprogress@0.2.0)(postcss@8.5.6)(qrcode@1.5.4)(tsx@4.22.4)(typescript@5.9.3)(yaml@2.9.0)
       vitest:
         specifier: ^4.1.10
         version: 4.1.10(@opentelemetry/api@1.9.0)(@types/node@24.10.9)(@vitest/coverage-v8@4.1.10)(happy-dom@20.9.0)(jsdom@29.1.1(@noble/hashes@1.8.0))(vite@8.1.4(@types/node@24.10.9)(esbuild@0.28.1)(jiti@2.6.1)(tsx@4.22.4)(yaml@2.9.0))
@@ -4872,6 +4875,13 @@ packages:
       sass:
         optional: true
 
+  nextjs-toploader@3.9.17:
+    resolution: {integrity: sha512-9OF0KSSLtoSAuNg2LZ3aTl4hR9mBDj5L9s9DZiFCbMlXehyICGjkIz5dVGzuATU2bheJZoBdFgq9w07AKSuQQw==}
+    peerDependencies:
+      next: '>= 6.0.0'
+      react: '>= 16.0.0'
+      react-dom: '>= 16.0.0'
+
   nice-try@1.0.5:
     resolution: {integrity: sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==}
 
@@ -4892,6 +4902,9 @@ packages:
     resolution: {integrity: sha512-Oo82gJDAVcaMdi3nuoKFavkIHBRVqQ1qvMb+9LHk/cF4P6B2m8aP04hGf7oL6wZ9BuGwX1onlLhpuoofSyoQDQ==}
     engines: {node: '>= 4'}
     hasBin: true
+
+  nprogress@0.2.0:
+    resolution: {integrity: sha512-I19aIingLgR1fmhftnbWWO3dXc0hSxqHQHQb3H8m+K3TnEn/iSeTZZOyvKXWqQESMwuUVnatlCnZdLBZZt2VSA==}
 
   object-assign@4.1.1:
     resolution: {integrity: sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==}
@@ -8718,13 +8731,14 @@ snapshots:
       '@vueuse/shared': 14.3.0(vue@3.5.40(typescript@5.9.3))
       vue: 3.5.40(typescript@5.9.3)
 
-  '@vueuse/integrations@14.3.0(focus-trap@8.2.2)(qrcode@1.5.4)(vue@3.5.40(typescript@5.9.3))':
+  '@vueuse/integrations@14.3.0(focus-trap@8.2.2)(nprogress@0.2.0)(qrcode@1.5.4)(vue@3.5.40(typescript@5.9.3))':
     dependencies:
       '@vueuse/core': 14.3.0(vue@3.5.40(typescript@5.9.3))
       '@vueuse/shared': 14.3.0(vue@3.5.40(typescript@5.9.3))
       vue: 3.5.40(typescript@5.9.3)
     optionalDependencies:
       focus-trap: 8.2.2
+      nprogress: 0.2.0
       qrcode: 1.5.4
 
   '@vueuse/metadata@14.3.0': {}
@@ -10722,6 +10736,14 @@ snapshots:
       - '@types/node'
       - babel-plugin-macros
 
+  nextjs-toploader@3.9.17(next@16.3.1(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.61.1)(@types/node@24.10.9)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react-dom@19.2.3(react@19.2.3))(react@19.2.3):
+    dependencies:
+      next: 16.3.1(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.61.1)(@types/node@24.10.9)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      nprogress: 0.2.0
+      prop-types: 15.8.1
+      react: 19.2.3
+      react-dom: 19.2.3(react@19.2.3)
+
   nice-try@1.0.5: {}
 
   node-releases@2.0.27: {}
@@ -10748,6 +10770,8 @@ snapshots:
       read-pkg: 3.0.0
       shell-quote: 1.8.3
       string.prototype.padend: 3.1.6
+
+  nprogress@0.2.0: {}
 
   object-assign@4.1.1: {}
 
@@ -12113,7 +12137,7 @@ snapshots:
       tsx: 4.22.4
       yaml: 2.9.0
 
-  vitepress@2.0.0-alpha.18(@types/node@24.10.9)(esbuild@0.28.1)(jiti@2.6.1)(postcss@8.5.6)(qrcode@1.5.4)(tsx@4.22.4)(typescript@5.9.3)(yaml@2.9.0):
+  vitepress@2.0.0-alpha.18(@types/node@24.10.9)(esbuild@0.28.1)(jiti@2.6.1)(nprogress@0.2.0)(postcss@8.5.6)(qrcode@1.5.4)(tsx@4.22.4)(typescript@5.9.3)(yaml@2.9.0):
     dependencies:
       '@docsearch/css': 4.6.3
       '@docsearch/js': 4.6.3
@@ -12127,7 +12151,7 @@ snapshots:
       '@vue/devtools-api': 8.1.5
       '@vue/shared': 3.5.40
       '@vueuse/core': 14.3.0(vue@3.5.40(typescript@5.9.3))
-      '@vueuse/integrations': 14.3.0(focus-trap@8.2.2)(qrcode@1.5.4)(vue@3.5.40(typescript@5.9.3))
+      '@vueuse/integrations': 14.3.0(focus-trap@8.2.2)(nprogress@0.2.0)(qrcode@1.5.4)(vue@3.5.40(typescript@5.9.3))
       focus-trap: 8.2.2
       mark.js: 8.11.1
       minisearch: 7.2.0

--- a/src/app/(main)/tymove-dokumenty/page.tsx
+++ b/src/app/(main)/tymove-dokumenty/page.tsx
@@ -1,0 +1,52 @@
+import { redirect } from "next/navigation"
+import { Files } from "lucide-react"
+
+import { TeamDocuments } from "@/components/team-documents/team-documents"
+import { Card } from "@/components/ui/card"
+import { PageHeader } from "@/components/ui/page-header"
+import { PageShell } from "@/components/ui/page-shell"
+import { getSessionProfile } from "@/lib/auth/session"
+import { createClient } from "@/lib/supabase/server"
+import { listTeamDocuments } from "@/lib/team-documents/queries"
+
+export const metadata = {
+  title: "Týmové dokumenty | Tappka",
+  description: "Týmová smlouva, finanční směrnice a další verzované dokumenty",
+}
+
+export default async function TeamDocumentsPage() {
+  const supabase = await createClient()
+  const { data: { user } } = await supabase.auth.getUser()
+  if (!user) redirect("/auth/login")
+
+  const profile = await getSessionProfile()
+  if (!profile) redirect("/auth/login")
+  if (!profile.beta_access_granted_at || !profile.team_id) redirect("/")
+
+  const documents = await listTeamDocuments(supabase, profile.team_id)
+
+  return (
+    <PageShell className="max-w-5xl">
+      <PageHeader
+        title="Týmové dokumenty"
+        description="Jedno místo pro důležité týmové dokumenty a jejich historii."
+        count={{ value: documents.length, label: "dokumentů" }}
+      />
+
+      <Card className="flex-row items-start gap-3 p-4 sm:p-5">
+        <div className="flex size-9 shrink-0 items-center justify-center rounded-lg bg-primary/10 text-primary">
+          <Files className="size-5" />
+        </div>
+        <div className="space-y-1">
+          <p className="font-medium">Každé nahrání vytváří novou verzi</p>
+          <p className="text-sm text-muted-foreground">
+            Nahrajte hotové PDF. Předchozí verze zůstávají dostupné, takže tým vždy dohledá,
+            co platilo dříve.
+          </p>
+        </div>
+      </Card>
+
+      <TeamDocuments teamId={profile.team_id} initialDocuments={documents} />
+    </PageShell>
+  )
+}

--- a/src/app/(main)/tymove-dokumenty/page.tsx
+++ b/src/app/(main)/tymove-dokumenty/page.tsx
@@ -2,7 +2,6 @@ import { redirect } from "next/navigation"
 import { Files } from "lucide-react"
 
 import { TeamDocuments } from "@/components/team-documents/team-documents"
-import { Card } from "@/components/ui/card"
 import { PageHeader } from "@/components/ui/page-header"
 import { PageShell } from "@/components/ui/page-shell"
 import { getSessionProfile } from "@/lib/auth/session"
@@ -33,18 +32,18 @@ export default async function TeamDocumentsPage() {
         count={{ value: documents.length, label: "dokumentů" }}
       />
 
-      <Card className="flex-row items-start gap-3 p-4 sm:p-5">
-        <div className="flex size-9 shrink-0 items-center justify-center rounded-lg bg-primary/10 text-primary">
+      <aside className="flex items-start gap-3 text-sm">
+        <div className="flex size-8 shrink-0 items-center justify-center rounded-md bg-primary/10 text-primary">
           <Files className="size-5" />
         </div>
         <div className="space-y-1">
           <p className="font-medium">Každé nahrání vytváří novou verzi</p>
-          <p className="text-sm text-muted-foreground">
+          <p className="text-muted-foreground">
             Nahrajte hotové PDF. Předchozí verze zůstávají dostupné, takže tým vždy dohledá,
             co platilo dříve.
           </p>
         </div>
-      </Card>
+      </aside>
 
       <TeamDocuments teamId={profile.team_id} initialDocuments={documents} />
     </PageShell>

--- a/src/app/api/storage/presign-upload/route.ts
+++ b/src/app/api/storage/presign-upload/route.ts
@@ -13,6 +13,7 @@ import { generatePresignedUpload } from "@/lib/storage/service";
 import {
   validateImageUpload,
   validatePersonalityTestUpload,
+  validateTeamDocumentUpload,
   getFileExtension,
 } from "@/lib/storage/validation";
 import type { StorageContext } from "@/lib/storage/types";
@@ -47,8 +48,9 @@ export async function POST(request: NextRequest) {
     }
 
     // Validate file type and size
-    const validationError =
-      context === "personality-test"
+    const validationError = context === "team-document"
+      ? validateTeamDocumentUpload(contentType, fileSize)
+      : context === "personality-test"
         ? validatePersonalityTestUpload(contentType, fileSize)
         : validateImageUpload(contentType, fileSize);
     if (validationError) {
@@ -68,7 +70,21 @@ export async function POST(request: NextRequest) {
     }
 
     // Authorization checks
-    if (context === "personality-test") {
+    if (context === "team-document") {
+      const { data: document, error } = await supabase
+        .from("team_documents")
+        .select("team_id")
+        .eq("id", entityId)
+        .is("removed_at", null)
+        .maybeSingle();
+
+      if (error || !document || document.team_id !== profile.team_id) {
+        return NextResponse.json(
+          { error: "Nemáš oprávnění nahrát verzi tohoto dokumentu" },
+          { status: 403 }
+        );
+      }
+    } else if (context === "personality-test") {
       // Users can only upload to their own profile
       if (entityId !== profile.id) {
         return NextResponse.json(

--- a/src/app/api/team-documents/[id]/route.ts
+++ b/src/app/api/team-documents/[id]/route.ts
@@ -1,0 +1,117 @@
+import { NextRequest, NextResponse } from "next/server"
+
+import { getCurrentUserProfile } from "@/lib/auth-helpers"
+import { createClient } from "@/lib/supabase/server"
+import type { Updatable } from "@/lib/supabase/tables"
+import { validateCreateDocumentInput } from "@/lib/team-documents/validation"
+
+interface RouteContext {
+  params: Promise<{ id: string }>
+}
+
+export async function PATCH(request: NextRequest, { params }: RouteContext) {
+  try {
+    const { id } = await params
+    const supabase = await createClient()
+    const { data: { user } } = await supabase.auth.getUser()
+    if (!user) return NextResponse.json({ error: "Neautorizováno" }, { status: 401 })
+
+    const profile = await getCurrentUserProfile(supabase, { user })
+    if (!profile?.team_id) {
+      return NextResponse.json({ error: "Nemáte přiřazený tým" }, { status: 403 })
+    }
+
+    const { data: existing, error: existingError } = await supabase
+      .from("team_documents")
+      .select("id, team_id, doc_type")
+      .eq("id", id)
+      .is("removed_at", null)
+      .maybeSingle()
+    if (existingError || !existing || existing.team_id !== profile.team_id) {
+      return NextResponse.json({ error: "Dokument nenalezen" }, { status: 404 })
+    }
+    if (existing.doc_type !== "other") {
+      return NextResponse.json(
+        { error: "Zvýrazněný dokument nelze přejmenovat" },
+        { status: 400 },
+      )
+    }
+
+    const body: unknown = await request.json()
+    const title = typeof body === "object" && body !== null && "title" in body
+      ? body.title
+      : undefined
+    const validation = validateCreateDocumentInput({ docType: "other", title })
+    if ("error" in validation) {
+      return NextResponse.json({ error: validation.error }, { status: 400 })
+    }
+
+    const update: Updatable<"team_documents"> = {
+      title: validation.data.title,
+      updated_by_profile_id: profile.id,
+    }
+    const { data, error } = await supabase
+      .from("team_documents")
+      .update(update)
+      .eq("id", id)
+      .select()
+      .maybeSingle()
+    if (error || !data) {
+      return NextResponse.json({ error: "Dokument se nepodařilo přejmenovat" }, { status: 500 })
+    }
+
+    return NextResponse.json({ success: true, data })
+  } catch (error) {
+    console.error("PATCH /api/team-documents/[id] error:", error)
+    return NextResponse.json({ error: "Dokument se nepodařilo přejmenovat" }, { status: 500 })
+  }
+}
+
+export async function DELETE(_request: NextRequest, { params }: RouteContext) {
+  try {
+    const { id } = await params
+    const supabase = await createClient()
+    const { data: { user } } = await supabase.auth.getUser()
+    if (!user) return NextResponse.json({ error: "Neautorizováno" }, { status: 401 })
+
+    const profile = await getCurrentUserProfile(supabase, { user })
+    if (!profile?.team_id) {
+      return NextResponse.json({ error: "Nemáte přiřazený tým" }, { status: 403 })
+    }
+
+    const { data: existing, error: existingError } = await supabase
+      .from("team_documents")
+      .select("id, team_id, doc_type")
+      .eq("id", id)
+      .is("removed_at", null)
+      .maybeSingle()
+    if (existingError || !existing || existing.team_id !== profile.team_id) {
+      return NextResponse.json({ error: "Dokument nenalezen" }, { status: 404 })
+    }
+    if (existing.doc_type !== "other") {
+      return NextResponse.json(
+        { error: "Zvýrazněný dokument nelze archivovat" },
+        { status: 400 },
+      )
+    }
+
+    const update: Updatable<"team_documents"> = {
+      removed_at: new Date().toISOString(),
+      updated_by_profile_id: profile.id,
+    }
+    const { data, error } = await supabase
+      .from("team_documents")
+      .update(update)
+      .eq("id", id)
+      .select("id")
+      .maybeSingle()
+    if (error || !data) {
+      return NextResponse.json({ error: "Dokument se nepodařilo archivovat" }, { status: 500 })
+    }
+
+    return NextResponse.json({ success: true })
+  } catch (error) {
+    console.error("DELETE /api/team-documents/[id] error:", error)
+    return NextResponse.json({ error: "Dokument se nepodařilo archivovat" }, { status: 500 })
+  }
+}

--- a/src/app/api/team-documents/[id]/versions/route.ts
+++ b/src/app/api/team-documents/[id]/versions/route.ts
@@ -1,0 +1,91 @@
+import { NextRequest, NextResponse } from "next/server"
+
+import { getCurrentUserProfile } from "@/lib/auth-helpers"
+import { createClient } from "@/lib/supabase/server"
+import type { Insertable } from "@/lib/supabase/tables"
+import { validateVersionInput } from "@/lib/team-documents/validation"
+
+const MAX_VERSION_INSERT_ATTEMPTS = 2
+
+interface RouteContext {
+  params: Promise<{ id: string }>
+}
+
+export async function POST(request: NextRequest, { params }: RouteContext) {
+  try {
+    const { id } = await params
+    const supabase = await createClient()
+    const { data: { user } } = await supabase.auth.getUser()
+    if (!user) return NextResponse.json({ error: "Neautorizováno" }, { status: 401 })
+
+    const profile = await getCurrentUserProfile(supabase, { user })
+    if (!profile?.team_id) {
+      return NextResponse.json({ error: "Nemáte přiřazený tým" }, { status: 403 })
+    }
+
+    const { data: document, error: documentError } = await supabase
+      .from("team_documents")
+      .select("id, team_id")
+      .eq("id", id)
+      .is("removed_at", null)
+      .maybeSingle()
+    if (documentError || !document || document.team_id !== profile.team_id) {
+      return NextResponse.json({ error: "Dokument nenalezen" }, { status: 404 })
+    }
+
+    const validation = validateVersionInput(await request.json(), id)
+    if ("error" in validation) {
+      return NextResponse.json({ error: validation.error }, { status: 400 })
+    }
+
+    for (let attempt = 0; attempt < MAX_VERSION_INSERT_ATTEMPTS; attempt += 1) {
+      const { data: latest, error: latestError } = await supabase
+        .from("team_document_versions")
+        .select("version_no")
+        .eq("document_id", id)
+        .order("version_no", { ascending: false })
+        .limit(1)
+        .maybeSingle()
+      if (latestError) throw latestError
+
+      const payload: Insertable<"team_document_versions"> = {
+        document_id: id,
+        version_no: (latest?.version_no ?? 0) + 1,
+        file_path: validation.data.key,
+        file_name: validation.data.fileName,
+        file_size: validation.data.fileSize,
+        effective_from: validation.data.effectiveFrom,
+        change_note: validation.data.changeNote,
+        created_by_profile_id: profile.id,
+      }
+      const { data, error } = await supabase
+        .from("team_document_versions")
+        .insert(payload)
+        .select()
+        .single()
+
+      if (!error && data) {
+        return NextResponse.json({
+          success: true,
+          data: {
+            ...data,
+            created_by: {
+              id: profile.id,
+              name: profile.name,
+              picture: profile.picture,
+            },
+          },
+        }, { status: 201 })
+      }
+      if (error?.code !== "23505" || attempt === MAX_VERSION_INSERT_ATTEMPTS - 1) {
+        console.error("POST /api/team-documents/[id]/versions insert error:", error)
+        return NextResponse.json({ error: "Verzi se nepodařilo uložit" }, { status: 500 })
+      }
+    }
+
+    return NextResponse.json({ error: "Verzi se nepodařilo uložit" }, { status: 500 })
+  } catch (error) {
+    console.error("POST /api/team-documents/[id]/versions error:", error)
+    return NextResponse.json({ error: "Verzi se nepodařilo uložit" }, { status: 500 })
+  }
+}

--- a/src/app/api/team-documents/route.ts
+++ b/src/app/api/team-documents/route.ts
@@ -1,0 +1,53 @@
+import { NextRequest, NextResponse } from "next/server"
+
+import { getCurrentUserProfile } from "@/lib/auth-helpers"
+import { createClient } from "@/lib/supabase/server"
+import type { Insertable } from "@/lib/supabase/tables"
+import { validateCreateDocumentInput } from "@/lib/team-documents/validation"
+
+export async function POST(request: NextRequest) {
+  try {
+    const supabase = await createClient()
+    const { data: { user } } = await supabase.auth.getUser()
+    if (!user) return NextResponse.json({ error: "Neautorizováno" }, { status: 401 })
+
+    const profile = await getCurrentUserProfile(supabase, { user })
+    if (!profile?.team_id) {
+      return NextResponse.json({ error: "Nemáte přiřazený tým" }, { status: 403 })
+    }
+
+    const validation = validateCreateDocumentInput(await request.json())
+    if ("error" in validation) {
+      return NextResponse.json({ error: validation.error }, { status: 400 })
+    }
+
+    const payload: Insertable<"team_documents"> = {
+      team_id: profile.team_id,
+      doc_type: validation.data.docType,
+      title: validation.data.title,
+      created_by_profile_id: profile.id,
+      updated_by_profile_id: profile.id,
+    }
+    const { data, error } = await supabase
+      .from("team_documents")
+      .insert(payload)
+      .select()
+      .single()
+
+    if (error?.code === "23505") {
+      return NextResponse.json(
+        { error: "Tento zvýrazněný dokument už tým má" },
+        { status: 409 },
+      )
+    }
+    if (error || !data) {
+      console.error("POST /api/team-documents insert error:", error)
+      return NextResponse.json({ error: "Dokument se nepodařilo vytvořit" }, { status: 500 })
+    }
+
+    return NextResponse.json({ success: true, data }, { status: 201 })
+  } catch (error) {
+    console.error("POST /api/team-documents error:", error)
+    return NextResponse.json({ error: "Dokument se nepodařilo vytvořit" }, { status: 500 })
+  }
+}

--- a/src/app/api/team-documents/versions/[versionId]/open/route.ts
+++ b/src/app/api/team-documents/versions/[versionId]/open/route.ts
@@ -1,0 +1,32 @@
+import { NextRequest, NextResponse } from "next/server"
+
+import { createClient } from "@/lib/supabase/server"
+import { getSignedStorageUrl } from "@/lib/storage/service"
+
+interface RouteContext {
+  params: Promise<{ versionId: string }>
+}
+
+export async function GET(_request: NextRequest, { params }: RouteContext) {
+  try {
+    const { versionId } = await params
+    const supabase = await createClient()
+    const { data: { user } } = await supabase.auth.getUser()
+    if (!user) return NextResponse.json({ error: "Neautorizováno" }, { status: 401 })
+
+    const { data, error } = await supabase
+      .from("team_document_versions")
+      .select("file_path")
+      .eq("id", versionId)
+      .maybeSingle()
+    if (error || !data) {
+      return NextResponse.json({ error: "Verze nenalezena" }, { status: 404 })
+    }
+
+    const url = await getSignedStorageUrl("documents", data.file_path)
+    return NextResponse.redirect(url, 307)
+  } catch (error) {
+    console.error("GET /api/team-documents/versions/[versionId]/open error:", error)
+    return NextResponse.json({ error: "Soubor se nepodařilo otevřít" }, { status: 500 })
+  }
+}

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,6 +1,7 @@
 import type { Metadata, Viewport } from "next";
 import { Poppins, Roboto, Pacifico } from "next/font/google";
 import { ThemeProvider } from "next-themes";
+import NextTopLoader from "nextjs-toploader";
 import { Toaster } from "@/components/ui/sonner";
 import { PostHogProvider } from "./posthog-provider";
 import { PostHogPageView } from "./posthog-pageview";
@@ -75,6 +76,7 @@ export default function RootLayout({
       <body
         className={`${roboto.variable} ${poppins.variable} ${pacifico.variable} font-body antialiased`}
       >
+        <NextTopLoader color="#b31b1b" showSpinner={false} height={3} />
         <PostHogProvider>
           <ThemeProvider
             attribute="class"

--- a/src/components/app-sidebar.tsx
+++ b/src/components/app-sidebar.tsx
@@ -18,6 +18,7 @@ import {
   Activity,
   Wrench,
   Brain,
+  Files,
 } from "lucide-react"
 
 import { cn } from "@/lib/utils"
@@ -105,6 +106,11 @@ const getNavData = (isDevelopment: boolean, _isCoachOrAdmin: boolean, _reviewCou
           icon: Activity,
         },
         {
+          title: "Týmové dokumenty",
+          url: "/tymove-dokumenty",
+          icon: Files,
+        },
+        {
           title: "Nástroje a techniky",
           url: "/nastroje-techniky",
           icon: Wrench,
@@ -167,6 +173,7 @@ function AppSidebarContent({ user, reviewCount = 0 }: { user?: AppSidebarProps["
   const isKoucovaniActive = pathname.startsWith("/koucovani")
   const isTymovaReflexeActive = pathname.startsWith("/tymova-reflexe")
   const isTymovyDenikActive = pathname.startsWith("/tymovy-denik")
+  const isTymoveDokumentyActive = pathname.startsWith("/tymove-dokumenty")
   const isNastrojeTechnikyActive = pathname.startsWith("/nastroje-techniky")
   const isCteniActive = pathname.startsWith("/cteni")
   const cteniSubItems = [
@@ -341,6 +348,32 @@ function AppSidebarContent({ user, reviewCount = 0 }: { user?: AppSidebarProps["
                         <SidebarMenuButton
                           asChild
                           isActive={isTymovyDenikActive}
+                          tooltip={item.title}
+                        >
+                          <Link href={item.url} onClick={closeSidebarOnMobile}>
+                            <item.icon className="size-4" />
+                            <span>{item.title}</span>
+                            <Badge
+                              variant="secondary"
+                              className="ml-auto h-5 text-[10px] px-1.5"
+                            >
+                              Beta
+                            </Badge>
+                          </Link>
+                        </SidebarMenuButton>
+                      </SidebarMenuItem>
+                    )
+                  }
+
+                  // Týmové dokumenty — beta-only
+                  if (item.title === "Týmové dokumenty") {
+                    if (!isBeta) return null
+
+                    return (
+                      <SidebarMenuItem key={item.title}>
+                        <SidebarMenuButton
+                          asChild
+                          isActive={isTymoveDokumentyActive}
                           tooltip={item.title}
                         >
                           <Link href={item.url} onClick={closeSidebarOnMobile}>

--- a/src/components/team-documents/document-upload-form.tsx
+++ b/src/components/team-documents/document-upload-form.tsx
@@ -1,0 +1,201 @@
+"use client"
+
+import { useState } from "react"
+import { Loader2 } from "lucide-react"
+import { toast } from "sonner"
+
+import { Button } from "@/components/ui/button"
+import { Input } from "@/components/ui/input"
+import { Label } from "@/components/ui/label"
+import { Textarea } from "@/components/ui/textarea"
+import { MAX_DOCUMENT_SIZE } from "@/lib/storage/validation"
+import type {
+  TeamDocument,
+  TeamDocumentType,
+  TeamDocumentVersionWithCreator,
+  TeamDocumentWithVersions,
+} from "@/lib/team-documents/types"
+
+const PDF_CONTENT_TYPE = "application/pdf"
+
+interface DocumentUploadFormProps {
+  document: TeamDocumentWithVersions | null
+  documentType: TeamDocumentType
+  onSuccess: (
+    document: TeamDocumentWithVersions,
+    version: TeamDocumentVersionWithCreator,
+  ) => void
+  onCancel: () => void
+}
+
+export function DocumentUploadForm({
+  document,
+  documentType,
+  onSuccess,
+  onCancel,
+}: DocumentUploadFormProps) {
+  const [title, setTitle] = useState("")
+  const [file, setFile] = useState<File | null>(null)
+  const [effectiveFrom, setEffectiveFrom] = useState("")
+  const [changeNote, setChangeNote] = useState("")
+  const [error, setError] = useState<string | null>(null)
+  const [loading, setLoading] = useState(false)
+
+  async function handleSubmit(event: React.FormEvent) {
+    event.preventDefault()
+    setError(null)
+
+    if (documentType === "other" && !document && !title.trim()) {
+      setError("Zadejte název dokumentu.")
+      return
+    }
+    if (!file || file.type !== PDF_CONTENT_TYPE) {
+      setError("Vyberte soubor ve formátu PDF.")
+      return
+    }
+    if (file.size > MAX_DOCUMENT_SIZE) {
+      setError(`Maximální velikost souboru je ${MAX_DOCUMENT_SIZE / 1024 / 1024} MB.`)
+      return
+    }
+
+    setLoading(true)
+    try {
+      let targetDocument = document
+      if (!targetDocument) {
+        const createResponse = await fetch("/api/team-documents", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({
+            docType: documentType,
+            ...(documentType === "other" ? { title: title.trim() } : {}),
+          }),
+        })
+        const createJson = await createResponse.json()
+        if (!createResponse.ok || !createJson.data) {
+          throw new Error(createJson.error ?? "Dokument se nepodařilo vytvořit")
+        }
+        targetDocument = {
+          ...(createJson.data as TeamDocument),
+          versions: [],
+        }
+      }
+
+      const presignResponse = await fetch("/api/storage/presign-upload", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          context: "team-document",
+          entityId: targetDocument.id,
+          contentType: file.type,
+          fileSize: file.size,
+        }),
+      })
+      const presignJson = await presignResponse.json()
+      if (!presignResponse.ok || !presignJson.data) {
+        throw new Error(presignJson.error ?? "Nahrávání se nepodařilo připravit")
+      }
+      const { url, key } = presignJson.data as { url: string; key: string }
+
+      const uploadResponse = await fetch(url, {
+        method: "PUT",
+        headers: { "Content-Type": file.type },
+        body: file,
+      })
+      if (!uploadResponse.ok) throw new Error("Soubor se nepodařilo nahrát")
+
+      const versionResponse = await fetch(`/api/team-documents/${targetDocument.id}/versions`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          key,
+          fileName: file.name,
+          fileSize: file.size,
+          effectiveFrom: effectiveFrom || null,
+          changeNote: changeNote.trim() || null,
+        }),
+      })
+      const versionJson = await versionResponse.json()
+      if (!versionResponse.ok || !versionJson.data) {
+        throw new Error(versionJson.error ?? "Verzi se nepodařilo uložit")
+      }
+
+      onSuccess(targetDocument, versionJson.data as TeamDocumentVersionWithCreator)
+      toast.success(document ? "Nová verze je nahraná" : "Dokument je nahraný")
+    } catch (caughtError) {
+      const message = caughtError instanceof Error
+        ? caughtError.message
+        : "Dokument se nepodařilo nahrát"
+      setError(message)
+      toast.error(message)
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  return (
+    <form onSubmit={handleSubmit} className="space-y-4">
+      {error && (
+        <div className="rounded-md bg-destructive/10 p-3 text-sm text-destructive">
+          {error}
+        </div>
+      )}
+
+      {documentType === "other" && !document && (
+        <div className="space-y-2">
+          <Label htmlFor="team-document-title">Název dokumentu</Label>
+          <Input
+            id="team-document-title"
+            value={title}
+            onChange={(event) => setTitle(event.target.value)}
+            maxLength={120}
+            placeholder="Např. Pravidla porad"
+          />
+        </div>
+      )}
+
+      <div className="space-y-2">
+        <Label htmlFor="team-document-file">Soubor PDF</Label>
+        <Input
+          id="team-document-file"
+          type="file"
+          accept="application/pdf,.pdf"
+          onChange={(event) => setFile(event.target.files?.[0] ?? null)}
+        />
+        <p className="text-xs text-muted-foreground">
+          PDF · max {MAX_DOCUMENT_SIZE / 1024 / 1024} MB
+        </p>
+      </div>
+
+      <div className="space-y-2">
+        <Label htmlFor="team-document-effective-from">Účinnost od (volitelné)</Label>
+        <Input
+          id="team-document-effective-from"
+          type="date"
+          value={effectiveFrom}
+          onChange={(event) => setEffectiveFrom(event.target.value)}
+        />
+      </div>
+
+      <div className="space-y-2">
+        <Label htmlFor="team-document-change-note">Poznámka ke změně (volitelné)</Label>
+        <Textarea
+          id="team-document-change-note"
+          value={changeNote}
+          onChange={(event) => setChangeNote(event.target.value)}
+          maxLength={1000}
+          placeholder="Co se v této verzi změnilo?"
+        />
+      </div>
+
+      <div className="flex justify-end gap-2">
+        <Button type="button" variant="outline" onClick={onCancel} disabled={loading}>
+          Zrušit
+        </Button>
+        <Button type="submit" disabled={loading}>
+          {loading && <Loader2 className="size-4 animate-spin" />}
+          Nahrát verzi
+        </Button>
+      </div>
+    </form>
+  )
+}

--- a/src/components/team-documents/team-document-card.tsx
+++ b/src/components/team-documents/team-document-card.tsx
@@ -26,7 +26,6 @@ import {
   type TeamDocumentType,
   type TeamDocumentWithVersions,
 } from "@/lib/team-documents/types"
-import { cn } from "@/lib/utils"
 
 interface TeamDocumentCardProps {
   document: TeamDocumentWithVersions | null
@@ -54,16 +53,17 @@ export function TeamDocumentCard({
   const title = document
     ? getTeamDocumentTitle(document)
     : getTeamDocumentTitle({ doc_type: documentType, title: null })
+  const Heading = featured ? "h2" : "h3"
 
-  return (
-    <Card className={cn("gap-4 py-5", featured && "bg-accent/40")}>
+  const content = (
+    <>
       <CardHeader className="flex-row items-start justify-between gap-4 px-5">
         <div className="flex min-w-0 gap-3">
           <div className="flex size-10 shrink-0 items-center justify-center rounded-lg bg-primary/10 text-primary">
             <FileText className="size-5" />
           </div>
           <div className="min-w-0 space-y-1">
-            <h2 className="font-heading text-lg font-semibold">{title}</h2>
+            <Heading className="font-heading text-lg font-semibold">{title}</Heading>
             {FEATURED_DESCRIPTIONS[documentType] && (
               <p className="text-sm text-muted-foreground">
                 {FEATURED_DESCRIPTIONS[documentType]}
@@ -76,7 +76,7 @@ export function TeamDocumentCard({
 
       <CardContent className="space-y-4 px-5">
         {latestVersion ? (
-          <div className="rounded-lg border bg-background/80 p-4">
+          <div className="py-2">
             <div className="flex flex-col justify-between gap-3 sm:flex-row sm:items-center">
               <div className="min-w-0">
                 <p className="truncate text-sm font-medium">{latestVersion.file_name}</p>
@@ -99,13 +99,13 @@ export function TeamDocumentCard({
             </div>
           </div>
         ) : (
-          <div className="rounded-lg border border-dashed p-4 text-sm text-muted-foreground">
+          <div className="rounded-md bg-muted/50 px-4 py-3 text-sm text-muted-foreground">
             Zatím není nahraná žádná verze.
           </div>
         )}
 
         {document && document.versions.length > 1 && (
-          <details className="rounded-lg border px-4 py-3">
+          <details className="border-t pt-3">
             <summary className="flex cursor-pointer list-none items-center gap-2 text-sm font-medium">
               <FileClock className="size-4" />
               Historie verzí ({document.versions.length})
@@ -167,6 +167,12 @@ export function TeamDocumentCard({
           )}
         </div>
       </CardContent>
-    </Card>
+    </>
+  )
+
+  return featured ? (
+    <Card className="gap-4 bg-accent/40 py-5">{content}</Card>
+  ) : (
+    <article className="py-5">{content}</article>
   )
 }

--- a/src/components/team-documents/team-document-card.tsx
+++ b/src/components/team-documents/team-document-card.tsx
@@ -1,0 +1,172 @@
+"use client"
+
+import { Archive, FileClock, FileText, Pencil, Upload } from "lucide-react"
+
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+  AlertDialogTrigger,
+} from "@/components/ui/alert-dialog"
+import { Badge } from "@/components/ui/badge"
+import { Button } from "@/components/ui/button"
+import { Card, CardContent, CardHeader } from "@/components/ui/card"
+import {
+  formatDocumentDate,
+  formatDocumentFileSize,
+  formatVersionLabel,
+} from "@/lib/team-documents/format"
+import {
+  getTeamDocumentTitle,
+  type TeamDocumentType,
+  type TeamDocumentWithVersions,
+} from "@/lib/team-documents/types"
+import { cn } from "@/lib/utils"
+
+interface TeamDocumentCardProps {
+  document: TeamDocumentWithVersions | null
+  documentType: TeamDocumentType
+  featured?: boolean
+  onUpload: () => void
+  onRename?: () => void
+  onArchive?: () => void
+}
+
+const FEATURED_DESCRIPTIONS: Partial<Record<TeamDocumentType, string>> = {
+  team_contract: "Společná pravidla, hodnoty a směřování týmu.",
+  financial_policy: "Pravidla finančního řízení a nakládání s penězi.",
+}
+
+export function TeamDocumentCard({
+  document,
+  documentType,
+  featured = false,
+  onUpload,
+  onRename,
+  onArchive,
+}: TeamDocumentCardProps) {
+  const latestVersion = document?.versions[0] ?? null
+  const title = document
+    ? getTeamDocumentTitle(document)
+    : getTeamDocumentTitle({ doc_type: documentType, title: null })
+
+  return (
+    <Card className={cn("gap-4 py-5", featured && "bg-accent/40")}>
+      <CardHeader className="flex-row items-start justify-between gap-4 px-5">
+        <div className="flex min-w-0 gap-3">
+          <div className="flex size-10 shrink-0 items-center justify-center rounded-lg bg-primary/10 text-primary">
+            <FileText className="size-5" />
+          </div>
+          <div className="min-w-0 space-y-1">
+            <h2 className="font-heading text-lg font-semibold">{title}</h2>
+            {FEATURED_DESCRIPTIONS[documentType] && (
+              <p className="text-sm text-muted-foreground">
+                {FEATURED_DESCRIPTIONS[documentType]}
+              </p>
+            )}
+          </div>
+        </div>
+        {latestVersion && <Badge variant="secondary">{formatVersionLabel(latestVersion.version_no)}</Badge>}
+      </CardHeader>
+
+      <CardContent className="space-y-4 px-5">
+        {latestVersion ? (
+          <div className="rounded-lg border bg-background/80 p-4">
+            <div className="flex flex-col justify-between gap-3 sm:flex-row sm:items-center">
+              <div className="min-w-0">
+                <p className="truncate text-sm font-medium">{latestVersion.file_name}</p>
+                <p className="mt-1 text-xs text-muted-foreground">
+                  Nahráno {formatDocumentDate(latestVersion.created_at)}
+                  {latestVersion.created_by?.name ? ` · ${latestVersion.created_by.name}` : ""}
+                  {` · ${formatDocumentFileSize(latestVersion.file_size)}`}
+                </p>
+              </div>
+              <Button asChild size="sm" variant="outline">
+                <a
+                  href={`/api/team-documents/versions/${latestVersion.id}/open`}
+                  target="_blank"
+                  rel="noreferrer"
+                  aria-label="Otevřít aktuální verzi"
+                >
+                  Otevřít
+                </a>
+              </Button>
+            </div>
+          </div>
+        ) : (
+          <div className="rounded-lg border border-dashed p-4 text-sm text-muted-foreground">
+            Zatím není nahraná žádná verze.
+          </div>
+        )}
+
+        {document && document.versions.length > 1 && (
+          <details className="rounded-lg border px-4 py-3">
+            <summary className="flex cursor-pointer list-none items-center gap-2 text-sm font-medium">
+              <FileClock className="size-4" />
+              Historie verzí ({document.versions.length})
+            </summary>
+            <ul className="mt-3 divide-y" aria-label="Historie verzí">
+              {document.versions.map((version) => (
+                <li key={version.id} className="flex items-center justify-between gap-3 py-3 text-sm">
+                  <div className="min-w-0">
+                    <p className="font-medium">{formatVersionLabel(version.version_no)}</p>
+                    <p className="truncate text-xs text-muted-foreground">{version.file_name}</p>
+                  </div>
+                  <Button asChild variant="ghost" size="sm">
+                    <a
+                      href={`/api/team-documents/versions/${version.id}/open`}
+                      target="_blank"
+                      rel="noreferrer"
+                    >
+                      Otevřít
+                    </a>
+                  </Button>
+                </li>
+              ))}
+            </ul>
+          </details>
+        )}
+
+        <div className="flex flex-wrap gap-2">
+          <Button onClick={onUpload} size="sm">
+            <Upload className="size-4" />
+            {document ? "Nahrát novou verzi" : "Nahrát první verzi"}
+          </Button>
+          {documentType === "other" && document && onRename && (
+            <Button onClick={onRename} variant="outline" size="sm" aria-label="Přejmenovat">
+              <Pencil className="size-4" />
+              Přejmenovat
+            </Button>
+          )}
+          {documentType === "other" && document && onArchive && (
+            <AlertDialog>
+              <AlertDialogTrigger asChild>
+                <Button variant="outline" size="sm" aria-label="Archivovat">
+                  <Archive className="size-4" />
+                  Archivovat
+                </Button>
+              </AlertDialogTrigger>
+              <AlertDialogContent>
+                <AlertDialogHeader>
+                  <AlertDialogTitle>Archivovat dokument?</AlertDialogTitle>
+                  <AlertDialogDescription>
+                    Dokument zmizí z přehledu. Jeho soubory a historie verzí zůstanou uložené.
+                  </AlertDialogDescription>
+                </AlertDialogHeader>
+                <AlertDialogFooter>
+                  <AlertDialogCancel>Zrušit</AlertDialogCancel>
+                  <AlertDialogAction onClick={onArchive}>Potvrdit archivaci</AlertDialogAction>
+                </AlertDialogFooter>
+              </AlertDialogContent>
+            </AlertDialog>
+          )}
+        </div>
+      </CardContent>
+    </Card>
+  )
+}

--- a/src/components/team-documents/team-documents.test.tsx
+++ b/src/components/team-documents/team-documents.test.tsx
@@ -1,0 +1,190 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+import { render, screen, waitFor } from "@testing-library/react"
+import userEvent from "@testing-library/user-event"
+
+import { TeamDocuments } from "./team-documents"
+import type { TeamDocumentWithVersions } from "@/lib/team-documents/types"
+
+const { errorToast, successToast } = vi.hoisted(() => ({
+  errorToast: vi.fn(),
+  successToast: vi.fn(),
+}))
+
+vi.mock("sonner", () => ({
+  toast: { error: errorToast, success: successToast },
+}))
+
+const fetchMock = vi.fn()
+
+function documentRow(
+  overrides: Partial<TeamDocumentWithVersions> = {},
+): TeamDocumentWithVersions {
+  return {
+    id: "document-1",
+    team_id: "team-1",
+    doc_type: "other",
+    title: "Pravidla porad",
+    removed_at: null,
+    created_at: "2026-08-19T09:00:00Z",
+    updated_at: "2026-08-19T09:00:00Z",
+    created_by_profile_id: "profile-1",
+    updated_by_profile_id: "profile-1",
+    versions: [],
+    ...overrides,
+  }
+}
+
+beforeEach(() => {
+  vi.stubGlobal("fetch", fetchMock)
+  fetchMock.mockReset()
+  errorToast.mockReset()
+  successToast.mockReset()
+})
+
+afterEach(() => {
+  vi.unstubAllGlobals()
+})
+
+describe("TeamDocuments", () => {
+  it("always renders the two featured document slots", () => {
+    render(<TeamDocuments initialDocuments={[]} teamId="team-1" />)
+
+    expect(screen.getByRole("heading", { name: "Týmová smlouva" })).toBeInTheDocument()
+    expect(screen.getByRole("heading", { name: "Finanční směrnice" })).toBeInTheDocument()
+    expect(screen.getAllByRole("button", { name: "Nahrát první verzi" })).toHaveLength(2)
+    expect(screen.queryByRole("button", { name: "Přejmenovat" })).not.toBeInTheDocument()
+    expect(screen.queryByRole("button", { name: "Archivovat" })).not.toBeInTheDocument()
+  })
+
+  it("lists custom documents and their immutable versions newest first", () => {
+    render(
+      <TeamDocuments
+        teamId="team-1"
+        initialDocuments={[
+          documentRow({
+            versions: [
+              {
+                id: "version-2",
+                document_id: "document-1",
+                version_no: 2,
+                file_path: "team-document/document-1/v2.pdf",
+                file_name: "pravidla-v2.pdf",
+                file_size: 2048,
+                effective_from: "2026-09-01",
+                change_note: "Doplněné role",
+                created_at: "2026-08-19T11:00:00Z",
+                created_by_profile_id: "profile-1",
+                created_by: { id: "profile-1", name: "Alex", picture: null },
+              },
+              {
+                id: "version-1",
+                document_id: "document-1",
+                version_no: 1,
+                file_path: "team-document/document-1/v1.pdf",
+                file_name: "pravidla-v1.pdf",
+                file_size: 1024,
+                effective_from: null,
+                change_note: null,
+                created_at: "2026-08-18T11:00:00Z",
+                created_by_profile_id: "profile-1",
+                created_by: { id: "profile-1", name: "Alex", picture: null },
+              },
+            ],
+          }),
+        ]}
+      />,
+    )
+
+    expect(screen.getByRole("heading", { name: "Pravidla porad" })).toBeInTheDocument()
+    expect(screen.getAllByText("Verze 2").length).toBeGreaterThan(0)
+    expect(screen.getByRole("link", { name: "Otevřít aktuální verzi" })).toHaveAttribute(
+      "href",
+      "/api/team-documents/versions/version-2/open",
+    )
+    expect(screen.getByRole("button", { name: "Přejmenovat" })).toBeInTheDocument()
+    expect(screen.getByRole("button", { name: "Archivovat" })).toBeInTheDocument()
+  })
+
+  it("rejects non-PDF uploads before making a request", async () => {
+    const user = userEvent.setup()
+    render(
+      <TeamDocuments
+        teamId="team-1"
+        initialDocuments={[documentRow()]}
+      />,
+    )
+
+    await user.click(screen.getByRole("button", { name: "Nahrát novou verzi" }))
+    await user.upload(
+      screen.getByLabelText("Soubor PDF"),
+      new File(["image"], "rules.png", { type: "image/png" }),
+    )
+    await user.click(screen.getByRole("button", { name: "Nahrát verzi" }))
+
+    expect(screen.getByText("Vyberte soubor ve formátu PDF.")).toBeInTheDocument()
+    expect(fetchMock).not.toHaveBeenCalled()
+  })
+
+  it("uploads a new version through presign, storage and metadata requests", async () => {
+    fetchMock
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          data: { url: "https://storage.example/upload", key: "team-document/document-1/v2.pdf" },
+        }),
+      })
+      .mockResolvedValueOnce({ ok: true })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          data: {
+            id: "version-2",
+            document_id: "document-1",
+            version_no: 2,
+            file_path: "team-document/document-1/v2.pdf",
+            file_name: "rules.pdf",
+            file_size: 3,
+            effective_from: null,
+            change_note: null,
+            created_at: "2026-08-19T12:00:00Z",
+            created_by_profile_id: "profile-1",
+            created_by: { id: "profile-1", name: "Alex", picture: null },
+          },
+        }),
+      })
+    const user = userEvent.setup()
+    render(<TeamDocuments teamId="team-1" initialDocuments={[documentRow()]} />)
+
+    await user.click(screen.getByRole("button", { name: "Nahrát novou verzi" }))
+    await user.upload(
+      screen.getByLabelText("Soubor PDF"),
+      new File(["pdf"], "rules.pdf", { type: "application/pdf" }),
+    )
+    await user.click(screen.getByRole("button", { name: "Nahrát verzi" }))
+
+    await waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(3))
+    expect(fetchMock.mock.calls[0][0]).toBe("/api/storage/presign-upload")
+    expect(fetchMock.mock.calls[1][0]).toBe("https://storage.example/upload")
+    expect(fetchMock.mock.calls[2][0]).toBe("/api/team-documents/document-1/versions")
+    expect(successToast).toHaveBeenCalledWith("Nová verze je nahraná")
+  })
+
+  it("archives a custom document after confirmation", async () => {
+    fetchMock.mockResolvedValue({ ok: true, json: async () => ({ success: true }) })
+    const user = userEvent.setup()
+    render(<TeamDocuments teamId="team-1" initialDocuments={[documentRow()]} />)
+
+    await user.click(screen.getByRole("button", { name: "Archivovat" }))
+    expect(screen.getByText("Archivovat dokument?")).toBeInTheDocument()
+    await user.click(screen.getByRole("button", { name: "Potvrdit archivaci" }))
+
+    await waitFor(() => {
+      expect(fetchMock).toHaveBeenCalledWith("/api/team-documents/document-1", {
+        method: "DELETE",
+      })
+    })
+    await waitFor(() => {
+      expect(screen.queryByRole("heading", { name: "Pravidla porad" })).not.toBeInTheDocument()
+    })
+  })
+})

--- a/src/components/team-documents/team-documents.test.tsx
+++ b/src/components/team-documents/team-documents.test.tsx
@@ -47,17 +47,26 @@ afterEach(() => {
 
 describe("TeamDocuments", () => {
   it("always renders the two featured document slots", () => {
-    render(<TeamDocuments initialDocuments={[]} teamId="team-1" />)
+    const { container } = render(<TeamDocuments initialDocuments={[]} teamId="team-1" />)
 
     expect(screen.getByRole("heading", { name: "Týmová smlouva" })).toBeInTheDocument()
     expect(screen.getByRole("heading", { name: "Finanční směrnice" })).toBeInTheDocument()
     expect(screen.getAllByRole("button", { name: "Nahrát první verzi" })).toHaveLength(2)
     expect(screen.queryByRole("button", { name: "Přejmenovat" })).not.toBeInTheDocument()
     expect(screen.queryByRole("button", { name: "Archivovat" })).not.toBeInTheDocument()
+    expect(container.querySelectorAll('[data-slot="card"]')).toHaveLength(2)
+    const customEmptyState = screen.getByText("Zatím žádné další dokumenty").closest(
+      '[data-slot="empty"]',
+    )
+    expect(customEmptyState).toBeInTheDocument()
+    expect(customEmptyState).not.toHaveClass("border")
+    for (const emptyVersion of screen.getAllByText("Zatím není nahraná žádná verze.")) {
+      expect(emptyVersion).not.toHaveClass("border", "border-dashed")
+    }
   })
 
   it("lists custom documents and their immutable versions newest first", () => {
-    render(
+    const { container } = render(
       <TeamDocuments
         teamId="team-1"
         initialDocuments={[
@@ -95,12 +104,14 @@ describe("TeamDocuments", () => {
       />,
     )
 
-    expect(screen.getByRole("heading", { name: "Pravidla porad" })).toBeInTheDocument()
+    expect(screen.getByRole("heading", { name: "Pravidla porad", level: 3 })).toBeInTheDocument()
     expect(screen.getAllByText("Verze 2").length).toBeGreaterThan(0)
     expect(screen.getByRole("link", { name: "Otevřít aktuální verzi" })).toHaveAttribute(
       "href",
       "/api/team-documents/versions/version-2/open",
     )
+    expect(container.querySelectorAll("div.border")).toHaveLength(2)
+    expect(screen.getByText("Historie verzí (2)").closest("details")).not.toHaveClass("border")
     expect(screen.getByRole("button", { name: "Přejmenovat" })).toBeInTheDocument()
     expect(screen.getByRole("button", { name: "Archivovat" })).toBeInTheDocument()
   })

--- a/src/components/team-documents/team-documents.tsx
+++ b/src/components/team-documents/team-documents.tsx
@@ -1,0 +1,214 @@
+"use client"
+
+import { useState } from "react"
+import { FolderPlus } from "lucide-react"
+import { toast } from "sonner"
+
+import { DocumentUploadForm } from "./document-upload-form"
+import { TeamDocumentCard } from "./team-document-card"
+import { Button } from "@/components/ui/button"
+import { Input } from "@/components/ui/input"
+import { Label } from "@/components/ui/label"
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/responsive-dialog"
+import {
+  getTeamDocumentTitle,
+  type TeamDocumentType,
+  type TeamDocumentVersionWithCreator,
+  type TeamDocumentWithVersions,
+} from "@/lib/team-documents/types"
+
+interface TeamDocumentsProps {
+  teamId: string
+  initialDocuments: TeamDocumentWithVersions[]
+}
+
+interface UploadTarget {
+  document: TeamDocumentWithVersions | null
+  documentType: TeamDocumentType
+}
+
+const FEATURED_TYPES = ["team_contract", "financial_policy"] as const
+
+export function TeamDocuments({ initialDocuments }: TeamDocumentsProps) {
+  const [documents, setDocuments] = useState(initialDocuments)
+  const [uploadTarget, setUploadTarget] = useState<UploadTarget | null>(null)
+  const [renameDocument, setRenameDocument] = useState<TeamDocumentWithVersions | null>(null)
+  const [renameTitle, setRenameTitle] = useState("")
+  const [renaming, setRenaming] = useState(false)
+
+  function handleVersionUploaded(
+    targetDocument: TeamDocumentWithVersions,
+    version: TeamDocumentVersionWithCreator,
+  ) {
+    setDocuments((current) => {
+      const existing = current.some((document) => document.id === targetDocument.id)
+      if (!existing) return [...current, { ...targetDocument, versions: [version] }]
+      return current.map((document) => document.id === targetDocument.id
+        ? { ...document, versions: [version, ...document.versions] }
+        : document)
+    })
+    setUploadTarget(null)
+  }
+
+  async function handleRename() {
+    if (!renameDocument || !renameTitle.trim()) return
+    setRenaming(true)
+    try {
+      const response = await fetch(`/api/team-documents/${renameDocument.id}`, {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ title: renameTitle.trim() }),
+      })
+      const json = await response.json()
+      if (!response.ok || !json.data) {
+        throw new Error(json.error ?? "Dokument se nepodařilo přejmenovat")
+      }
+      setDocuments((current) => current.map((document) => document.id === renameDocument.id
+        ? { ...document, title: json.data.title }
+        : document))
+      setRenameDocument(null)
+      toast.success("Dokument je přejmenovaný")
+    } catch (error) {
+      toast.error(error instanceof Error ? error.message : "Dokument se nepodařilo přejmenovat")
+    } finally {
+      setRenaming(false)
+    }
+  }
+
+  async function handleArchive(documentId: string) {
+    try {
+      const response = await fetch(`/api/team-documents/${documentId}`, { method: "DELETE" })
+      const json = await response.json()
+      if (!response.ok) throw new Error(json.error ?? "Dokument se nepodařilo archivovat")
+      setDocuments((current) => current.filter((document) => document.id !== documentId))
+      toast.success("Dokument je archivovaný")
+    } catch (error) {
+      toast.error(error instanceof Error ? error.message : "Dokument se nepodařilo archivovat")
+    }
+  }
+
+  const customDocuments = documents.filter((document) => document.doc_type === "other")
+
+  return (
+    <div className="space-y-8">
+      <section className="grid gap-4 lg:grid-cols-2" aria-label="Zvýrazněné dokumenty">
+        {FEATURED_TYPES.map((documentType) => {
+          const document = documents.find((candidate) => candidate.doc_type === documentType) ?? null
+          return (
+            <TeamDocumentCard
+              key={documentType}
+              document={document}
+              documentType={documentType}
+              featured
+              onUpload={() => setUploadTarget({ document, documentType })}
+            />
+          )
+        })}
+      </section>
+
+      <section className="space-y-4" aria-labelledby="other-documents-title">
+        <div className="flex flex-col justify-between gap-3 sm:flex-row sm:items-center">
+          <div>
+            <h2 id="other-documents-title" className="font-heading text-xl font-semibold">
+              Další dokumenty
+            </h2>
+            <p className="text-sm text-muted-foreground">
+              Interní pravidla, zápisy a další důležité týmové soubory.
+            </p>
+          </div>
+          <Button
+            onClick={() => setUploadTarget({ document: null, documentType: "other" })}
+            className="sm:self-start"
+          >
+            <FolderPlus className="size-4" />
+            Přidat dokument
+          </Button>
+        </div>
+
+        {customDocuments.length ? (
+          <div className="grid gap-4">
+            {customDocuments.map((document) => (
+              <TeamDocumentCard
+                key={document.id}
+                document={document}
+                documentType="other"
+                onUpload={() => setUploadTarget({ document, documentType: "other" })}
+                onRename={() => {
+                  setRenameTitle(document.title ?? "")
+                  setRenameDocument(document)
+                }}
+                onArchive={() => handleArchive(document.id)}
+              />
+            ))}
+          </div>
+        ) : (
+          <div className="rounded-xl border border-dashed p-8 text-center">
+            <p className="font-medium">Zatím žádné další dokumenty</p>
+            <p className="mt-1 text-sm text-muted-foreground">
+              Přidejte první PDF, které má mít tým po ruce.
+            </p>
+          </div>
+        )}
+      </section>
+
+      <Dialog open={uploadTarget !== null} onOpenChange={(open) => !open && setUploadTarget(null)}>
+        <DialogContent className="sm:max-w-lg">
+          <DialogHeader>
+            <DialogTitle>
+              {uploadTarget?.document
+                ? `Nová verze · ${getTeamDocumentTitle(uploadTarget.document)}`
+                : uploadTarget?.documentType === "other"
+                  ? "Přidat dokument"
+                  : "Nahrát první verzi"}
+            </DialogTitle>
+            <DialogDescription>
+              Každé nahrání vytvoří samostatnou verzi. Starší verze zůstanou dostupné.
+            </DialogDescription>
+          </DialogHeader>
+          {uploadTarget && (
+            <DocumentUploadForm
+              document={uploadTarget.document}
+              documentType={uploadTarget.documentType}
+              onSuccess={handleVersionUploaded}
+              onCancel={() => setUploadTarget(null)}
+            />
+          )}
+        </DialogContent>
+      </Dialog>
+
+      <Dialog open={renameDocument !== null} onOpenChange={(open) => !open && setRenameDocument(null)}>
+        <DialogContent className="sm:max-w-md">
+          <DialogHeader>
+            <DialogTitle>Přejmenovat dokument</DialogTitle>
+            <DialogDescription>Změna názvu neovlivní uložené verze.</DialogDescription>
+          </DialogHeader>
+          <div className="space-y-4">
+            <div className="space-y-2">
+              <Label htmlFor="rename-team-document">Název dokumentu</Label>
+              <Input
+                id="rename-team-document"
+                value={renameTitle}
+                onChange={(event) => setRenameTitle(event.target.value)}
+                maxLength={120}
+              />
+            </div>
+            <div className="flex justify-end gap-2">
+              <Button variant="outline" onClick={() => setRenameDocument(null)} disabled={renaming}>
+                Zrušit
+              </Button>
+              <Button onClick={handleRename} disabled={renaming || !renameTitle.trim()}>
+                Uložit název
+              </Button>
+            </div>
+          </div>
+        </DialogContent>
+      </Dialog>
+    </div>
+  )
+}

--- a/src/components/team-documents/team-documents.tsx
+++ b/src/components/team-documents/team-documents.tsx
@@ -7,6 +7,7 @@ import { toast } from "sonner"
 import { DocumentUploadForm } from "./document-upload-form"
 import { TeamDocumentCard } from "./team-document-card"
 import { Button } from "@/components/ui/button"
+import { Empty, EmptyDescription, EmptyHeader, EmptyTitle } from "@/components/ui/empty"
 import { Input } from "@/components/ui/input"
 import { Label } from "@/components/ui/label"
 import {
@@ -132,7 +133,7 @@ export function TeamDocuments({ initialDocuments }: TeamDocumentsProps) {
         </div>
 
         {customDocuments.length ? (
-          <div className="grid gap-4">
+          <div className="divide-y">
             {customDocuments.map((document) => (
               <TeamDocumentCard
                 key={document.id}
@@ -148,12 +149,14 @@ export function TeamDocuments({ initialDocuments }: TeamDocumentsProps) {
             ))}
           </div>
         ) : (
-          <div className="rounded-xl border border-dashed p-8 text-center">
-            <p className="font-medium">Zatím žádné další dokumenty</p>
-            <p className="mt-1 text-sm text-muted-foreground">
+          <Empty className="bg-muted/40 py-10">
+            <EmptyHeader>
+              <EmptyTitle>Zatím žádné další dokumenty</EmptyTitle>
+              <EmptyDescription>
               Přidejte první PDF, které má mít tým po ruce.
-            </p>
-          </div>
+              </EmptyDescription>
+            </EmptyHeader>
+          </Empty>
         )}
       </section>
 

--- a/src/lib/storage/buckets.ts
+++ b/src/lib/storage/buckets.ts
@@ -38,6 +38,7 @@ export function contextToBucket(context: StorageContext): BucketId {
     case "book":
       return "images";
     case "personality-test":
+    case "team-document":
       return "documents";
   }
 }

--- a/src/lib/storage/types.ts
+++ b/src/lib/storage/types.ts
@@ -2,7 +2,12 @@
  * Storage Types for Supabase Storage S3 Integration
  */
 
-export type StorageContext = "profile" | "team" | "book" | "personality-test";
+export type StorageContext =
+  | "profile"
+  | "team"
+  | "book"
+  | "personality-test"
+  | "team-document";
 
 export interface UploadOptions {
   context: StorageContext;

--- a/src/lib/storage/validation.test.ts
+++ b/src/lib/storage/validation.test.ts
@@ -3,6 +3,7 @@ import {
   ALLOWED_DOCUMENT_TYPES,
   MAX_DOCUMENT_SIZE,
   validatePersonalityTestUpload,
+  validateTeamDocumentUpload,
 } from "./validation"
 
 describe("validatePersonalityTestUpload", () => {
@@ -20,6 +21,33 @@ describe("validatePersonalityTestUpload", () => {
 
   it("rejects files over the size limit", () => {
     expect(validatePersonalityTestUpload("application/pdf", MAX_DOCUMENT_SIZE + 1)).toMatchObject({
+      field: "fileSize",
+    })
+  })
+})
+
+describe("validateTeamDocumentUpload", () => {
+  it("accepts PDF files at the size limit", () => {
+    expect(validateTeamDocumentUpload("application/pdf", MAX_DOCUMENT_SIZE)).toBeNull()
+  })
+
+  it("rejects non-PDF document and image types", () => {
+    expect(validateTeamDocumentUpload("image/png", 1024)).toMatchObject({
+      field: "contentType",
+    })
+    expect(
+      validateTeamDocumentUpload(
+        "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+        1024,
+      ),
+    ).toMatchObject({ field: "contentType" })
+  })
+
+  it("rejects empty and oversized files", () => {
+    expect(validateTeamDocumentUpload("application/pdf", 0)).toMatchObject({
+      field: "fileSize",
+    })
+    expect(validateTeamDocumentUpload("application/pdf", MAX_DOCUMENT_SIZE + 1)).toMatchObject({
       field: "fileSize",
     })
   })

--- a/src/lib/storage/validation.ts
+++ b/src/lib/storage/validation.ts
@@ -79,6 +79,30 @@ export function validatePersonalityTestUpload(
 }
 
 /**
+ * Validate versioned team documents, which deliberately support PDF only.
+ */
+export function validateTeamDocumentUpload(
+  contentType: string,
+  fileSize: number
+): ValidationError | null {
+  if (contentType !== "application/pdf") {
+    return {
+      field: "contentType",
+      message: "Povolený formát: PDF",
+    };
+  }
+
+  if (!Number.isFinite(fileSize) || fileSize <= 0 || fileSize > MAX_DOCUMENT_SIZE) {
+    return {
+      field: "fileSize",
+      message: `Maximální velikost souboru je ${MAX_DOCUMENT_SIZE / 1024 / 1024}MB`,
+    };
+  }
+
+  return null;
+}
+
+/**
  * Get file extension from MIME type
  */
 export function getFileExtension(contentType: string): string {

--- a/src/lib/supabase/database.types.ts
+++ b/src/lib/supabase/database.types.ts
@@ -1579,6 +1579,118 @@ export type Database = {
           },
         ]
       }
+      team_document_versions: {
+        Row: {
+          change_note: string | null
+          created_at: string
+          created_by_profile_id: string
+          document_id: string
+          effective_from: string | null
+          file_name: string
+          file_path: string
+          file_size: number
+          id: string
+          version_no: number
+        }
+        Insert: {
+          change_note?: string | null
+          created_at?: string
+          created_by_profile_id: string
+          document_id: string
+          effective_from?: string | null
+          file_name: string
+          file_path: string
+          file_size: number
+          id?: string
+          version_no: number
+        }
+        Update: {
+          change_note?: string | null
+          created_at?: string
+          created_by_profile_id?: string
+          document_id?: string
+          effective_from?: string | null
+          file_name?: string
+          file_path?: string
+          file_size?: number
+          id?: string
+          version_no?: number
+        }
+        Relationships: [
+          {
+            foreignKeyName: "team_document_versions_created_by_profile_id_fkey"
+            columns: ["created_by_profile_id"]
+            isOneToOne: false
+            referencedRelation: "profiles"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "team_document_versions_document_id_fkey"
+            columns: ["document_id"]
+            isOneToOne: false
+            referencedRelation: "team_documents"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
+      team_documents: {
+        Row: {
+          created_at: string
+          created_by_profile_id: string
+          doc_type: Database["public"]["Enums"]["team_document_type"]
+          id: string
+          removed_at: string | null
+          team_id: string
+          title: string | null
+          updated_at: string
+          updated_by_profile_id: string
+        }
+        Insert: {
+          created_at?: string
+          created_by_profile_id: string
+          doc_type: Database["public"]["Enums"]["team_document_type"]
+          id?: string
+          removed_at?: string | null
+          team_id: string
+          title?: string | null
+          updated_at?: string
+          updated_by_profile_id: string
+        }
+        Update: {
+          created_at?: string
+          created_by_profile_id?: string
+          doc_type?: Database["public"]["Enums"]["team_document_type"]
+          id?: string
+          removed_at?: string | null
+          team_id?: string
+          title?: string | null
+          updated_at?: string
+          updated_by_profile_id?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "team_documents_created_by_profile_id_fkey"
+            columns: ["created_by_profile_id"]
+            isOneToOne: false
+            referencedRelation: "profiles"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "team_documents_team_id_fkey"
+            columns: ["team_id"]
+            isOneToOne: false
+            referencedRelation: "teams"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "team_documents_updated_by_profile_id_fkey"
+            columns: ["updated_by_profile_id"]
+            isOneToOne: false
+            referencedRelation: "profiles"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
       team_reflections: {
         Row: {
           created_at: string
@@ -2027,6 +2139,7 @@ export type Database = {
         | "komunitni_a_cross_projekty"
         | "zacleneni_tucnaku"
         | "dalsi"
+      team_document_type: "team_contract" | "financial_policy" | "other"
       tool_type: "model" | "technique" | "tool"
     }
     CompositeTypes: {
@@ -2181,6 +2294,7 @@ export const Constants = {
         "zacleneni_tucnaku",
         "dalsi",
       ],
+      team_document_type: ["team_contract", "financial_policy", "other"],
       tool_type: ["model", "technique", "tool"],
     },
   },

--- a/src/lib/team-documents/format.test.ts
+++ b/src/lib/team-documents/format.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from "vitest"
+
+import {
+  formatDocumentDate,
+  formatDocumentFileSize,
+  formatVersionLabel,
+} from "./format"
+import { getTeamDocumentTitle } from "./types"
+
+describe("team document format helpers", () => {
+  it("formats dates in Czech numeric form", () => {
+    expect(formatDocumentDate("2026-08-19")).toBe("19. 8. 2026")
+  })
+
+  it("formats file sizes with a Czech decimal comma", () => {
+    expect(formatDocumentFileSize(512)).toBe("512 B")
+    expect(formatDocumentFileSize(2048)).toBe("2 KB")
+    expect(formatDocumentFileSize(2.5 * 1024 * 1024)).toBe("2,5 MB")
+  })
+
+  it("formats a numbered version label", () => {
+    expect(formatVersionLabel(3)).toBe("Verze 3")
+  })
+})
+
+describe("team document titles", () => {
+  it("uses fixed titles for featured document types", () => {
+    expect(getTeamDocumentTitle({ doc_type: "team_contract", title: null })).toBe(
+      "Týmová smlouva",
+    )
+    expect(getTeamDocumentTitle({ doc_type: "financial_policy", title: null })).toBe(
+      "Finanční směrnice",
+    )
+  })
+
+  it("uses the supplied custom document title", () => {
+    expect(getTeamDocumentTitle({ doc_type: "other", title: "Pravidla porad" })).toBe(
+      "Pravidla porad",
+    )
+  })
+})

--- a/src/lib/team-documents/format.ts
+++ b/src/lib/team-documents/format.ts
@@ -1,0 +1,17 @@
+export function formatDocumentDate(dateString: string): string {
+  const [year, month, day] = dateString.slice(0, 10).split("-")
+  return `${Number(day)}. ${Number(month)}. ${year}`
+}
+
+export function formatDocumentFileSize(bytes: number): string {
+  const KILOBYTE = 1024
+  const MEGABYTE = KILOBYTE * KILOBYTE
+
+  if (bytes < KILOBYTE) return `${bytes} B`
+  if (bytes < MEGABYTE) return `${Math.round(bytes / KILOBYTE)} KB`
+  return `${(bytes / MEGABYTE).toFixed(1).replace(".", ",")} MB`
+}
+
+export function formatVersionLabel(versionNumber: number): string {
+  return `Verze ${versionNumber}`
+}

--- a/src/lib/team-documents/queries.ts
+++ b/src/lib/team-documents/queries.ts
@@ -1,0 +1,45 @@
+import type { SupabaseClient } from "@supabase/supabase-js"
+
+import type { Database } from "@/lib/supabase/database.types"
+import {
+  TEAM_DOCUMENT_VERSION_WITH_CREATOR_SELECT,
+  type TeamDocument,
+  type TeamDocumentVersionWithCreator,
+  type TeamDocumentWithVersions,
+} from "./types"
+
+export async function listTeamDocuments(
+  supabase: SupabaseClient<Database>,
+  teamId: string,
+): Promise<TeamDocumentWithVersions[]> {
+  const { data: documents, error: documentsError } = await supabase
+    .from("team_documents")
+    .select("*")
+    .eq("team_id", teamId)
+    .is("removed_at", null)
+    .order("created_at", { ascending: true })
+
+  if (documentsError) throw documentsError
+  if (!documents?.length) return []
+
+  const documentRows = documents as TeamDocument[]
+  const { data: versions, error: versionsError } = await supabase
+    .from("team_document_versions")
+    .select(TEAM_DOCUMENT_VERSION_WITH_CREATOR_SELECT)
+    .in("document_id", documentRows.map((document) => document.id))
+    .order("version_no", { ascending: false })
+
+  if (versionsError) throw versionsError
+
+  const versionsByDocument = new Map<string, TeamDocumentVersionWithCreator[]>()
+  for (const version of (versions ?? []) as TeamDocumentVersionWithCreator[]) {
+    const documentVersions = versionsByDocument.get(version.document_id) ?? []
+    documentVersions.push(version)
+    versionsByDocument.set(version.document_id, documentVersions)
+  }
+
+  return documentRows.map((document) => ({
+    ...document,
+    versions: versionsByDocument.get(document.id) ?? [],
+  }))
+}

--- a/src/lib/team-documents/types.ts
+++ b/src/lib/team-documents/types.ts
@@ -1,0 +1,38 @@
+import type { Profile } from "@/lib/auth-helpers"
+import type { Database } from "@/lib/supabase/database.types"
+import type { Tables } from "@/lib/supabase/tables"
+
+export type TeamDocument = Tables<"team_documents">
+export type TeamDocumentVersion = Tables<"team_document_versions">
+export type TeamDocumentType = Database["public"]["Enums"]["team_document_type"]
+
+export interface TeamDocumentVersionWithCreator extends TeamDocumentVersion {
+  created_by: Pick<Profile, "id" | "name" | "picture"> | null
+}
+
+export interface TeamDocumentWithVersions extends TeamDocument {
+  versions: TeamDocumentVersionWithCreator[]
+}
+
+export const TEAM_DOCUMENT_TYPES = [
+  "team_contract",
+  "financial_policy",
+  "other",
+] as const satisfies readonly TeamDocumentType[]
+
+export const TEAM_DOCUMENT_TYPE_LABELS: Record<TeamDocumentType, string> = {
+  team_contract: "Týmová smlouva",
+  financial_policy: "Finanční směrnice",
+  other: "Další dokument",
+}
+
+export const TEAM_DOCUMENT_VERSION_WITH_CREATOR_SELECT =
+  "*, created_by:profiles!created_by_profile_id(id, name, picture)"
+
+export function getTeamDocumentTitle(
+  document: Pick<TeamDocument, "doc_type" | "title">,
+): string {
+  return document.doc_type === "other"
+    ? document.title ?? TEAM_DOCUMENT_TYPE_LABELS.other
+    : TEAM_DOCUMENT_TYPE_LABELS[document.doc_type]
+}

--- a/src/lib/team-documents/validation.test.ts
+++ b/src/lib/team-documents/validation.test.ts
@@ -1,0 +1,99 @@
+import { describe, expect, it } from "vitest"
+
+import {
+  validateCreateDocumentInput,
+  validateVersionInput,
+} from "./validation"
+
+describe("validateCreateDocumentInput", () => {
+  it("accepts featured documents without a title", () => {
+    expect(validateCreateDocumentInput({ docType: "team_contract" })).toEqual({
+      data: { docType: "team_contract", title: null },
+    })
+  })
+
+  it("trims custom titles and rejects missing titles", () => {
+    expect(
+      validateCreateDocumentInput({ docType: "other", title: "  Pravidla porad  " }),
+    ).toEqual({ data: { docType: "other", title: "Pravidla porad" } })
+    expect(validateCreateDocumentInput({ docType: "other", title: "   " })).toEqual({
+      error: "Zadejte název dokumentu",
+    })
+  })
+
+  it("rejects unknown types and titles on featured documents", () => {
+    expect(validateCreateDocumentInput({ docType: "minutes" })).toHaveProperty("error")
+    expect(
+      validateCreateDocumentInput({ docType: "financial_policy", title: "Rozpočet" }),
+    ).toHaveProperty("error")
+  })
+})
+
+describe("validateVersionInput", () => {
+  const documentId = "document-1"
+
+  it("normalizes valid version metadata", () => {
+    expect(
+      validateVersionInput(
+        {
+          key: "team-document/document-1/version.pdf",
+          fileName: " contract.pdf ",
+          fileSize: 2048,
+          effectiveFrom: "2026-09-01",
+          changeNote: "  Nová pravidla  ",
+        },
+        documentId,
+      ),
+    ).toEqual({
+      data: {
+        key: "team-document/document-1/version.pdf",
+        fileName: "contract.pdf",
+        fileSize: 2048,
+        effectiveFrom: "2026-09-01",
+        changeNote: "Nová pravidla",
+      },
+    })
+  })
+
+  it("rejects keys outside the document folder", () => {
+    expect(
+      validateVersionInput(
+        {
+          key: "team-document/other-document/version.pdf",
+          fileName: "contract.pdf",
+          fileSize: 2048,
+        },
+        documentId,
+      ),
+    ).toHaveProperty("error")
+  })
+
+  it("rejects invalid file metadata and dates", () => {
+    expect(
+      validateVersionInput(
+        {
+          key: "team-document/document-1/version.pdf",
+          fileName: "",
+          fileSize: 0,
+          effectiveFrom: "1. 9. 2026",
+        },
+        documentId,
+      ),
+    ).toHaveProperty("error")
+  })
+
+  it("normalizes omitted optional metadata to null", () => {
+    expect(
+      validateVersionInput(
+        {
+          key: "team-document/document-1/version.pdf",
+          fileName: "contract.pdf",
+          fileSize: 2048,
+        },
+        documentId,
+      ),
+    ).toMatchObject({
+      data: { effectiveFrom: null, changeNote: null },
+    })
+  })
+})

--- a/src/lib/team-documents/validation.ts
+++ b/src/lib/team-documents/validation.ts
@@ -1,0 +1,108 @@
+import { MAX_DOCUMENT_SIZE } from "@/lib/storage/validation"
+import { TEAM_DOCUMENT_TYPES, type TeamDocumentType } from "./types"
+
+const MAX_DOCUMENT_TITLE_LENGTH = 120
+const MAX_FILE_NAME_LENGTH = 255
+const MAX_CHANGE_NOTE_LENGTH = 1000
+const DATE_PATTERN = /^\d{4}-\d{2}-\d{2}$/
+
+interface CreateDocumentInput {
+  docType: TeamDocumentType
+  title: string | null
+}
+
+interface VersionInput {
+  key: string
+  fileName: string
+  fileSize: number
+  effectiveFrom: string | null
+  changeNote: string | null
+}
+
+interface ValidationSuccess<T> {
+  data: T
+}
+
+interface ValidationFailure {
+  error: string
+}
+
+type ValidationResult<T> = ValidationSuccess<T> | ValidationFailure
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null
+}
+
+export function validateCreateDocumentInput(
+  input: unknown,
+): ValidationResult<CreateDocumentInput> {
+  if (!isRecord(input) || typeof input.docType !== "string") {
+    return { error: "Vyberte typ dokumentu" }
+  }
+  if (!(TEAM_DOCUMENT_TYPES as readonly string[]).includes(input.docType)) {
+    return { error: "Neplatný typ dokumentu" }
+  }
+
+  const docType = input.docType as TeamDocumentType
+  if (docType !== "other") {
+    if (input.title !== undefined && input.title !== null) {
+      return { error: "Název zvýrazněného dokumentu nelze změnit" }
+    }
+    return { data: { docType, title: null } }
+  }
+
+  const title = typeof input.title === "string" ? input.title.trim() : ""
+  if (!title) return { error: "Zadejte název dokumentu" }
+  if (title.length > MAX_DOCUMENT_TITLE_LENGTH) {
+    return { error: `Název může mít nejvýše ${MAX_DOCUMENT_TITLE_LENGTH} znaků` }
+  }
+
+  return { data: { docType, title } }
+}
+
+export function validateVersionInput(
+  input: unknown,
+  documentId: string,
+): ValidationResult<VersionInput> {
+  if (!isRecord(input)) return { error: "Chybí údaje o verzi" }
+
+  const expectedKeyPrefix = `team-document/${documentId}/`
+  if (typeof input.key !== "string" || !input.key.startsWith(expectedKeyPrefix)) {
+    return { error: "Neplatný klíč souboru" }
+  }
+
+  const fileName = typeof input.fileName === "string" ? input.fileName.trim() : ""
+  if (!fileName || fileName.length > MAX_FILE_NAME_LENGTH) {
+    return { error: "Neplatný název souboru" }
+  }
+  if (
+    typeof input.fileSize !== "number"
+    || !Number.isFinite(input.fileSize)
+    || input.fileSize <= 0
+    || input.fileSize > MAX_DOCUMENT_SIZE
+  ) {
+    return { error: "Neplatná velikost souboru" }
+  }
+
+  const effectiveFrom = typeof input.effectiveFrom === "string"
+    ? input.effectiveFrom.trim()
+    : ""
+  if (effectiveFrom && !DATE_PATTERN.test(effectiveFrom)) {
+    return { error: "Neplatné datum účinnosti" }
+  }
+
+  const changeNote = typeof input.changeNote === "string" ? input.changeNote.trim() : ""
+  if (changeNote.length > MAX_CHANGE_NOTE_LENGTH) {
+    return { error: `Poznámka může mít nejvýše ${MAX_CHANGE_NOTE_LENGTH} znaků` }
+  }
+
+  return {
+    data: {
+      key: input.key,
+      fileName,
+      fileSize: input.fileSize,
+      effectiveFrom: effectiveFrom || null,
+      changeNote: changeNote || null,
+    },
+  }
+}

--- a/supabase/migrations/20260818230449_aspiring_meggan.sql
+++ b/supabase/migrations/20260818230449_aspiring_meggan.sql
@@ -1,0 +1,59 @@
+CREATE TYPE "public"."team_document_type" AS ENUM('team_contract', 'financial_policy', 'other');--> statement-breakpoint
+CREATE TABLE "team_document_versions" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"document_id" uuid NOT NULL,
+	"version_no" integer NOT NULL,
+	"file_path" text NOT NULL,
+	"file_name" text NOT NULL,
+	"file_size" integer NOT NULL,
+	"effective_from" date,
+	"change_note" text,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"created_by_profile_id" uuid NOT NULL,
+	CONSTRAINT "team_document_versions_version_positive" CHECK (version_no > 0),
+	CONSTRAINT "team_document_versions_file_size_positive" CHECK (file_size > 0)
+);
+--> statement-breakpoint
+ALTER TABLE "team_document_versions" ENABLE ROW LEVEL SECURITY;--> statement-breakpoint
+CREATE TABLE "team_documents" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"team_id" uuid NOT NULL,
+	"doc_type" "team_document_type" NOT NULL,
+	"title" text,
+	"removed_at" timestamp with time zone,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"updated_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"created_by_profile_id" uuid NOT NULL,
+	"updated_by_profile_id" uuid NOT NULL,
+	CONSTRAINT "team_documents_title_matches_type" CHECK ((
+		(doc_type = 'other' AND title IS NOT NULL AND length(trim(title)) > 0)
+		OR (doc_type <> 'other' AND title IS NULL)
+	))
+);
+--> statement-breakpoint
+ALTER TABLE "team_documents" ENABLE ROW LEVEL SECURITY;--> statement-breakpoint
+ALTER TABLE "team_document_versions" ADD CONSTRAINT "team_document_versions_document_id_fkey" FOREIGN KEY ("document_id") REFERENCES "public"."team_documents"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "team_document_versions" ADD CONSTRAINT "team_document_versions_created_by_profile_id_fkey" FOREIGN KEY ("created_by_profile_id") REFERENCES "public"."profiles"("id") ON DELETE restrict ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "team_documents" ADD CONSTRAINT "team_documents_team_id_fkey" FOREIGN KEY ("team_id") REFERENCES "public"."teams"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "team_documents" ADD CONSTRAINT "team_documents_created_by_profile_id_fkey" FOREIGN KEY ("created_by_profile_id") REFERENCES "public"."profiles"("id") ON DELETE restrict ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "team_documents" ADD CONSTRAINT "team_documents_updated_by_profile_id_fkey" FOREIGN KEY ("updated_by_profile_id") REFERENCES "public"."profiles"("id") ON DELETE restrict ON UPDATE no action;--> statement-breakpoint
+CREATE UNIQUE INDEX "team_document_versions_document_version_idx" ON "team_document_versions" USING btree ("document_id" uuid_ops,"version_no" int4_ops);--> statement-breakpoint
+CREATE UNIQUE INDEX "team_documents_featured_team_type_idx" ON "team_documents" USING btree ("team_id" uuid_ops,"doc_type" enum_ops) WHERE doc_type IN ('team_contract', 'financial_policy') AND removed_at IS NULL;--> statement-breakpoint
+CREATE POLICY "Team members can view document versions" ON "team_document_versions" AS PERMISSIVE FOR SELECT TO "authenticated" USING (document_id IN (
+			SELECT team_documents.id
+			FROM team_documents
+			WHERE team_documents.team_id IN (
+				SELECT team_id FROM profiles WHERE id = current_profile_id() AND access_removed_at IS NULL
+			)
+		));--> statement-breakpoint
+CREATE POLICY "Team members can create document versions" ON "team_document_versions" AS PERMISSIVE FOR INSERT TO "authenticated" WITH CHECK (created_by_profile_id = current_profile_id() AND document_id IN (
+			SELECT team_documents.id
+			FROM team_documents
+			WHERE team_documents.removed_at IS NULL
+				AND team_documents.team_id IN (
+					SELECT team_id FROM profiles WHERE id = current_profile_id() AND access_removed_at IS NULL
+				)
+		));--> statement-breakpoint
+CREATE POLICY "Team members can view documents" ON "team_documents" AS PERMISSIVE FOR SELECT TO "authenticated" USING (team_id IN (SELECT team_id FROM profiles WHERE id = current_profile_id() AND access_removed_at IS NULL));--> statement-breakpoint
+CREATE POLICY "Team members can create documents" ON "team_documents" AS PERMISSIVE FOR INSERT TO "authenticated" WITH CHECK (team_id IN (SELECT team_id FROM profiles WHERE id = current_profile_id() AND access_removed_at IS NULL) AND created_by_profile_id = current_profile_id() AND updated_by_profile_id = current_profile_id());--> statement-breakpoint
+CREATE POLICY "Team members can update custom documents" ON "team_documents" AS PERMISSIVE FOR UPDATE TO "authenticated" USING (doc_type = 'other' AND team_id IN (SELECT team_id FROM profiles WHERE id = current_profile_id() AND access_removed_at IS NULL)) WITH CHECK (doc_type = 'other' AND team_id IN (SELECT team_id FROM profiles WHERE id = current_profile_id() AND access_removed_at IS NULL) AND updated_by_profile_id = current_profile_id());

--- a/supabase/migrations/20260818230458_careless_killmonger.sql
+++ b/supabase/migrations/20260818230458_careless_killmonger.sql
@@ -1,0 +1,9 @@
+-- Custom SQL migration file, put your code below! --
+
+-- Keep mutable document metadata timestamps consistent with the rest of the app.
+drop trigger if exists team_documents_updated_at_trigger on public.team_documents;
+
+create trigger team_documents_updated_at_trigger
+before update on public.team_documents
+for each row
+execute function public.handle_updated_at();

--- a/supabase/migrations/meta/20260818230449_snapshot.json
+++ b/supabase/migrations/meta/20260818230449_snapshot.json
@@ -1,0 +1,6164 @@
+{
+  "id": "4fc2edb9-1220-45f1-96c8-e1089b745b81",
+  "prevId": "31159044-1747-4a04-804d-a931817faf2d",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.book_loans": {
+      "name": "book_loans",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "library_book_id": {
+          "name": "library_book_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "borrower_id": {
+          "name": "borrower_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "borrowed_at": {
+          "name": "borrowed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "due_at": {
+          "name": "due_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "returned_at": {
+          "name": "returned_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "book_loans_library_book_id_idx": {
+          "name": "book_loans_library_book_id_idx",
+          "columns": [
+            {
+              "expression": "library_book_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "uuid_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "book_loans_borrower_id_idx": {
+          "name": "book_loans_borrower_id_idx",
+          "columns": [
+            {
+              "expression": "borrower_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "uuid_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "book_loans_active_idx": {
+          "name": "book_loans_active_idx",
+          "columns": [
+            {
+              "expression": "library_book_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "uuid_ops"
+            }
+          ],
+          "isUnique": false,
+          "where": "(returned_at IS NULL)",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "book_loans_library_book_id_fkey": {
+          "name": "book_loans_library_book_id_fkey",
+          "tableFrom": "book_loans",
+          "tableTo": "library_books",
+          "columnsFrom": [
+            "library_book_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "book_loans_borrower_id_fkey": {
+          "name": "book_loans_borrower_id_fkey",
+          "tableFrom": "book_loans",
+          "tableTo": "profiles",
+          "columnsFrom": [
+            "borrower_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {
+        "Authenticated users can view loans": {
+          "name": "Authenticated users can view loans",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": [
+            "authenticated"
+          ],
+          "using": "true"
+        },
+        "Users can borrow for themselves": {
+          "name": "Users can borrow for themselves",
+          "as": "PERMISSIVE",
+          "for": "INSERT",
+          "to": [
+            "authenticated"
+          ],
+          "withCheck": "(borrower_id = current_profile_id())"
+        },
+        "Borrower can return their own loan": {
+          "name": "Borrower can return their own loan",
+          "as": "PERMISSIVE",
+          "for": "UPDATE",
+          "to": [
+            "authenticated"
+          ],
+          "using": "(borrower_id = current_profile_id())",
+          "withCheck": "(borrower_id = current_profile_id())"
+        }
+      },
+      "checkConstraints": {},
+      "isRLSEnabled": true
+    },
+    "public.book_tags": {
+      "name": "book_tags",
+      "schema": "",
+      "columns": {
+        "book_id": {
+          "name": "book_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tag_id": {
+          "name": "tag_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_by_profile_id": {
+          "name": "created_by_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_by_profile_id": {
+          "name": "updated_by_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "book_tags_tag_idx": {
+          "name": "book_tags_tag_idx",
+          "columns": [
+            {
+              "expression": "tag_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "uuid_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "book_tags_book_id_fkey": {
+          "name": "book_tags_book_id_fkey",
+          "tableFrom": "book_tags",
+          "tableTo": "books",
+          "columnsFrom": [
+            "book_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "book_tags_tag_id_fkey": {
+          "name": "book_tags_tag_id_fkey",
+          "tableFrom": "book_tags",
+          "tableTo": "tags",
+          "columnsFrom": [
+            "tag_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "book_tags_created_by_profile_id_fkey": {
+          "name": "book_tags_created_by_profile_id_fkey",
+          "tableFrom": "book_tags",
+          "tableTo": "profiles",
+          "columnsFrom": [
+            "created_by_profile_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "book_tags_updated_by_profile_id_fkey": {
+          "name": "book_tags_updated_by_profile_id_fkey",
+          "tableFrom": "book_tags",
+          "tableTo": "profiles",
+          "columnsFrom": [
+            "updated_by_profile_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "book_tags_pkey": {
+          "name": "book_tags_pkey",
+          "columns": [
+            "book_id",
+            "tag_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {
+        "Authenticated users can view book tags": {
+          "name": "Authenticated users can view book tags",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": [
+            "authenticated"
+          ],
+          "using": "true"
+        },
+        "Authenticated users can assign book tags": {
+          "name": "Authenticated users can assign book tags",
+          "as": "PERMISSIVE",
+          "for": "INSERT",
+          "to": [
+            "authenticated"
+          ],
+          "withCheck": "(created_by_profile_id = current_profile_id())"
+        },
+        "Coaches and admins can update book tags": {
+          "name": "Coaches and admins can update book tags",
+          "as": "PERMISSIVE",
+          "for": "UPDATE",
+          "to": [
+            "authenticated"
+          ],
+          "using": "is_coach_or_admin()",
+          "withCheck": "is_coach_or_admin()"
+        },
+        "Coaches and admins can remove book tags": {
+          "name": "Coaches and admins can remove book tags",
+          "as": "PERMISSIVE",
+          "for": "DELETE",
+          "to": [
+            "authenticated"
+          ],
+          "using": "is_coach_or_admin()"
+        }
+      },
+      "checkConstraints": {},
+      "isRLSEnabled": true
+    },
+    "public.books": {
+      "name": "books",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "title_cs": {
+          "name": "title_cs",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title_en": {
+          "name": "title_en",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "author": {
+          "name": "author",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "isbn_13": {
+          "name": "isbn_13",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "google_books_cover_url": {
+          "name": "google_books_cover_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "book_points": {
+          "name": "book_points",
+          "type": "numeric(3, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "page_count": {
+          "name": "page_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "preview_link": {
+          "name": "preview_link",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source": {
+          "name": "source",
+          "type": "book_source",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'manual'"
+        },
+        "external_id": {
+          "name": "external_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "list_status": {
+          "name": "list_status",
+          "type": "book_list_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'processing'"
+        },
+        "list_status_changed_at": {
+          "name": "list_status_changed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "list_status_changed_by_profile_id": {
+          "name": "list_status_changed_by_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "list_status_reason": {
+          "name": "list_status_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "highlight_category_id": {
+          "name": "highlight_category_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_rocket_model": {
+          "name": "is_rocket_model",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_by_profile_id": {
+          "name": "created_by_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_by_profile_id": {
+          "name": "updated_by_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "books_created_by_idx": {
+          "name": "books_created_by_idx",
+          "columns": [
+            {
+              "expression": "created_by_profile_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "uuid_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "books_author_trgm_idx": {
+          "name": "books_author_trgm_idx",
+          "columns": [
+            {
+              "expression": "author",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "gin_trgm_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        },
+        "books_created_desc_idx": {
+          "name": "books_created_desc_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "first",
+              "opclass": "timestamptz_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "books_isbn_13_idx": {
+          "name": "books_isbn_13_idx",
+          "columns": [
+            {
+              "expression": "isbn_13",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "text_ops"
+            }
+          ],
+          "isUnique": false,
+          "where": "(isbn_13 IS NOT NULL)",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "books_list_status_idx": {
+          "name": "books_list_status_idx",
+          "columns": [
+            {
+              "expression": "list_status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "enum_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "books_title_cs_trgm_idx": {
+          "name": "books_title_cs_trgm_idx",
+          "columns": [
+            {
+              "expression": "title_cs",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "gin_trgm_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "books_created_by_profile_id_fkey": {
+          "name": "books_created_by_profile_id_fkey",
+          "tableFrom": "books",
+          "tableTo": "profiles",
+          "columnsFrom": [
+            "created_by_profile_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "books_updated_by_profile_id_fkey": {
+          "name": "books_updated_by_profile_id_fkey",
+          "tableFrom": "books",
+          "tableTo": "profiles",
+          "columnsFrom": [
+            "updated_by_profile_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "books_list_status_changed_by_profile_id_fkey": {
+          "name": "books_list_status_changed_by_profile_id_fkey",
+          "tableFrom": "books",
+          "tableTo": "profiles",
+          "columnsFrom": [
+            "list_status_changed_by_profile_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "books_highlight_category_id_fkey": {
+          "name": "books_highlight_category_id_fkey",
+          "tableFrom": "books",
+          "tableTo": "highlight_categories",
+          "columnsFrom": [
+            "highlight_category_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {
+        "Coaches and admins can delete books": {
+          "name": "Coaches and admins can delete books",
+          "as": "PERMISSIVE",
+          "for": "DELETE",
+          "to": [
+            "public"
+          ],
+          "using": "is_coach_or_admin()"
+        },
+        "Coaches and admins can update books": {
+          "name": "Coaches and admins can update books",
+          "as": "PERMISSIVE",
+          "for": "UPDATE",
+          "to": [
+            "authenticated"
+          ],
+          "using": "is_coach_or_admin()",
+          "withCheck": "is_coach_or_admin()"
+        },
+        "Authenticated users can add books": {
+          "name": "Authenticated users can add books",
+          "as": "PERMISSIVE",
+          "for": "INSERT",
+          "to": [
+            "authenticated"
+          ],
+          "withCheck": "(created_by_profile_id = current_profile_id())"
+        },
+        "Authenticated users can view all books": {
+          "name": "Authenticated users can view all books",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": [
+            "authenticated"
+          ],
+          "using": "true"
+        }
+      },
+      "checkConstraints": {
+        "books_book_points_check": {
+          "name": "books_book_points_check",
+          "value": "(book_points IS NULL) OR ((book_points >= (0)::numeric) AND (book_points <= (3)::numeric))"
+        },
+        "books_archived_points_check": {
+          "name": "books_archived_points_check",
+          "value": "(list_status <> 'archived') OR (book_points = (0)::numeric)"
+        }
+      },
+      "isRLSEnabled": true
+    },
+    "public.highlight_categories": {
+      "name": "highlight_categories",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_by_profile_id": {
+          "name": "created_by_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_by_profile_id": {
+          "name": "updated_by_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "highlight_categories_created_by_profile_id_fkey": {
+          "name": "highlight_categories_created_by_profile_id_fkey",
+          "tableFrom": "highlight_categories",
+          "tableTo": "profiles",
+          "columnsFrom": [
+            "created_by_profile_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "highlight_categories_updated_by_profile_id_fkey": {
+          "name": "highlight_categories_updated_by_profile_id_fkey",
+          "tableFrom": "highlight_categories",
+          "tableTo": "profiles",
+          "columnsFrom": [
+            "updated_by_profile_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {
+        "Authenticated users can view highlight categories": {
+          "name": "Authenticated users can view highlight categories",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": [
+            "authenticated"
+          ],
+          "using": "true"
+        },
+        "Coaches and admins can add highlight categories": {
+          "name": "Coaches and admins can add highlight categories",
+          "as": "PERMISSIVE",
+          "for": "INSERT",
+          "to": [
+            "authenticated"
+          ],
+          "withCheck": "is_coach_or_admin()"
+        },
+        "Coaches and admins can update highlight categories": {
+          "name": "Coaches and admins can update highlight categories",
+          "as": "PERMISSIVE",
+          "for": "UPDATE",
+          "to": [
+            "authenticated"
+          ],
+          "using": "is_coach_or_admin()",
+          "withCheck": "is_coach_or_admin()"
+        },
+        "Coaches and admins can delete highlight categories": {
+          "name": "Coaches and admins can delete highlight categories",
+          "as": "PERMISSIVE",
+          "for": "DELETE",
+          "to": [
+            "authenticated"
+          ],
+          "using": "is_coach_or_admin()"
+        }
+      },
+      "checkConstraints": {},
+      "isRLSEnabled": true
+    },
+    "public.library_books": {
+      "name": "library_books",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "book_id": {
+          "name": "book_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "isbn_13": {
+          "name": "isbn_13",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_by_profile_id": {
+          "name": "created_by_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_by_profile_id": {
+          "name": "updated_by_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "library_books_book_id_idx": {
+          "name": "library_books_book_id_idx",
+          "columns": [
+            {
+              "expression": "book_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "uuid_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "library_books_isbn_13_idx": {
+          "name": "library_books_isbn_13_idx",
+          "columns": [
+            {
+              "expression": "isbn_13",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "text_ops"
+            }
+          ],
+          "isUnique": false,
+          "where": "(isbn_13 IS NOT NULL)",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "library_books_book_id_fkey": {
+          "name": "library_books_book_id_fkey",
+          "tableFrom": "library_books",
+          "tableTo": "books",
+          "columnsFrom": [
+            "book_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "library_books_created_by_profile_id_fkey": {
+          "name": "library_books_created_by_profile_id_fkey",
+          "tableFrom": "library_books",
+          "tableTo": "profiles",
+          "columnsFrom": [
+            "created_by_profile_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "library_books_updated_by_profile_id_fkey": {
+          "name": "library_books_updated_by_profile_id_fkey",
+          "tableFrom": "library_books",
+          "tableTo": "profiles",
+          "columnsFrom": [
+            "updated_by_profile_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {
+        "Authenticated users can view library books": {
+          "name": "Authenticated users can view library books",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": [
+            "authenticated"
+          ],
+          "using": "true"
+        },
+        "Coaches and admins can add library books": {
+          "name": "Coaches and admins can add library books",
+          "as": "PERMISSIVE",
+          "for": "INSERT",
+          "to": [
+            "authenticated"
+          ],
+          "withCheck": "is_coach_or_admin()"
+        },
+        "Coaches and admins can update library books": {
+          "name": "Coaches and admins can update library books",
+          "as": "PERMISSIVE",
+          "for": "UPDATE",
+          "to": [
+            "authenticated"
+          ],
+          "using": "is_coach_or_admin()",
+          "withCheck": "is_coach_or_admin()"
+        },
+        "Coaches and admins can delete library books": {
+          "name": "Coaches and admins can delete library books",
+          "as": "PERMISSIVE",
+          "for": "DELETE",
+          "to": [
+            "authenticated"
+          ],
+          "using": "is_coach_or_admin()"
+        }
+      },
+      "checkConstraints": {},
+      "isRLSEnabled": true
+    },
+    "public.tags": {
+      "name": "tags",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_by_profile_id": {
+          "name": "created_by_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_by_profile_id": {
+          "name": "updated_by_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "tags_created_by_profile_id_fkey": {
+          "name": "tags_created_by_profile_id_fkey",
+          "tableFrom": "tags",
+          "tableTo": "profiles",
+          "columnsFrom": [
+            "created_by_profile_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "tags_updated_by_profile_id_fkey": {
+          "name": "tags_updated_by_profile_id_fkey",
+          "tableFrom": "tags",
+          "tableTo": "profiles",
+          "columnsFrom": [
+            "updated_by_profile_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "tags_name_key": {
+          "name": "tags_name_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "name"
+          ]
+        }
+      },
+      "policies": {
+        "Authenticated users can view tags": {
+          "name": "Authenticated users can view tags",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": [
+            "authenticated"
+          ],
+          "using": "true"
+        },
+        "Coaches and admins can add tags": {
+          "name": "Coaches and admins can add tags",
+          "as": "PERMISSIVE",
+          "for": "INSERT",
+          "to": [
+            "authenticated"
+          ],
+          "withCheck": "is_coach_or_admin()"
+        },
+        "Coaches and admins can update tags": {
+          "name": "Coaches and admins can update tags",
+          "as": "PERMISSIVE",
+          "for": "UPDATE",
+          "to": [
+            "authenticated"
+          ],
+          "using": "is_coach_or_admin()",
+          "withCheck": "is_coach_or_admin()"
+        },
+        "Coaches and admins can delete tags": {
+          "name": "Coaches and admins can delete tags",
+          "as": "PERMISSIVE",
+          "for": "DELETE",
+          "to": [
+            "authenticated"
+          ],
+          "using": "is_coach_or_admin()"
+        }
+      },
+      "checkConstraints": {},
+      "isRLSEnabled": true
+    },
+    "public.customer_meetings": {
+      "name": "customer_meetings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "profile_id": {
+          "name": "profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "meeting_at": {
+          "name": "meeting_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "company": {
+          "name": "company",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "contact_person": {
+          "name": "contact_person",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "position": {
+          "name": "position",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "objective": {
+          "name": "objective",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "post_mortem": {
+          "name": "post_mortem",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "team_share": {
+          "name": "team_share",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "removed_at": {
+          "name": "removed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_by_profile_id": {
+          "name": "created_by_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_by_profile_id": {
+          "name": "updated_by_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "customer_meetings_profile_idx": {
+          "name": "customer_meetings_profile_idx",
+          "columns": [
+            {
+              "expression": "profile_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "uuid_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "customer_meetings_created_desc_idx": {
+          "name": "customer_meetings_created_desc_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "first",
+              "opclass": "timestamptz_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "customer_meetings_profile_id_fkey": {
+          "name": "customer_meetings_profile_id_fkey",
+          "tableFrom": "customer_meetings",
+          "tableTo": "profiles",
+          "columnsFrom": [
+            "profile_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "customer_meetings_created_by_profile_id_fkey": {
+          "name": "customer_meetings_created_by_profile_id_fkey",
+          "tableFrom": "customer_meetings",
+          "tableTo": "profiles",
+          "columnsFrom": [
+            "created_by_profile_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "customer_meetings_updated_by_profile_id_fkey": {
+          "name": "customer_meetings_updated_by_profile_id_fkey",
+          "tableFrom": "customer_meetings",
+          "tableTo": "profiles",
+          "columnsFrom": [
+            "updated_by_profile_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {
+        "Users can view their own customer meetings": {
+          "name": "Users can view their own customer meetings",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": [
+            "authenticated"
+          ],
+          "using": "(profile_id = current_profile_id())"
+        },
+        "Users can create their own customer meetings": {
+          "name": "Users can create their own customer meetings",
+          "as": "PERMISSIVE",
+          "for": "INSERT",
+          "to": [
+            "authenticated"
+          ],
+          "withCheck": "(profile_id = current_profile_id())"
+        },
+        "Users can update their own customer meetings": {
+          "name": "Users can update their own customer meetings",
+          "as": "PERMISSIVE",
+          "for": "UPDATE",
+          "to": [
+            "authenticated"
+          ],
+          "using": "(profile_id = current_profile_id())",
+          "withCheck": "(profile_id = current_profile_id())"
+        },
+        "Users can delete their own customer meetings": {
+          "name": "Users can delete their own customer meetings",
+          "as": "PERMISSIVE",
+          "for": "DELETE",
+          "to": [
+            "authenticated"
+          ],
+          "using": "(profile_id = current_profile_id())"
+        }
+      },
+      "checkConstraints": {},
+      "isRLSEnabled": true
+    },
+    "public.dashboard_layouts": {
+      "name": "dashboard_layouts",
+      "schema": "",
+      "columns": {
+        "profile_id": {
+          "name": "profile_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "widgets": {
+          "name": "widgets",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_by_profile_id": {
+          "name": "created_by_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_by_profile_id": {
+          "name": "updated_by_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "dashboard_layouts_profile_id_fkey": {
+          "name": "dashboard_layouts_profile_id_fkey",
+          "tableFrom": "dashboard_layouts",
+          "tableTo": "profiles",
+          "columnsFrom": [
+            "profile_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "dashboard_layouts_created_by_profile_id_fkey": {
+          "name": "dashboard_layouts_created_by_profile_id_fkey",
+          "tableFrom": "dashboard_layouts",
+          "tableTo": "profiles",
+          "columnsFrom": [
+            "created_by_profile_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "dashboard_layouts_updated_by_profile_id_fkey": {
+          "name": "dashboard_layouts_updated_by_profile_id_fkey",
+          "tableFrom": "dashboard_layouts",
+          "tableTo": "profiles",
+          "columnsFrom": [
+            "updated_by_profile_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {
+        "Users can delete their own dashboard layout": {
+          "name": "Users can delete their own dashboard layout",
+          "as": "PERMISSIVE",
+          "for": "DELETE",
+          "to": [
+            "public"
+          ],
+          "using": "(profile_id = current_profile_id())"
+        },
+        "Users can update their own dashboard layout": {
+          "name": "Users can update their own dashboard layout",
+          "as": "PERMISSIVE",
+          "for": "UPDATE",
+          "to": [
+            "public"
+          ],
+          "using": "(profile_id = current_profile_id())",
+          "withCheck": "(profile_id = current_profile_id())"
+        },
+        "Users can insert their own dashboard layout": {
+          "name": "Users can insert their own dashboard layout",
+          "as": "PERMISSIVE",
+          "for": "INSERT",
+          "to": [
+            "public"
+          ],
+          "withCheck": "(profile_id = current_profile_id())"
+        },
+        "Users can view their own dashboard layout": {
+          "name": "Users can view their own dashboard layout",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": [
+            "public"
+          ],
+          "using": "(profile_id = current_profile_id())"
+        }
+      },
+      "checkConstraints": {},
+      "isRLSEnabled": true
+    },
+    "public.essay_coach_reads": {
+      "name": "essay_coach_reads",
+      "schema": "",
+      "columns": {
+        "essay_id": {
+          "name": "essay_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "coach_profile_id": {
+          "name": "coach_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "read_at": {
+          "name": "read_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_by_profile_id": {
+          "name": "created_by_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_by_profile_id": {
+          "name": "updated_by_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "essay_coach_reads_coach_idx": {
+          "name": "essay_coach_reads_coach_idx",
+          "columns": [
+            {
+              "expression": "coach_profile_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "uuid_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "essay_coach_reads_essay_id_fkey": {
+          "name": "essay_coach_reads_essay_id_fkey",
+          "tableFrom": "essay_coach_reads",
+          "tableTo": "essays",
+          "columnsFrom": [
+            "essay_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "essay_coach_reads_coach_profile_id_fkey": {
+          "name": "essay_coach_reads_coach_profile_id_fkey",
+          "tableFrom": "essay_coach_reads",
+          "tableTo": "profiles",
+          "columnsFrom": [
+            "coach_profile_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "essay_coach_reads_created_by_profile_id_fkey": {
+          "name": "essay_coach_reads_created_by_profile_id_fkey",
+          "tableFrom": "essay_coach_reads",
+          "tableTo": "profiles",
+          "columnsFrom": [
+            "created_by_profile_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "essay_coach_reads_updated_by_profile_id_fkey": {
+          "name": "essay_coach_reads_updated_by_profile_id_fkey",
+          "tableFrom": "essay_coach_reads",
+          "tableTo": "profiles",
+          "columnsFrom": [
+            "updated_by_profile_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "essay_coach_reads_pkey": {
+          "name": "essay_coach_reads_pkey",
+          "columns": [
+            "essay_id",
+            "coach_profile_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {
+        "Coaches remove own reads": {
+          "name": "Coaches remove own reads",
+          "as": "PERMISSIVE",
+          "for": "DELETE",
+          "to": [
+            "authenticated"
+          ],
+          "using": "(coach_profile_id = current_profile_id())"
+        },
+        "Coaches mark own reads within their team": {
+          "name": "Coaches mark own reads within their team",
+          "as": "PERMISSIVE",
+          "for": "INSERT",
+          "to": [
+            "authenticated"
+          ],
+          "withCheck": "((coach_profile_id = current_profile_id()) AND coach_can_review_essay(essay_id))"
+        },
+        "Coach sees own reads; author sees reads of own essays": {
+          "name": "Coach sees own reads; author sees reads of own essays",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": [
+            "authenticated"
+          ],
+          "using": "((coach_profile_id = current_profile_id()) OR (EXISTS ( SELECT 1\n   FROM essays e\n  WHERE ((e.id = essay_coach_reads.essay_id) AND (e.author_profile_id = current_profile_id())))))"
+        }
+      },
+      "checkConstraints": {},
+      "isRLSEnabled": true
+    },
+    "public.essay_comments": {
+      "name": "essay_comments",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "essay_id": {
+          "name": "essay_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "author_profile_id": {
+          "name": "author_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "parent_id": {
+          "name": "parent_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "removed_at": {
+          "name": "removed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_by_profile_id": {
+          "name": "created_by_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_by_profile_id": {
+          "name": "updated_by_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "essay_comments_author_idx": {
+          "name": "essay_comments_author_idx",
+          "columns": [
+            {
+              "expression": "author_profile_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "uuid_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "essay_comments_essay_idx": {
+          "name": "essay_comments_essay_idx",
+          "columns": [
+            {
+              "expression": "essay_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "uuid_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "essay_comments_essay_id_fkey": {
+          "name": "essay_comments_essay_id_fkey",
+          "tableFrom": "essay_comments",
+          "tableTo": "essays",
+          "columnsFrom": [
+            "essay_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "essay_comments_author_profile_id_fkey": {
+          "name": "essay_comments_author_profile_id_fkey",
+          "tableFrom": "essay_comments",
+          "tableTo": "profiles",
+          "columnsFrom": [
+            "author_profile_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "essay_comments_created_by_profile_id_fkey": {
+          "name": "essay_comments_created_by_profile_id_fkey",
+          "tableFrom": "essay_comments",
+          "tableTo": "profiles",
+          "columnsFrom": [
+            "created_by_profile_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "essay_comments_updated_by_profile_id_fkey": {
+          "name": "essay_comments_updated_by_profile_id_fkey",
+          "tableFrom": "essay_comments",
+          "tableTo": "profiles",
+          "columnsFrom": [
+            "updated_by_profile_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "essay_comments_parent_id_fkey": {
+          "name": "essay_comments_parent_id_fkey",
+          "tableFrom": "essay_comments",
+          "tableTo": "essay_comments",
+          "columnsFrom": [
+            "parent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {
+        "Authors and admins can delete essay comments": {
+          "name": "Authors and admins can delete essay comments",
+          "as": "PERMISSIVE",
+          "for": "DELETE",
+          "to": [
+            "authenticated"
+          ],
+          "using": "((author_profile_id = current_profile_id()) OR is_admin())"
+        },
+        "Authors can update their own essay comments": {
+          "name": "Authors can update their own essay comments",
+          "as": "PERMISSIVE",
+          "for": "UPDATE",
+          "to": [
+            "authenticated"
+          ],
+          "using": "(author_profile_id = current_profile_id())",
+          "withCheck": "(author_profile_id = current_profile_id())"
+        },
+        "Authenticated users can add essay comments": {
+          "name": "Authenticated users can add essay comments",
+          "as": "PERMISSIVE",
+          "for": "INSERT",
+          "to": [
+            "authenticated"
+          ],
+          "withCheck": "(author_profile_id = current_profile_id())"
+        },
+        "Authenticated users can view essay comments": {
+          "name": "Authenticated users can view essay comments",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": [
+            "authenticated"
+          ],
+          "using": "true"
+        }
+      },
+      "checkConstraints": {
+        "essay_comments_body_check": {
+          "name": "essay_comments_body_check",
+          "value": "(char_length(body) >= 1) AND (char_length(body) <= 4000)"
+        }
+      },
+      "isRLSEnabled": true
+    },
+    "public.essay_revisions": {
+      "name": "essay_revisions",
+      "schema": "",
+      "columns": {
+        "essay_id": {
+          "name": "essay_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "revision_no": {
+          "name": "revision_no",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content_json": {
+          "name": "content_json",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "invalid_since": {
+          "name": "invalid_since",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_by_profile_id": {
+          "name": "created_by_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_by_profile_id": {
+          "name": "updated_by_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "essay_revisions_essay_id_fkey": {
+          "name": "essay_revisions_essay_id_fkey",
+          "tableFrom": "essay_revisions",
+          "tableTo": "essays",
+          "columnsFrom": [
+            "essay_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "essay_revisions_created_by_profile_id_fkey": {
+          "name": "essay_revisions_created_by_profile_id_fkey",
+          "tableFrom": "essay_revisions",
+          "tableTo": "profiles",
+          "columnsFrom": [
+            "created_by_profile_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "essay_revisions_updated_by_profile_id_fkey": {
+          "name": "essay_revisions_updated_by_profile_id_fkey",
+          "tableFrom": "essay_revisions",
+          "tableTo": "profiles",
+          "columnsFrom": [
+            "updated_by_profile_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "essay_revisions_pkey": {
+          "name": "essay_revisions_pkey",
+          "columns": [
+            "essay_id",
+            "revision_no"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {
+        "Authenticated users can view essay revisions": {
+          "name": "Authenticated users can view essay revisions",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": [
+            "authenticated"
+          ],
+          "using": "(EXISTS ( SELECT 1\n   FROM essays e\n  WHERE ((e.id = essay_revisions.essay_id) AND ((e.published_at IS NOT NULL) OR (e.author_profile_id = ( SELECT current_profile_id())) OR ( SELECT is_admin())))))"
+        },
+        "Authors can create essay revisions": {
+          "name": "Authors can create essay revisions",
+          "as": "PERMISSIVE",
+          "for": "INSERT",
+          "to": [
+            "authenticated"
+          ],
+          "withCheck": "(created_by_profile_id = current_profile_id())"
+        },
+        "Authors can update their newest recent essay revision": {
+          "name": "Authors can update their newest recent essay revision",
+          "as": "PERMISSIVE",
+          "for": "UPDATE",
+          "to": [
+            "authenticated"
+          ],
+          "using": "((created_by_profile_id = ( SELECT current_profile_id())) AND (created_at > (now() - '00:30:00'::interval)))",
+          "withCheck": "(created_by_profile_id = ( SELECT current_profile_id()))"
+        },
+        "Essay revisions cannot be deleted": {
+          "name": "Essay revisions cannot be deleted",
+          "as": "PERMISSIVE",
+          "for": "DELETE",
+          "to": [
+            "authenticated"
+          ],
+          "using": "false"
+        }
+      },
+      "checkConstraints": {},
+      "isRLSEnabled": true
+    },
+    "public.essay_views": {
+      "name": "essay_views",
+      "schema": "",
+      "columns": {
+        "essay_id": {
+          "name": "essay_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "viewer_profile_id": {
+          "name": "viewer_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "first_viewed_at": {
+          "name": "first_viewed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_viewed_at": {
+          "name": "last_viewed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_by_profile_id": {
+          "name": "created_by_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_by_profile_id": {
+          "name": "updated_by_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "essay_views_viewer_idx": {
+          "name": "essay_views_viewer_idx",
+          "columns": [
+            {
+              "expression": "viewer_profile_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "uuid_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "essay_views_essay_id_fkey": {
+          "name": "essay_views_essay_id_fkey",
+          "tableFrom": "essay_views",
+          "tableTo": "essays",
+          "columnsFrom": [
+            "essay_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "essay_views_viewer_profile_id_fkey": {
+          "name": "essay_views_viewer_profile_id_fkey",
+          "tableFrom": "essay_views",
+          "tableTo": "profiles",
+          "columnsFrom": [
+            "viewer_profile_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "essay_views_created_by_profile_id_fkey": {
+          "name": "essay_views_created_by_profile_id_fkey",
+          "tableFrom": "essay_views",
+          "tableTo": "profiles",
+          "columnsFrom": [
+            "created_by_profile_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "essay_views_updated_by_profile_id_fkey": {
+          "name": "essay_views_updated_by_profile_id_fkey",
+          "tableFrom": "essay_views",
+          "tableTo": "profiles",
+          "columnsFrom": [
+            "updated_by_profile_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "essay_views_pkey": {
+          "name": "essay_views_pkey",
+          "columns": [
+            "essay_id",
+            "viewer_profile_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {
+        "No direct inserts to essay_views": {
+          "name": "No direct inserts to essay_views",
+          "as": "PERMISSIVE",
+          "for": "INSERT",
+          "to": [
+            "authenticated"
+          ],
+          "withCheck": "false"
+        },
+        "Authors see all viewers; others see own row": {
+          "name": "Authors see all viewers; others see own row",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": [
+            "authenticated"
+          ],
+          "using": "((viewer_profile_id = current_profile_id()) OR (EXISTS ( SELECT 1\n   FROM essays e\n  WHERE ((e.id = essay_views.essay_id) AND (e.author_profile_id = current_profile_id())))))"
+        }
+      },
+      "checkConstraints": {},
+      "isRLSEnabled": true
+    },
+    "public.essay_votes": {
+      "name": "essay_votes",
+      "schema": "",
+      "columns": {
+        "essay_id": {
+          "name": "essay_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "voter_profile_id": {
+          "name": "voter_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_by_profile_id": {
+          "name": "created_by_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_by_profile_id": {
+          "name": "updated_by_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "essay_votes_voter_idx": {
+          "name": "essay_votes_voter_idx",
+          "columns": [
+            {
+              "expression": "voter_profile_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "uuid_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "essay_votes_essay_id_fkey": {
+          "name": "essay_votes_essay_id_fkey",
+          "tableFrom": "essay_votes",
+          "tableTo": "essays",
+          "columnsFrom": [
+            "essay_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "essay_votes_voter_profile_id_fkey": {
+          "name": "essay_votes_voter_profile_id_fkey",
+          "tableFrom": "essay_votes",
+          "tableTo": "profiles",
+          "columnsFrom": [
+            "voter_profile_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "essay_votes_created_by_profile_id_fkey": {
+          "name": "essay_votes_created_by_profile_id_fkey",
+          "tableFrom": "essay_votes",
+          "tableTo": "profiles",
+          "columnsFrom": [
+            "created_by_profile_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "essay_votes_updated_by_profile_id_fkey": {
+          "name": "essay_votes_updated_by_profile_id_fkey",
+          "tableFrom": "essay_votes",
+          "tableTo": "profiles",
+          "columnsFrom": [
+            "updated_by_profile_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "essay_votes_pkey": {
+          "name": "essay_votes_pkey",
+          "columns": [
+            "essay_id",
+            "voter_profile_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {
+        "Users can vote (not own essays)": {
+          "name": "Users can vote (not own essays)",
+          "as": "PERMISSIVE",
+          "for": "INSERT",
+          "to": [
+            "authenticated"
+          ],
+          "withCheck": "((voter_profile_id = current_profile_id()) AND (NOT (essay_id IN ( SELECT essays.id\n   FROM essays\n  WHERE (essays.author_profile_id = current_profile_id())))))"
+        },
+        "Authenticated users can view votes": {
+          "name": "Authenticated users can view votes",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": [
+            "authenticated"
+          ],
+          "using": "true"
+        },
+        "Users can remove own votes": {
+          "name": "Users can remove own votes",
+          "as": "PERMISSIVE",
+          "for": "DELETE",
+          "to": [
+            "authenticated"
+          ],
+          "using": "(voter_profile_id = current_profile_id())"
+        }
+      },
+      "checkConstraints": {},
+      "isRLSEnabled": true
+    },
+    "public.essays": {
+      "name": "essays",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "external_id": {
+          "name": "external_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "author_profile_id": {
+          "name": "author_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "book_id": {
+          "name": "book_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "published_at": {
+          "name": "published_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pinned_at": {
+          "name": "pinned_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pinned_by_profile_id": {
+          "name": "pinned_by_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "removed_at": {
+          "name": "removed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_by_profile_id": {
+          "name": "created_by_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_by_profile_id": {
+          "name": "updated_by_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "essays_author_idx": {
+          "name": "essays_author_idx",
+          "columns": [
+            {
+              "expression": "author_profile_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "uuid_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "essays_book_idx": {
+          "name": "essays_book_idx",
+          "columns": [
+            {
+              "expression": "book_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "uuid_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "essays_created_desc_idx": {
+          "name": "essays_created_desc_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "first",
+              "opclass": "timestamptz_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "essays_author_profile_id_fkey": {
+          "name": "essays_author_profile_id_fkey",
+          "tableFrom": "essays",
+          "tableTo": "profiles",
+          "columnsFrom": [
+            "author_profile_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "essays_book_id_fkey": {
+          "name": "essays_book_id_fkey",
+          "tableFrom": "essays",
+          "tableTo": "books",
+          "columnsFrom": [
+            "book_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "essays_pinned_by_profile_id_fkey": {
+          "name": "essays_pinned_by_profile_id_fkey",
+          "tableFrom": "essays",
+          "tableTo": "profiles",
+          "columnsFrom": [
+            "pinned_by_profile_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "essays_created_by_profile_id_fkey": {
+          "name": "essays_created_by_profile_id_fkey",
+          "tableFrom": "essays",
+          "tableTo": "profiles",
+          "columnsFrom": [
+            "created_by_profile_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "essays_updated_by_profile_id_fkey": {
+          "name": "essays_updated_by_profile_id_fkey",
+          "tableFrom": "essays",
+          "tableTo": "profiles",
+          "columnsFrom": [
+            "updated_by_profile_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {
+        "Authors can create their own essays": {
+          "name": "Authors can create their own essays",
+          "as": "PERMISSIVE",
+          "for": "INSERT",
+          "to": [
+            "authenticated"
+          ],
+          "withCheck": "(author_profile_id = current_profile_id())"
+        },
+        "Authenticated users can view all essays": {
+          "name": "Authenticated users can view all essays",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": [
+            "authenticated"
+          ],
+          "using": "((published_at IS NOT NULL) OR (author_profile_id = ( SELECT current_profile_id())) OR ( SELECT is_admin()))"
+        },
+        "Authors and admins can delete essays": {
+          "name": "Authors and admins can delete essays",
+          "as": "PERMISSIVE",
+          "for": "DELETE",
+          "to": [
+            "authenticated"
+          ],
+          "using": "((author_profile_id = current_profile_id()) OR is_admin())"
+        },
+        "Authors can update their own essays": {
+          "name": "Authors can update their own essays",
+          "as": "PERMISSIVE",
+          "for": "UPDATE",
+          "to": [
+            "authenticated"
+          ],
+          "using": "(author_profile_id = current_profile_id())",
+          "withCheck": "(author_profile_id = current_profile_id())"
+        }
+      },
+      "checkConstraints": {},
+      "isRLSEnabled": true
+    },
+    "public.feedback": {
+      "name": "feedback",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "author_profile_id": {
+          "name": "author_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "resolved_at": {
+          "name": "resolved_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_by_profile_id": {
+          "name": "created_by_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_by_profile_id": {
+          "name": "updated_by_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "feedback_active_created_idx": {
+          "name": "feedback_active_created_idx",
+          "columns": [
+            {
+              "expression": "resolved_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "timestamptz_ops"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "first",
+              "opclass": "timestamptz_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "feedback_author_idx": {
+          "name": "feedback_author_idx",
+          "columns": [
+            {
+              "expression": "author_profile_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "uuid_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "feedback_author_profile_id_fkey": {
+          "name": "feedback_author_profile_id_fkey",
+          "tableFrom": "feedback",
+          "tableTo": "profiles",
+          "columnsFrom": [
+            "author_profile_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "feedback_created_by_profile_id_fkey": {
+          "name": "feedback_created_by_profile_id_fkey",
+          "tableFrom": "feedback",
+          "tableTo": "profiles",
+          "columnsFrom": [
+            "created_by_profile_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "feedback_updated_by_profile_id_fkey": {
+          "name": "feedback_updated_by_profile_id_fkey",
+          "tableFrom": "feedback",
+          "tableTo": "profiles",
+          "columnsFrom": [
+            "updated_by_profile_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {
+        "Authenticated users can view feedback": {
+          "name": "Authenticated users can view feedback",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": [
+            "authenticated"
+          ],
+          "using": "true"
+        },
+        "Authenticated users can create feedback": {
+          "name": "Authenticated users can create feedback",
+          "as": "PERMISSIVE",
+          "for": "INSERT",
+          "to": [
+            "authenticated"
+          ],
+          "withCheck": "(author_profile_id = current_profile_id())"
+        },
+        "Admins can update feedback": {
+          "name": "Admins can update feedback",
+          "as": "PERMISSIVE",
+          "for": "UPDATE",
+          "to": [
+            "authenticated"
+          ],
+          "using": "is_admin()",
+          "withCheck": "is_admin()"
+        },
+        "Authors and admins can delete feedback": {
+          "name": "Authors and admins can delete feedback",
+          "as": "PERMISSIVE",
+          "for": "DELETE",
+          "to": [
+            "authenticated"
+          ],
+          "using": "((author_profile_id = current_profile_id()) OR is_admin())"
+        }
+      },
+      "checkConstraints": {
+        "feedback_body_check": {
+          "name": "feedback_body_check",
+          "value": "(char_length(body) >= 1) AND (char_length(body) <= 4000)"
+        }
+      },
+      "isRLSEnabled": true
+    },
+    "public.individual_coaching_sessions": {
+      "name": "individual_coaching_sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "profile_id": {
+          "name": "profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "session_at": {
+          "name": "session_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "coach_profile_id": {
+          "name": "coach_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "external_coach_name": {
+          "name": "external_coach_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "key_takeaways": {
+          "name": "key_takeaways",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "action_steps": {
+          "name": "action_steps",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "removed_at": {
+          "name": "removed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_by_profile_id": {
+          "name": "created_by_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_by_profile_id": {
+          "name": "updated_by_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "individual_coaching_sessions_profile_idx": {
+          "name": "individual_coaching_sessions_profile_idx",
+          "columns": [
+            {
+              "expression": "profile_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "uuid_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "individual_coaching_sessions_coach_idx": {
+          "name": "individual_coaching_sessions_coach_idx",
+          "columns": [
+            {
+              "expression": "coach_profile_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "uuid_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "individual_coaching_sessions_created_desc_idx": {
+          "name": "individual_coaching_sessions_created_desc_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "first",
+              "opclass": "timestamptz_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "individual_coaching_sessions_profile_id_fkey": {
+          "name": "individual_coaching_sessions_profile_id_fkey",
+          "tableFrom": "individual_coaching_sessions",
+          "tableTo": "profiles",
+          "columnsFrom": [
+            "profile_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "individual_coaching_sessions_coach_profile_id_fkey": {
+          "name": "individual_coaching_sessions_coach_profile_id_fkey",
+          "tableFrom": "individual_coaching_sessions",
+          "tableTo": "profiles",
+          "columnsFrom": [
+            "coach_profile_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "individual_coaching_sessions_created_by_profile_id_fkey": {
+          "name": "individual_coaching_sessions_created_by_profile_id_fkey",
+          "tableFrom": "individual_coaching_sessions",
+          "tableTo": "profiles",
+          "columnsFrom": [
+            "created_by_profile_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "individual_coaching_sessions_updated_by_profile_id_fkey": {
+          "name": "individual_coaching_sessions_updated_by_profile_id_fkey",
+          "tableFrom": "individual_coaching_sessions",
+          "tableTo": "profiles",
+          "columnsFrom": [
+            "updated_by_profile_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {
+        "Users can view their own coaching sessions": {
+          "name": "Users can view their own coaching sessions",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": [
+            "authenticated"
+          ],
+          "using": "(profile_id = current_profile_id())"
+        },
+        "Users can create their own coaching sessions": {
+          "name": "Users can create their own coaching sessions",
+          "as": "PERMISSIVE",
+          "for": "INSERT",
+          "to": [
+            "authenticated"
+          ],
+          "withCheck": "(profile_id = current_profile_id())"
+        },
+        "Users can update their own coaching sessions": {
+          "name": "Users can update their own coaching sessions",
+          "as": "PERMISSIVE",
+          "for": "UPDATE",
+          "to": [
+            "authenticated"
+          ],
+          "using": "(profile_id = current_profile_id())",
+          "withCheck": "(profile_id = current_profile_id())"
+        },
+        "Users can delete their own coaching sessions": {
+          "name": "Users can delete their own coaching sessions",
+          "as": "PERMISSIVE",
+          "for": "DELETE",
+          "to": [
+            "authenticated"
+          ],
+          "using": "(profile_id = current_profile_id())"
+        }
+      },
+      "checkConstraints": {
+        "individual_coaching_sessions_coach_xor": {
+          "name": "individual_coaching_sessions_coach_xor",
+          "value": "(coach_profile_id IS NOT NULL) <> (external_coach_name IS NOT NULL)"
+        }
+      },
+      "isRLSEnabled": true
+    },
+    "public.notification_preferences": {
+      "name": "notification_preferences",
+      "schema": "",
+      "columns": {
+        "profile_id": {
+          "name": "profile_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "essay_coach_read_email": {
+          "name": "essay_coach_read_email",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "essay_comment_email": {
+          "name": "essay_comment_email",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "essay_vote_email": {
+          "name": "essay_vote_email",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "book_submitted_email": {
+          "name": "book_submitted_email",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_by_profile_id": {
+          "name": "created_by_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_by_profile_id": {
+          "name": "updated_by_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "notification_preferences_profile_id_fkey": {
+          "name": "notification_preferences_profile_id_fkey",
+          "tableFrom": "notification_preferences",
+          "tableTo": "profiles",
+          "columnsFrom": [
+            "profile_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "notification_preferences_created_by_profile_id_fkey": {
+          "name": "notification_preferences_created_by_profile_id_fkey",
+          "tableFrom": "notification_preferences",
+          "tableTo": "profiles",
+          "columnsFrom": [
+            "created_by_profile_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "notification_preferences_updated_by_profile_id_fkey": {
+          "name": "notification_preferences_updated_by_profile_id_fkey",
+          "tableFrom": "notification_preferences",
+          "tableTo": "profiles",
+          "columnsFrom": [
+            "updated_by_profile_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {
+        "Users can view their own notification preferences": {
+          "name": "Users can view their own notification preferences",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": [
+            "authenticated"
+          ],
+          "using": "(profile_id = current_profile_id())"
+        },
+        "Users can insert their own notification preferences": {
+          "name": "Users can insert their own notification preferences",
+          "as": "PERMISSIVE",
+          "for": "INSERT",
+          "to": [
+            "authenticated"
+          ],
+          "withCheck": "(profile_id = current_profile_id())"
+        },
+        "Users can update their own notification preferences": {
+          "name": "Users can update their own notification preferences",
+          "as": "PERMISSIVE",
+          "for": "UPDATE",
+          "to": [
+            "authenticated"
+          ],
+          "using": "(profile_id = current_profile_id())",
+          "withCheck": "(profile_id = current_profile_id())"
+        }
+      },
+      "checkConstraints": {},
+      "isRLSEnabled": true
+    },
+    "public.personality_tests": {
+      "name": "personality_tests",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "profile_id": {
+          "name": "profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "test_type": {
+          "name": "test_type",
+          "type": "personality_test_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "test_type_other": {
+          "name": "test_type_other",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tested_on": {
+          "name": "tested_on",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "file_path": {
+          "name": "file_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "file_name": {
+          "name": "file_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "file_size": {
+          "name": "file_size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "removed_at": {
+          "name": "removed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_by_profile_id": {
+          "name": "created_by_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_by_profile_id": {
+          "name": "updated_by_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "personality_tests_profile_tested_on_idx": {
+          "name": "personality_tests_profile_tested_on_idx",
+          "columns": [
+            {
+              "expression": "profile_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "uuid_ops"
+            },
+            {
+              "expression": "tested_on",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "date_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "personality_tests_profile_id_fkey": {
+          "name": "personality_tests_profile_id_fkey",
+          "tableFrom": "personality_tests",
+          "tableTo": "profiles",
+          "columnsFrom": [
+            "profile_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "personality_tests_created_by_profile_id_fkey": {
+          "name": "personality_tests_created_by_profile_id_fkey",
+          "tableFrom": "personality_tests",
+          "tableTo": "profiles",
+          "columnsFrom": [
+            "created_by_profile_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "personality_tests_updated_by_profile_id_fkey": {
+          "name": "personality_tests_updated_by_profile_id_fkey",
+          "tableFrom": "personality_tests",
+          "tableTo": "profiles",
+          "columnsFrom": [
+            "updated_by_profile_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {
+        "Verified users can view personality tests": {
+          "name": "Verified users can view personality tests",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": [
+            "authenticated"
+          ],
+          "using": "(EXISTS (SELECT 1 FROM users WHERE (users.auth_user_id = (SELECT auth.uid()) AND users.verified_work_email IS NOT NULL)))"
+        },
+        "Users can create their own personality tests": {
+          "name": "Users can create their own personality tests",
+          "as": "PERMISSIVE",
+          "for": "INSERT",
+          "to": [
+            "authenticated"
+          ],
+          "withCheck": "(profile_id = current_profile_id())"
+        },
+        "Users can update their own personality tests": {
+          "name": "Users can update their own personality tests",
+          "as": "PERMISSIVE",
+          "for": "UPDATE",
+          "to": [
+            "authenticated"
+          ],
+          "using": "(profile_id = current_profile_id())",
+          "withCheck": "(profile_id = current_profile_id())"
+        },
+        "Users can delete their own personality tests": {
+          "name": "Users can delete their own personality tests",
+          "as": "PERMISSIVE",
+          "for": "DELETE",
+          "to": [
+            "authenticated"
+          ],
+          "using": "(profile_id = current_profile_id())"
+        }
+      },
+      "checkConstraints": {
+        "personality_tests_other_type_required": {
+          "name": "personality_tests_other_type_required",
+          "value": "(test_type <> 'other' OR (test_type_other IS NOT NULL AND length(trim(test_type_other)) > 0))"
+        }
+      },
+      "isRLSEnabled": true
+    },
+    "public.profiles": {
+      "name": "profiles",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "picture": {
+          "name": "picture",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "work_email": {
+          "name": "work_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "profile_role",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'student'"
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "phone_number": {
+          "name": "phone_number",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "personal_email": {
+          "name": "personal_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "date_of_birth": {
+          "name": "date_of_birth",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_removed_at": {
+          "name": "access_removed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_removed_by_profile_id": {
+          "name": "access_removed_by_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "beta_access_granted_at": {
+          "name": "beta_access_granted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_by_profile_id": {
+          "name": "created_by_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_by_profile_id": {
+          "name": "updated_by_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "profiles_team_id_idx": {
+          "name": "profiles_team_id_idx",
+          "columns": [
+            {
+              "expression": "team_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "uuid_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "profiles_team_id_user_id_idx": {
+          "name": "profiles_team_id_user_id_idx",
+          "columns": [
+            {
+              "expression": "team_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "uuid_ops"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "uuid_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "profiles_user_id_idx": {
+          "name": "profiles_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "uuid_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "profiles_work_email_idx": {
+          "name": "profiles_work_email_idx",
+          "columns": [
+            {
+              "expression": "work_email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "text_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "profiles_user_id_fkey": {
+          "name": "profiles_user_id_fkey",
+          "tableFrom": "profiles",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "profiles_team_id_fkey": {
+          "name": "profiles_team_id_fkey",
+          "tableFrom": "profiles",
+          "tableTo": "teams",
+          "columnsFrom": [
+            "team_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "profiles_access_removed_by_profile_id_fkey": {
+          "name": "profiles_access_removed_by_profile_id_fkey",
+          "tableFrom": "profiles",
+          "tableTo": "profiles",
+          "columnsFrom": [
+            "access_removed_by_profile_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "profiles_created_by_profile_id_fkey": {
+          "name": "profiles_created_by_profile_id_fkey",
+          "tableFrom": "profiles",
+          "tableTo": "profiles",
+          "columnsFrom": [
+            "created_by_profile_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "profiles_updated_by_profile_id_fkey": {
+          "name": "profiles_updated_by_profile_id_fkey",
+          "tableFrom": "profiles",
+          "tableTo": "profiles",
+          "columnsFrom": [
+            "updated_by_profile_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "profiles_user_id_key": {
+          "name": "profiles_user_id_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id"
+          ]
+        },
+        "profiles_work_email_key": {
+          "name": "profiles_work_email_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "work_email"
+          ]
+        }
+      },
+      "policies": {
+        "Verified users can view all profiles": {
+          "name": "Verified users can view all profiles",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": [
+            "authenticated"
+          ],
+          "using": "((access_removed_at IS NULL) AND (EXISTS ( SELECT 1\n   FROM users\n  WHERE ((users.auth_user_id = ( SELECT auth.uid() AS uid)) AND (users.verified_work_email IS NOT NULL)))))"
+        },
+        "Users can update their own profile picture": {
+          "name": "Users can update their own profile picture",
+          "as": "PERMISSIVE",
+          "for": "UPDATE",
+          "to": [
+            "authenticated"
+          ],
+          "using": "(user_id IN ( SELECT users.id\n   FROM users\n  WHERE (users.auth_user_id = ( SELECT auth.uid() AS uid))))",
+          "withCheck": "(user_id IN ( SELECT users.id\n   FROM users\n  WHERE (users.auth_user_id = ( SELECT auth.uid() AS uid))))"
+        }
+      },
+      "checkConstraints": {
+        "valid_czu_domain": {
+          "name": "valid_czu_domain",
+          "value": "(lower(split_part(work_email, '@'::text, 2)) = ANY (ARRAY['pef.czu.cz'::text, 'studenti.czu.cz'::text, 'rektorat.czu.cz'::text]))"
+        }
+      },
+      "isRLSEnabled": true
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "auth_user_id": {
+          "name": "auth_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "google_email": {
+          "name": "google_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "suggested_work_email": {
+          "name": "suggested_work_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "verified_work_email": {
+          "name": "verified_work_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "verified_work_email_at": {
+          "name": "verified_work_email_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_otp_sent_at": {
+          "name": "last_otp_sent_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "users_google_email_idx": {
+          "name": "users_google_email_idx",
+          "columns": [
+            {
+              "expression": "google_email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "text_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "users_suggested_work_email_idx": {
+          "name": "users_suggested_work_email_idx",
+          "columns": [
+            {
+              "expression": "suggested_work_email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "text_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "users_auth_user_id_fkey": {
+          "name": "users_auth_user_id_fkey",
+          "tableFrom": "users",
+          "tableTo": "users",
+          "schemaTo": "auth",
+          "columnsFrom": [
+            "auth_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_auth_user_id_key": {
+          "name": "users_auth_user_id_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "auth_user_id"
+          ]
+        },
+        "users_google_email_key": {
+          "name": "users_google_email_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "google_email"
+          ]
+        }
+      },
+      "policies": {
+        "Users can update only suggested_work_email": {
+          "name": "Users can update only suggested_work_email",
+          "as": "PERMISSIVE",
+          "for": "UPDATE",
+          "to": [
+            "authenticated"
+          ],
+          "using": "(( SELECT auth.uid() AS uid) = auth_user_id)",
+          "withCheck": "(( SELECT auth.uid() AS uid) = auth_user_id)"
+        },
+        "Users can insert their own user record": {
+          "name": "Users can insert their own user record",
+          "as": "PERMISSIVE",
+          "for": "INSERT",
+          "to": [
+            "authenticated"
+          ],
+          "withCheck": "(( SELECT auth.uid() AS uid) = auth_user_id)"
+        },
+        "Users can view their own user record": {
+          "name": "Users can view their own user record",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": [
+            "authenticated"
+          ],
+          "using": "(( SELECT auth.uid() AS uid) = auth_user_id)"
+        }
+      },
+      "checkConstraints": {},
+      "isRLSEnabled": true
+    },
+    "public.recurring_schedules": {
+      "name": "recurring_schedules",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "room_id": {
+          "name": "room_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "schedule_type": {
+          "name": "schedule_type",
+          "type": "schedule_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "day_of_week": {
+          "name": "day_of_week",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "start_time": {
+          "name": "start_time",
+          "type": "time",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "end_time": {
+          "name": "end_time",
+          "type": "time",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "valid_from": {
+          "name": "valid_from",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "valid_until": {
+          "name": "valid_until",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "removed_at": {
+          "name": "removed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_by_profile_id": {
+          "name": "created_by_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_by_profile_id": {
+          "name": "updated_by_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "idx_recurring_schedules_day": {
+          "name": "idx_recurring_schedules_day",
+          "columns": [
+            {
+              "expression": "day_of_week",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "int2_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_recurring_schedules_room": {
+          "name": "idx_recurring_schedules_room",
+          "columns": [
+            {
+              "expression": "room_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "uuid_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_recurring_schedules_team": {
+          "name": "idx_recurring_schedules_team",
+          "columns": [
+            {
+              "expression": "team_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "uuid_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_recurring_schedules_type": {
+          "name": "idx_recurring_schedules_type",
+          "columns": [
+            {
+              "expression": "schedule_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "enum_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_recurring_schedules_valid": {
+          "name": "idx_recurring_schedules_valid",
+          "columns": [
+            {
+              "expression": "valid_from",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "date_ops"
+            },
+            {
+              "expression": "valid_until",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "date_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "recurring_schedules_room_id_fkey": {
+          "name": "recurring_schedules_room_id_fkey",
+          "tableFrom": "recurring_schedules",
+          "tableTo": "rooms",
+          "columnsFrom": [
+            "room_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "recurring_schedules_team_id_fkey": {
+          "name": "recurring_schedules_team_id_fkey",
+          "tableFrom": "recurring_schedules",
+          "tableTo": "teams",
+          "columnsFrom": [
+            "team_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "recurring_schedules_created_by_profile_id_fkey": {
+          "name": "recurring_schedules_created_by_profile_id_fkey",
+          "tableFrom": "recurring_schedules",
+          "tableTo": "profiles",
+          "columnsFrom": [
+            "created_by_profile_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "recurring_schedules_updated_by_profile_id_fkey": {
+          "name": "recurring_schedules_updated_by_profile_id_fkey",
+          "tableFrom": "recurring_schedules",
+          "tableTo": "profiles",
+          "columnsFrom": [
+            "updated_by_profile_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {
+        "Coaches can manage recurring_schedules": {
+          "name": "Coaches can manage recurring_schedules",
+          "as": "PERMISSIVE",
+          "for": "ALL",
+          "to": [
+            "authenticated"
+          ],
+          "using": "(EXISTS ( SELECT 1\n   FROM profiles\n  WHERE ((profiles.user_id IN ( SELECT users.id\n           FROM users\n          WHERE (users.auth_user_id = ( SELECT auth.uid() AS uid)))) AND (profiles.role = ANY (ARRAY['coach'::profile_role, 'admin'::profile_role])))))",
+          "withCheck": "(EXISTS ( SELECT 1\n   FROM profiles\n  WHERE ((profiles.user_id IN ( SELECT users.id\n           FROM users\n          WHERE (users.auth_user_id = ( SELECT auth.uid() AS uid)))) AND (profiles.role = ANY (ARRAY['coach'::profile_role, 'admin'::profile_role])))))"
+        },
+        "Authenticated can read recurring_schedules": {
+          "name": "Authenticated can read recurring_schedules",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": [
+            "authenticated"
+          ],
+          "using": "true"
+        }
+      },
+      "checkConstraints": {
+        "recurring_schedules_day_of_week_check": {
+          "name": "recurring_schedules_day_of_week_check",
+          "value": "(day_of_week >= 0) AND (day_of_week <= 6)"
+        },
+        "valid_time_range": {
+          "name": "valid_time_range",
+          "value": "end_time > start_time"
+        },
+        "valid_schedule_dates": {
+          "name": "valid_schedule_dates",
+          "value": "(valid_until IS NULL) OR (valid_until >= valid_from)"
+        },
+        "recurring_schedules_team_for_ts": {
+          "name": "recurring_schedules_team_for_ts",
+          "value": "(schedule_type <> 'training_session'::schedule_type) OR (team_id IS NOT NULL)"
+        }
+      },
+      "isRLSEnabled": true
+    },
+    "public.reservations": {
+      "name": "reservations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "room_id": {
+          "name": "room_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "owner_profile_id": {
+          "name": "owner_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "person_count": {
+          "name": "person_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "start_at": {
+          "name": "start_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "end_at": {
+          "name": "end_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cancelled_at": {
+          "name": "cancelled_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cancelled_by_profile_id": {
+          "name": "cancelled_by_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_by_profile_id": {
+          "name": "created_by_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_by_profile_id": {
+          "name": "updated_by_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "idx_reservations_room_time": {
+          "name": "idx_reservations_room_time",
+          "columns": [
+            {
+              "expression": "room_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "uuid_ops"
+            },
+            {
+              "expression": "start_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "timestamptz_ops"
+            },
+            {
+              "expression": "end_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "timestamptz_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_reservations_start": {
+          "name": "idx_reservations_start",
+          "columns": [
+            {
+              "expression": "start_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "timestamptz_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_reservations_owner": {
+          "name": "idx_reservations_owner",
+          "columns": [
+            {
+              "expression": "owner_profile_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "uuid_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "reservations_room_id_fkey": {
+          "name": "reservations_room_id_fkey",
+          "tableFrom": "reservations",
+          "tableTo": "rooms",
+          "columnsFrom": [
+            "room_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "reservations_owner_profile_id_fkey": {
+          "name": "reservations_owner_profile_id_fkey",
+          "tableFrom": "reservations",
+          "tableTo": "profiles",
+          "columnsFrom": [
+            "owner_profile_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "reservations_cancelled_by_profile_id_fkey": {
+          "name": "reservations_cancelled_by_profile_id_fkey",
+          "tableFrom": "reservations",
+          "tableTo": "profiles",
+          "columnsFrom": [
+            "cancelled_by_profile_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "reservations_created_by_profile_id_fkey": {
+          "name": "reservations_created_by_profile_id_fkey",
+          "tableFrom": "reservations",
+          "tableTo": "profiles",
+          "columnsFrom": [
+            "created_by_profile_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "reservations_updated_by_profile_id_fkey": {
+          "name": "reservations_updated_by_profile_id_fkey",
+          "tableFrom": "reservations",
+          "tableTo": "profiles",
+          "columnsFrom": [
+            "updated_by_profile_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {
+        "Authenticated can read reservations": {
+          "name": "Authenticated can read reservations",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": [
+            "authenticated"
+          ],
+          "using": "true"
+        },
+        "Users can delete own reservations": {
+          "name": "Users can delete own reservations",
+          "as": "PERMISSIVE",
+          "for": "DELETE",
+          "to": [
+            "authenticated"
+          ],
+          "using": "(owner_profile_id IN ( SELECT profiles.id\n   FROM profiles\n  WHERE (profiles.user_id IN ( SELECT users.id\n           FROM users\n          WHERE (users.auth_user_id = ( SELECT auth.uid() AS uid))))))"
+        },
+        "Users can update own reservations": {
+          "name": "Users can update own reservations",
+          "as": "PERMISSIVE",
+          "for": "UPDATE",
+          "to": [
+            "authenticated"
+          ],
+          "using": "(owner_profile_id IN ( SELECT profiles.id\n   FROM profiles\n  WHERE (profiles.user_id IN ( SELECT users.id\n           FROM users\n          WHERE (users.auth_user_id = ( SELECT auth.uid() AS uid))))))",
+          "withCheck": "(owner_profile_id IN ( SELECT profiles.id\n   FROM profiles\n  WHERE (profiles.user_id IN ( SELECT users.id\n           FROM users\n          WHERE (users.auth_user_id = ( SELECT auth.uid() AS uid))))))"
+        },
+        "Users can create own reservations": {
+          "name": "Users can create own reservations",
+          "as": "PERMISSIVE",
+          "for": "INSERT",
+          "to": [
+            "authenticated"
+          ],
+          "withCheck": "(owner_profile_id IN ( SELECT profiles.id\n   FROM profiles\n  WHERE (profiles.user_id IN ( SELECT users.id\n           FROM users\n          WHERE (users.auth_user_id = ( SELECT auth.uid() AS uid))))))"
+        }
+      },
+      "checkConstraints": {
+        "valid_reservation_time": {
+          "name": "valid_reservation_time",
+          "value": "end_at > start_at"
+        }
+      },
+      "isRLSEnabled": true
+    },
+    "public.rooms": {
+      "name": "rooms",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "code": {
+          "name": "code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "available_days": {
+          "name": "available_days",
+          "type": "integer[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "can_have_ts": {
+          "name": "can_have_ts",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "removed_at": {
+          "name": "removed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_by_profile_id": {
+          "name": "created_by_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_by_profile_id": {
+          "name": "updated_by_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "idx_rooms_code": {
+          "name": "idx_rooms_code",
+          "columns": [
+            {
+              "expression": "code",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "text_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "rooms_created_by_profile_id_fkey": {
+          "name": "rooms_created_by_profile_id_fkey",
+          "tableFrom": "rooms",
+          "tableTo": "profiles",
+          "columnsFrom": [
+            "created_by_profile_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "rooms_updated_by_profile_id_fkey": {
+          "name": "rooms_updated_by_profile_id_fkey",
+          "tableFrom": "rooms",
+          "tableTo": "profiles",
+          "columnsFrom": [
+            "updated_by_profile_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "rooms_code_key": {
+          "name": "rooms_code_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "code"
+          ]
+        }
+      },
+      "policies": {
+        "Admins can manage rooms": {
+          "name": "Admins can manage rooms",
+          "as": "PERMISSIVE",
+          "for": "ALL",
+          "to": [
+            "authenticated"
+          ],
+          "using": "(EXISTS ( SELECT 1\n   FROM profiles\n  WHERE ((profiles.user_id IN ( SELECT users.id\n           FROM users\n          WHERE (users.auth_user_id = ( SELECT auth.uid() AS uid)))) AND (profiles.role = 'admin'::profile_role))))",
+          "withCheck": "(EXISTS ( SELECT 1\n   FROM profiles\n  WHERE ((profiles.user_id IN ( SELECT users.id\n           FROM users\n          WHERE (users.auth_user_id = ( SELECT auth.uid() AS uid)))) AND (profiles.role = 'admin'::profile_role))))"
+        },
+        "Authenticated can read rooms": {
+          "name": "Authenticated can read rooms",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": [
+            "authenticated"
+          ],
+          "using": "true"
+        }
+      },
+      "checkConstraints": {},
+      "isRLSEnabled": true
+    },
+    "public.schedule_breaks": {
+      "name": "schedule_breaks",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "start_date": {
+          "name": "start_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "end_date": {
+          "name": "end_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_by_profile_id": {
+          "name": "created_by_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_by_profile_id": {
+          "name": "updated_by_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "idx_schedule_breaks_dates": {
+          "name": "idx_schedule_breaks_dates",
+          "columns": [
+            {
+              "expression": "start_date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "date_ops"
+            },
+            {
+              "expression": "end_date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "date_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "schedule_breaks_created_by_profile_id_fkey": {
+          "name": "schedule_breaks_created_by_profile_id_fkey",
+          "tableFrom": "schedule_breaks",
+          "tableTo": "profiles",
+          "columnsFrom": [
+            "created_by_profile_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "schedule_breaks_updated_by_profile_id_fkey": {
+          "name": "schedule_breaks_updated_by_profile_id_fkey",
+          "tableFrom": "schedule_breaks",
+          "tableTo": "profiles",
+          "columnsFrom": [
+            "updated_by_profile_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {
+        "Coaches can manage schedule_breaks": {
+          "name": "Coaches can manage schedule_breaks",
+          "as": "PERMISSIVE",
+          "for": "ALL",
+          "to": [
+            "authenticated"
+          ],
+          "using": "(EXISTS ( SELECT 1\n   FROM profiles\n  WHERE ((profiles.user_id IN ( SELECT users.id\n           FROM users\n          WHERE (users.auth_user_id = ( SELECT auth.uid() AS uid)))) AND (profiles.role = ANY (ARRAY['coach'::profile_role, 'admin'::profile_role])))))",
+          "withCheck": "(EXISTS ( SELECT 1\n   FROM profiles\n  WHERE ((profiles.user_id IN ( SELECT users.id\n           FROM users\n          WHERE (users.auth_user_id = ( SELECT auth.uid() AS uid)))) AND (profiles.role = ANY (ARRAY['coach'::profile_role, 'admin'::profile_role])))))"
+        },
+        "Authenticated can read schedule_breaks": {
+          "name": "Authenticated can read schedule_breaks",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": [
+            "authenticated"
+          ],
+          "using": "true"
+        }
+      },
+      "checkConstraints": {
+        "valid_break_date_range": {
+          "name": "valid_break_date_range",
+          "value": "end_date >= start_date"
+        }
+      },
+      "isRLSEnabled": true
+    },
+    "public.team_activities": {
+      "name": "team_activities",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "occurred_at": {
+          "name": "occurred_at",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "activity_type": {
+          "name": "activity_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "participants": {
+          "name": "participants",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reflection": {
+          "name": "reflection",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "removed_at": {
+          "name": "removed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_by_profile_id": {
+          "name": "created_by_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_by_profile_id": {
+          "name": "updated_by_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "team_activities_team_occurred_at_idx": {
+          "name": "team_activities_team_occurred_at_idx",
+          "columns": [
+            {
+              "expression": "team_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "uuid_ops"
+            },
+            {
+              "expression": "occurred_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "date_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "team_activities_team_id_fkey": {
+          "name": "team_activities_team_id_fkey",
+          "tableFrom": "team_activities",
+          "tableTo": "teams",
+          "columnsFrom": [
+            "team_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "team_activities_created_by_profile_id_fkey": {
+          "name": "team_activities_created_by_profile_id_fkey",
+          "tableFrom": "team_activities",
+          "tableTo": "profiles",
+          "columnsFrom": [
+            "created_by_profile_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "team_activities_updated_by_profile_id_fkey": {
+          "name": "team_activities_updated_by_profile_id_fkey",
+          "tableFrom": "team_activities",
+          "tableTo": "profiles",
+          "columnsFrom": [
+            "updated_by_profile_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {
+        "Team members can view activities": {
+          "name": "Team members can view activities",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": [
+            "authenticated"
+          ],
+          "using": "team_id IN (SELECT team_id FROM profiles WHERE id = current_profile_id() AND access_removed_at IS NULL)"
+        },
+        "Team members can create activities": {
+          "name": "Team members can create activities",
+          "as": "PERMISSIVE",
+          "for": "INSERT",
+          "to": [
+            "authenticated"
+          ],
+          "withCheck": "team_id IN (SELECT team_id FROM profiles WHERE id = current_profile_id() AND access_removed_at IS NULL)"
+        },
+        "Team members can update activities": {
+          "name": "Team members can update activities",
+          "as": "PERMISSIVE",
+          "for": "UPDATE",
+          "to": [
+            "authenticated"
+          ],
+          "using": "team_id IN (SELECT team_id FROM profiles WHERE id = current_profile_id() AND access_removed_at IS NULL)",
+          "withCheck": "team_id IN (SELECT team_id FROM profiles WHERE id = current_profile_id() AND access_removed_at IS NULL)"
+        },
+        "Team members can delete activities": {
+          "name": "Team members can delete activities",
+          "as": "PERMISSIVE",
+          "for": "DELETE",
+          "to": [
+            "authenticated"
+          ],
+          "using": "team_id IN (SELECT team_id FROM profiles WHERE id = current_profile_id() AND access_removed_at IS NULL)"
+        }
+      },
+      "checkConstraints": {},
+      "isRLSEnabled": true
+    },
+    "public.team_document_versions": {
+      "name": "team_document_versions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "document_id": {
+          "name": "document_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "version_no": {
+          "name": "version_no",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "file_path": {
+          "name": "file_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "file_name": {
+          "name": "file_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "file_size": {
+          "name": "file_size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "effective_from": {
+          "name": "effective_from",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "change_note": {
+          "name": "change_note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_by_profile_id": {
+          "name": "created_by_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "team_document_versions_document_version_idx": {
+          "name": "team_document_versions_document_version_idx",
+          "columns": [
+            {
+              "expression": "document_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "uuid_ops"
+            },
+            {
+              "expression": "version_no",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "int4_ops"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "team_document_versions_document_id_fkey": {
+          "name": "team_document_versions_document_id_fkey",
+          "tableFrom": "team_document_versions",
+          "tableTo": "team_documents",
+          "columnsFrom": [
+            "document_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "team_document_versions_created_by_profile_id_fkey": {
+          "name": "team_document_versions_created_by_profile_id_fkey",
+          "tableFrom": "team_document_versions",
+          "tableTo": "profiles",
+          "columnsFrom": [
+            "created_by_profile_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {
+        "Team members can view document versions": {
+          "name": "Team members can view document versions",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": [
+            "authenticated"
+          ],
+          "using": "document_id IN (\n\t\t\tSELECT team_documents.id\n\t\t\tFROM team_documents\n\t\t\tWHERE team_documents.team_id IN (\n\t\t\t\tSELECT team_id FROM profiles WHERE id = current_profile_id() AND access_removed_at IS NULL\n\t\t\t)\n\t\t)"
+        },
+        "Team members can create document versions": {
+          "name": "Team members can create document versions",
+          "as": "PERMISSIVE",
+          "for": "INSERT",
+          "to": [
+            "authenticated"
+          ],
+          "withCheck": "created_by_profile_id = current_profile_id() AND document_id IN (\n\t\t\tSELECT team_documents.id\n\t\t\tFROM team_documents\n\t\t\tWHERE team_documents.removed_at IS NULL\n\t\t\t\tAND team_documents.team_id IN (\n\t\t\t\t\tSELECT team_id FROM profiles WHERE id = current_profile_id() AND access_removed_at IS NULL\n\t\t\t\t)\n\t\t)"
+        }
+      },
+      "checkConstraints": {
+        "team_document_versions_version_positive": {
+          "name": "team_document_versions_version_positive",
+          "value": "version_no > 0"
+        },
+        "team_document_versions_file_size_positive": {
+          "name": "team_document_versions_file_size_positive",
+          "value": "file_size > 0"
+        }
+      },
+      "isRLSEnabled": true
+    },
+    "public.team_documents": {
+      "name": "team_documents",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "doc_type": {
+          "name": "doc_type",
+          "type": "team_document_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "removed_at": {
+          "name": "removed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_by_profile_id": {
+          "name": "created_by_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_by_profile_id": {
+          "name": "updated_by_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "team_documents_featured_team_type_idx": {
+          "name": "team_documents_featured_team_type_idx",
+          "columns": [
+            {
+              "expression": "team_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "uuid_ops"
+            },
+            {
+              "expression": "doc_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "enum_ops"
+            }
+          ],
+          "isUnique": true,
+          "where": "doc_type IN ('team_contract', 'financial_policy') AND removed_at IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "team_documents_team_id_fkey": {
+          "name": "team_documents_team_id_fkey",
+          "tableFrom": "team_documents",
+          "tableTo": "teams",
+          "columnsFrom": [
+            "team_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "team_documents_created_by_profile_id_fkey": {
+          "name": "team_documents_created_by_profile_id_fkey",
+          "tableFrom": "team_documents",
+          "tableTo": "profiles",
+          "columnsFrom": [
+            "created_by_profile_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "team_documents_updated_by_profile_id_fkey": {
+          "name": "team_documents_updated_by_profile_id_fkey",
+          "tableFrom": "team_documents",
+          "tableTo": "profiles",
+          "columnsFrom": [
+            "updated_by_profile_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {
+        "Team members can view documents": {
+          "name": "Team members can view documents",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": [
+            "authenticated"
+          ],
+          "using": "team_id IN (SELECT team_id FROM profiles WHERE id = current_profile_id() AND access_removed_at IS NULL)"
+        },
+        "Team members can create documents": {
+          "name": "Team members can create documents",
+          "as": "PERMISSIVE",
+          "for": "INSERT",
+          "to": [
+            "authenticated"
+          ],
+          "withCheck": "team_id IN (SELECT team_id FROM profiles WHERE id = current_profile_id() AND access_removed_at IS NULL) AND created_by_profile_id = current_profile_id() AND updated_by_profile_id = current_profile_id()"
+        },
+        "Team members can update custom documents": {
+          "name": "Team members can update custom documents",
+          "as": "PERMISSIVE",
+          "for": "UPDATE",
+          "to": [
+            "authenticated"
+          ],
+          "using": "doc_type = 'other' AND team_id IN (SELECT team_id FROM profiles WHERE id = current_profile_id() AND access_removed_at IS NULL)",
+          "withCheck": "doc_type = 'other' AND team_id IN (SELECT team_id FROM profiles WHERE id = current_profile_id() AND access_removed_at IS NULL) AND updated_by_profile_id = current_profile_id()"
+        }
+      },
+      "checkConstraints": {
+        "team_documents_title_matches_type": {
+          "name": "team_documents_title_matches_type",
+          "value": "(\n\t\t(doc_type = 'other' AND title IS NOT NULL AND length(trim(title)) > 0)\n\t\tOR (doc_type <> 'other' AND title IS NULL)\n\t)"
+        }
+      },
+      "isRLSEnabled": true
+    },
+    "public.team_reflections": {
+      "name": "team_reflections",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "month": {
+          "name": "month",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "what_went_well": {
+          "name": "what_went_well",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "what_didnt_go_well": {
+          "name": "what_didnt_go_well",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "what_we_do_differently": {
+          "name": "what_we_do_differently",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "planned_action_steps": {
+          "name": "planned_action_steps",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "responsible_person": {
+          "name": "responsible_person",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "removed_at": {
+          "name": "removed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_by_profile_id": {
+          "name": "created_by_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_by_profile_id": {
+          "name": "updated_by_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "team_reflections_team_month_idx": {
+          "name": "team_reflections_team_month_idx",
+          "columns": [
+            {
+              "expression": "team_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "uuid_ops"
+            },
+            {
+              "expression": "month",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "date_ops"
+            }
+          ],
+          "isUnique": true,
+          "where": "(removed_at IS NULL)",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "team_reflections_team_id_fkey": {
+          "name": "team_reflections_team_id_fkey",
+          "tableFrom": "team_reflections",
+          "tableTo": "teams",
+          "columnsFrom": [
+            "team_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "team_reflections_created_by_profile_id_fkey": {
+          "name": "team_reflections_created_by_profile_id_fkey",
+          "tableFrom": "team_reflections",
+          "tableTo": "profiles",
+          "columnsFrom": [
+            "created_by_profile_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "team_reflections_updated_by_profile_id_fkey": {
+          "name": "team_reflections_updated_by_profile_id_fkey",
+          "tableFrom": "team_reflections",
+          "tableTo": "profiles",
+          "columnsFrom": [
+            "updated_by_profile_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {
+        "Team members can view reflections": {
+          "name": "Team members can view reflections",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": [
+            "authenticated"
+          ],
+          "using": "team_id IN (SELECT team_id FROM profiles WHERE id = current_profile_id() AND access_removed_at IS NULL)"
+        },
+        "Team members can create reflections": {
+          "name": "Team members can create reflections",
+          "as": "PERMISSIVE",
+          "for": "INSERT",
+          "to": [
+            "authenticated"
+          ],
+          "withCheck": "team_id IN (SELECT team_id FROM profiles WHERE id = current_profile_id() AND access_removed_at IS NULL)"
+        },
+        "Team members can update reflections": {
+          "name": "Team members can update reflections",
+          "as": "PERMISSIVE",
+          "for": "UPDATE",
+          "to": [
+            "authenticated"
+          ],
+          "using": "team_id IN (SELECT team_id FROM profiles WHERE id = current_profile_id() AND access_removed_at IS NULL)",
+          "withCheck": "team_id IN (SELECT team_id FROM profiles WHERE id = current_profile_id() AND access_removed_at IS NULL)"
+        },
+        "Team members can delete reflections": {
+          "name": "Team members can delete reflections",
+          "as": "PERMISSIVE",
+          "for": "DELETE",
+          "to": [
+            "authenticated"
+          ],
+          "using": "team_id IN (SELECT team_id FROM profiles WHERE id = current_profile_id() AND access_removed_at IS NULL)"
+        }
+      },
+      "checkConstraints": {},
+      "isRLSEnabled": true
+    },
+    "public.team_semester_reflection_entries": {
+      "name": "team_semester_reflection_entries",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "semester_reflection_id": {
+          "name": "semester_reflection_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "topic": {
+          "name": "topic",
+          "type": "semester_reflection_topic",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "what_went_well": {
+          "name": "what_went_well",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "what_didnt_go_well": {
+          "name": "what_didnt_go_well",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "what_next_time": {
+          "name": "what_next_time",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_by_profile_id": {
+          "name": "updated_by_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "team_semester_reflection_entries_reflection_topic_idx": {
+          "name": "team_semester_reflection_entries_reflection_topic_idx",
+          "columns": [
+            {
+              "expression": "semester_reflection_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "uuid_ops"
+            },
+            {
+              "expression": "topic",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "enum_ops"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "team_semester_reflection_entries_reflection_idx": {
+          "name": "team_semester_reflection_entries_reflection_idx",
+          "columns": [
+            {
+              "expression": "semester_reflection_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "uuid_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "team_semester_reflection_entries_semester_reflection_id_fkey": {
+          "name": "team_semester_reflection_entries_semester_reflection_id_fkey",
+          "tableFrom": "team_semester_reflection_entries",
+          "tableTo": "team_semester_reflections",
+          "columnsFrom": [
+            "semester_reflection_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "team_semester_reflection_entries_updated_by_profile_id_fkey": {
+          "name": "team_semester_reflection_entries_updated_by_profile_id_fkey",
+          "tableFrom": "team_semester_reflection_entries",
+          "tableTo": "profiles",
+          "columnsFrom": [
+            "updated_by_profile_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {
+        "Team members can view semester reflection entries": {
+          "name": "Team members can view semester reflection entries",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": [
+            "authenticated"
+          ],
+          "using": "EXISTS (SELECT 1 FROM team_semester_reflections tsr WHERE tsr.id = team_semester_reflection_entries.semester_reflection_id AND tsr.team_id IN (SELECT team_id FROM profiles WHERE id = current_profile_id() AND access_removed_at IS NULL))"
+        },
+        "Team members can create semester reflection entries": {
+          "name": "Team members can create semester reflection entries",
+          "as": "PERMISSIVE",
+          "for": "INSERT",
+          "to": [
+            "authenticated"
+          ],
+          "withCheck": "EXISTS (SELECT 1 FROM team_semester_reflections tsr WHERE tsr.id = team_semester_reflection_entries.semester_reflection_id AND tsr.team_id IN (SELECT team_id FROM profiles WHERE id = current_profile_id() AND access_removed_at IS NULL))"
+        },
+        "Team members can update semester reflection entries": {
+          "name": "Team members can update semester reflection entries",
+          "as": "PERMISSIVE",
+          "for": "UPDATE",
+          "to": [
+            "authenticated"
+          ],
+          "using": "EXISTS (SELECT 1 FROM team_semester_reflections tsr WHERE tsr.id = team_semester_reflection_entries.semester_reflection_id AND tsr.team_id IN (SELECT team_id FROM profiles WHERE id = current_profile_id() AND access_removed_at IS NULL))",
+          "withCheck": "EXISTS (SELECT 1 FROM team_semester_reflections tsr WHERE tsr.id = team_semester_reflection_entries.semester_reflection_id AND tsr.team_id IN (SELECT team_id FROM profiles WHERE id = current_profile_id() AND access_removed_at IS NULL))"
+        }
+      },
+      "checkConstraints": {},
+      "isRLSEnabled": true
+    },
+    "public.team_semester_reflections": {
+      "name": "team_semester_reflections",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "semester_month": {
+          "name": "semester_month",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "removed_at": {
+          "name": "removed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_by_profile_id": {
+          "name": "created_by_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_by_profile_id": {
+          "name": "updated_by_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "team_semester_reflections_team_month_idx": {
+          "name": "team_semester_reflections_team_month_idx",
+          "columns": [
+            {
+              "expression": "team_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "uuid_ops"
+            },
+            {
+              "expression": "semester_month",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "date_ops"
+            }
+          ],
+          "isUnique": true,
+          "where": "(removed_at IS NULL)",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "team_semester_reflections_team_id_fkey": {
+          "name": "team_semester_reflections_team_id_fkey",
+          "tableFrom": "team_semester_reflections",
+          "tableTo": "teams",
+          "columnsFrom": [
+            "team_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "team_semester_reflections_created_by_profile_id_fkey": {
+          "name": "team_semester_reflections_created_by_profile_id_fkey",
+          "tableFrom": "team_semester_reflections",
+          "tableTo": "profiles",
+          "columnsFrom": [
+            "created_by_profile_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "team_semester_reflections_updated_by_profile_id_fkey": {
+          "name": "team_semester_reflections_updated_by_profile_id_fkey",
+          "tableFrom": "team_semester_reflections",
+          "tableTo": "profiles",
+          "columnsFrom": [
+            "updated_by_profile_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {
+        "Team members can view semester reflections": {
+          "name": "Team members can view semester reflections",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": [
+            "authenticated"
+          ],
+          "using": "team_id IN (SELECT team_id FROM profiles WHERE id = current_profile_id() AND access_removed_at IS NULL)"
+        },
+        "Team members can create semester reflections": {
+          "name": "Team members can create semester reflections",
+          "as": "PERMISSIVE",
+          "for": "INSERT",
+          "to": [
+            "authenticated"
+          ],
+          "withCheck": "team_id IN (SELECT team_id FROM profiles WHERE id = current_profile_id() AND access_removed_at IS NULL)"
+        },
+        "Team members can update semester reflections": {
+          "name": "Team members can update semester reflections",
+          "as": "PERMISSIVE",
+          "for": "UPDATE",
+          "to": [
+            "authenticated"
+          ],
+          "using": "team_id IN (SELECT team_id FROM profiles WHERE id = current_profile_id() AND access_removed_at IS NULL)",
+          "withCheck": "team_id IN (SELECT team_id FROM profiles WHERE id = current_profile_id() AND access_removed_at IS NULL)"
+        },
+        "Team members can delete semester reflections": {
+          "name": "Team members can delete semester reflections",
+          "as": "PERMISSIVE",
+          "for": "DELETE",
+          "to": [
+            "authenticated"
+          ],
+          "using": "team_id IN (SELECT team_id FROM profiles WHERE id = current_profile_id() AND access_removed_at IS NULL)"
+        }
+      },
+      "checkConstraints": {
+        "team_semester_reflections_month_check": {
+          "name": "team_semester_reflections_month_check",
+          "value": "EXTRACT(MONTH FROM semester_month) IN (1, 5)"
+        }
+      },
+      "isRLSEnabled": true
+    },
+    "public.teams": {
+      "name": "teams",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "picture": {
+          "name": "picture",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "color": {
+          "name": "color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "onboardingYear": {
+          "name": "onboardingYear",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "removed_at": {
+          "name": "removed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_by_profile_id": {
+          "name": "created_by_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_by_profile_id": {
+          "name": "updated_by_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {
+        "Authenticated users can read teams": {
+          "name": "Authenticated users can read teams",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": [
+            "authenticated"
+          ],
+          "using": "true"
+        }
+      },
+      "checkConstraints": {},
+      "isRLSEnabled": true
+    },
+    "public.tools_techniques": {
+      "name": "tools_techniques",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "profile_id": {
+          "name": "profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tool_type": {
+          "name": "tool_type",
+          "type": "tool_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reflection": {
+          "name": "reflection",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "removed_at": {
+          "name": "removed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_by_profile_id": {
+          "name": "created_by_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_by_profile_id": {
+          "name": "updated_by_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "tools_techniques_profile_idx": {
+          "name": "tools_techniques_profile_idx",
+          "columns": [
+            {
+              "expression": "profile_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "uuid_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "tools_techniques_profile_id_fkey": {
+          "name": "tools_techniques_profile_id_fkey",
+          "tableFrom": "tools_techniques",
+          "tableTo": "profiles",
+          "columnsFrom": [
+            "profile_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "tools_techniques_created_by_profile_id_fkey": {
+          "name": "tools_techniques_created_by_profile_id_fkey",
+          "tableFrom": "tools_techniques",
+          "tableTo": "profiles",
+          "columnsFrom": [
+            "created_by_profile_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "tools_techniques_updated_by_profile_id_fkey": {
+          "name": "tools_techniques_updated_by_profile_id_fkey",
+          "tableFrom": "tools_techniques",
+          "tableTo": "profiles",
+          "columnsFrom": [
+            "updated_by_profile_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {
+        "Users can view their own tools and techniques": {
+          "name": "Users can view their own tools and techniques",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": [
+            "authenticated"
+          ],
+          "using": "(profile_id = current_profile_id())"
+        },
+        "Users can create their own tools and techniques": {
+          "name": "Users can create their own tools and techniques",
+          "as": "PERMISSIVE",
+          "for": "INSERT",
+          "to": [
+            "authenticated"
+          ],
+          "withCheck": "(profile_id = current_profile_id())"
+        },
+        "Users can update their own tools and techniques": {
+          "name": "Users can update their own tools and techniques",
+          "as": "PERMISSIVE",
+          "for": "UPDATE",
+          "to": [
+            "authenticated"
+          ],
+          "using": "(profile_id = current_profile_id())",
+          "withCheck": "(profile_id = current_profile_id())"
+        },
+        "Users can delete their own tools and techniques": {
+          "name": "Users can delete their own tools and techniques",
+          "as": "PERMISSIVE",
+          "for": "DELETE",
+          "to": [
+            "authenticated"
+          ],
+          "using": "(profile_id = current_profile_id())"
+        }
+      },
+      "checkConstraints": {},
+      "isRLSEnabled": true
+    }
+  },
+  "enums": {
+    "public.book_list_status": {
+      "name": "book_list_status",
+      "schema": "public",
+      "values": [
+        "processing",
+        "shortlist",
+        "longlist",
+        "archived"
+      ]
+    },
+    "public.book_source": {
+      "name": "book_source",
+      "schema": "public",
+      "values": [
+        "manual",
+        "google_books",
+        "open_library"
+      ]
+    },
+    "public.personality_test_type": {
+      "name": "personality_test_type",
+      "schema": "public",
+      "values": [
+        "gallup",
+        "mbti",
+        "disc",
+        "big_five",
+        "enneagram",
+        "belbin",
+        "other"
+      ]
+    },
+    "public.profile_role": {
+      "name": "profile_role",
+      "schema": "public",
+      "values": [
+        "student",
+        "mentor",
+        "coach",
+        "admin"
+      ]
+    },
+    "public.schedule_type": {
+      "name": "schedule_type",
+      "schema": "public",
+      "values": [
+        "training_session",
+        "houston_calling"
+      ]
+    },
+    "public.team_document_type": {
+      "name": "team_document_type",
+      "schema": "public",
+      "values": [
+        "team_contract",
+        "financial_policy",
+        "other"
+      ]
+    },
+    "public.semester_reflection_topic": {
+      "name": "semester_reflection_topic",
+      "schema": "public",
+      "values": [
+        "predmety_zkousky_vyucujici",
+        "metodika_a_metriky",
+        "kouci_a_mentori",
+        "tymy_a_tymove_spolecnosti",
+        "individualni_prinos",
+        "komunita",
+        "komunitni_role",
+        "komunitni_akce",
+        "komunitni_a_cross_projekty",
+        "zacleneni_tucnaku",
+        "dalsi"
+      ]
+    },
+    "public.tool_type": {
+      "name": "tool_type",
+      "schema": "public",
+      "values": [
+        "model",
+        "technique",
+        "tool"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {
+    "public.books_with_essay_count": {
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "title_cs": {
+          "name": "title_cs",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "title_en": {
+          "name": "title_en",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "author": {
+          "name": "author",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "isbn_13": {
+          "name": "isbn_13",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "google_books_cover_url": {
+          "name": "google_books_cover_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "book_points": {
+          "name": "book_points",
+          "type": "numeric(3, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "page_count": {
+          "name": "page_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "preview_link": {
+          "name": "preview_link",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source": {
+          "name": "source",
+          "type": "book_source",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "external_id": {
+          "name": "external_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "list_status": {
+          "name": "list_status",
+          "type": "book_list_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "list_status_changed_at": {
+          "name": "list_status_changed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "list_status_changed_by_profile_id": {
+          "name": "list_status_changed_by_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "list_status_reason": {
+          "name": "list_status_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "highlight_category_id": {
+          "name": "highlight_category_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_rocket_model": {
+          "name": "is_rocket_model",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by_profile_id": {
+          "name": "created_by_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_by_profile_id": {
+          "name": "updated_by_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "essay_count": {
+          "name": "essay_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "definition": "SELECT b.id, b.title_cs, b.title_en, b.author, b.isbn_13, b.description, b.google_books_cover_url, b.book_points, b.page_count, b.preview_link, b.source, b.external_id, b.list_status, b.list_status_changed_at, b.list_status_changed_by_profile_id, b.list_status_reason, b.highlight_category_id, b.is_rocket_model, b.created_at, b.updated_at, b.created_by_profile_id, b.updated_by_profile_id, COALESCE(ec.essay_count, 0) AS essay_count FROM books b LEFT JOIN ( SELECT essays.book_id, count(*)::integer AS essay_count FROM essays WHERE essays.book_id IS NOT NULL AND essays.published_at IS NOT NULL AND essays.removed_at IS NULL GROUP BY essays.book_id) ec ON ec.book_id = b.id",
+      "name": "books_with_essay_count",
+      "schema": "public",
+      "isExisting": false,
+      "materialized": false
+    }
+  },
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/supabase/migrations/meta/20260818230458_snapshot.json
+++ b/supabase/migrations/meta/20260818230458_snapshot.json
@@ -1,0 +1,6164 @@
+{
+  "id": "dfa791a7-92e4-4bdc-a2cf-5cbf67536583",
+  "prevId": "4fc2edb9-1220-45f1-96c8-e1089b745b81",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.book_loans": {
+      "name": "book_loans",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "library_book_id": {
+          "name": "library_book_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "borrower_id": {
+          "name": "borrower_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "borrowed_at": {
+          "name": "borrowed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "due_at": {
+          "name": "due_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "returned_at": {
+          "name": "returned_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "book_loans_library_book_id_idx": {
+          "name": "book_loans_library_book_id_idx",
+          "columns": [
+            {
+              "expression": "library_book_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "uuid_ops"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "book_loans_borrower_id_idx": {
+          "name": "book_loans_borrower_id_idx",
+          "columns": [
+            {
+              "expression": "borrower_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "uuid_ops"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "book_loans_active_idx": {
+          "name": "book_loans_active_idx",
+          "columns": [
+            {
+              "expression": "library_book_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "uuid_ops"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "where": "(returned_at IS NULL)",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "book_loans_library_book_id_fkey": {
+          "name": "book_loans_library_book_id_fkey",
+          "tableFrom": "book_loans",
+          "columnsFrom": [
+            "library_book_id"
+          ],
+          "tableTo": "library_books",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "restrict"
+        },
+        "book_loans_borrower_id_fkey": {
+          "name": "book_loans_borrower_id_fkey",
+          "tableFrom": "book_loans",
+          "columnsFrom": [
+            "borrower_id"
+          ],
+          "tableTo": "profiles",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "restrict"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {
+        "Authenticated users can view loans": {
+          "name": "Authenticated users can view loans",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": [
+            "authenticated"
+          ],
+          "using": "true"
+        },
+        "Users can borrow for themselves": {
+          "name": "Users can borrow for themselves",
+          "as": "PERMISSIVE",
+          "for": "INSERT",
+          "to": [
+            "authenticated"
+          ],
+          "withCheck": "(borrower_id = current_profile_id())"
+        },
+        "Borrower can return their own loan": {
+          "name": "Borrower can return their own loan",
+          "as": "PERMISSIVE",
+          "for": "UPDATE",
+          "to": [
+            "authenticated"
+          ],
+          "using": "(borrower_id = current_profile_id())",
+          "withCheck": "(borrower_id = current_profile_id())"
+        }
+      },
+      "checkConstraints": {},
+      "isRLSEnabled": true
+    },
+    "public.book_tags": {
+      "name": "book_tags",
+      "schema": "",
+      "columns": {
+        "book_id": {
+          "name": "book_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tag_id": {
+          "name": "tag_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_by_profile_id": {
+          "name": "created_by_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_by_profile_id": {
+          "name": "updated_by_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "book_tags_tag_idx": {
+          "name": "book_tags_tag_idx",
+          "columns": [
+            {
+              "expression": "tag_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "uuid_ops"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "book_tags_book_id_fkey": {
+          "name": "book_tags_book_id_fkey",
+          "tableFrom": "book_tags",
+          "columnsFrom": [
+            "book_id"
+          ],
+          "tableTo": "books",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        },
+        "book_tags_tag_id_fkey": {
+          "name": "book_tags_tag_id_fkey",
+          "tableFrom": "book_tags",
+          "columnsFrom": [
+            "tag_id"
+          ],
+          "tableTo": "tags",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        },
+        "book_tags_created_by_profile_id_fkey": {
+          "name": "book_tags_created_by_profile_id_fkey",
+          "tableFrom": "book_tags",
+          "columnsFrom": [
+            "created_by_profile_id"
+          ],
+          "tableTo": "profiles",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "restrict"
+        },
+        "book_tags_updated_by_profile_id_fkey": {
+          "name": "book_tags_updated_by_profile_id_fkey",
+          "tableFrom": "book_tags",
+          "columnsFrom": [
+            "updated_by_profile_id"
+          ],
+          "tableTo": "profiles",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "restrict"
+        }
+      },
+      "compositePrimaryKeys": {
+        "book_tags_pkey": {
+          "name": "book_tags_pkey",
+          "columns": [
+            "book_id",
+            "tag_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {
+        "Authenticated users can view book tags": {
+          "name": "Authenticated users can view book tags",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": [
+            "authenticated"
+          ],
+          "using": "true"
+        },
+        "Authenticated users can assign book tags": {
+          "name": "Authenticated users can assign book tags",
+          "as": "PERMISSIVE",
+          "for": "INSERT",
+          "to": [
+            "authenticated"
+          ],
+          "withCheck": "(created_by_profile_id = current_profile_id())"
+        },
+        "Coaches and admins can update book tags": {
+          "name": "Coaches and admins can update book tags",
+          "as": "PERMISSIVE",
+          "for": "UPDATE",
+          "to": [
+            "authenticated"
+          ],
+          "using": "is_coach_or_admin()",
+          "withCheck": "is_coach_or_admin()"
+        },
+        "Coaches and admins can remove book tags": {
+          "name": "Coaches and admins can remove book tags",
+          "as": "PERMISSIVE",
+          "for": "DELETE",
+          "to": [
+            "authenticated"
+          ],
+          "using": "is_coach_or_admin()"
+        }
+      },
+      "checkConstraints": {},
+      "isRLSEnabled": true
+    },
+    "public.books": {
+      "name": "books",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "title_cs": {
+          "name": "title_cs",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title_en": {
+          "name": "title_en",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "author": {
+          "name": "author",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "isbn_13": {
+          "name": "isbn_13",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "google_books_cover_url": {
+          "name": "google_books_cover_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "book_points": {
+          "name": "book_points",
+          "type": "numeric(3, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "page_count": {
+          "name": "page_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "preview_link": {
+          "name": "preview_link",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source": {
+          "name": "source",
+          "type": "book_source",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'manual'"
+        },
+        "external_id": {
+          "name": "external_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "list_status": {
+          "name": "list_status",
+          "type": "book_list_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'processing'"
+        },
+        "list_status_changed_at": {
+          "name": "list_status_changed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "list_status_changed_by_profile_id": {
+          "name": "list_status_changed_by_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "list_status_reason": {
+          "name": "list_status_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "highlight_category_id": {
+          "name": "highlight_category_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_rocket_model": {
+          "name": "is_rocket_model",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_by_profile_id": {
+          "name": "created_by_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_by_profile_id": {
+          "name": "updated_by_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "books_created_by_idx": {
+          "name": "books_created_by_idx",
+          "columns": [
+            {
+              "expression": "created_by_profile_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "uuid_ops"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "books_author_trgm_idx": {
+          "name": "books_author_trgm_idx",
+          "columns": [
+            {
+              "expression": "author",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "gin_trgm_ops"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "gin",
+          "concurrently": false
+        },
+        "books_created_desc_idx": {
+          "name": "books_created_desc_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "first",
+              "opclass": "timestamptz_ops"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "books_isbn_13_idx": {
+          "name": "books_isbn_13_idx",
+          "columns": [
+            {
+              "expression": "isbn_13",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "text_ops"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "where": "(isbn_13 IS NOT NULL)",
+          "concurrently": false
+        },
+        "books_list_status_idx": {
+          "name": "books_list_status_idx",
+          "columns": [
+            {
+              "expression": "list_status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "enum_ops"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "books_title_cs_trgm_idx": {
+          "name": "books_title_cs_trgm_idx",
+          "columns": [
+            {
+              "expression": "title_cs",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "gin_trgm_ops"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "gin",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "books_created_by_profile_id_fkey": {
+          "name": "books_created_by_profile_id_fkey",
+          "tableFrom": "books",
+          "columnsFrom": [
+            "created_by_profile_id"
+          ],
+          "tableTo": "profiles",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "restrict"
+        },
+        "books_updated_by_profile_id_fkey": {
+          "name": "books_updated_by_profile_id_fkey",
+          "tableFrom": "books",
+          "columnsFrom": [
+            "updated_by_profile_id"
+          ],
+          "tableTo": "profiles",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "restrict"
+        },
+        "books_list_status_changed_by_profile_id_fkey": {
+          "name": "books_list_status_changed_by_profile_id_fkey",
+          "tableFrom": "books",
+          "columnsFrom": [
+            "list_status_changed_by_profile_id"
+          ],
+          "tableTo": "profiles",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "set null"
+        },
+        "books_highlight_category_id_fkey": {
+          "name": "books_highlight_category_id_fkey",
+          "tableFrom": "books",
+          "columnsFrom": [
+            "highlight_category_id"
+          ],
+          "tableTo": "highlight_categories",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "set null"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {
+        "Coaches and admins can delete books": {
+          "name": "Coaches and admins can delete books",
+          "as": "PERMISSIVE",
+          "for": "DELETE",
+          "to": [
+            "public"
+          ],
+          "using": "is_coach_or_admin()"
+        },
+        "Coaches and admins can update books": {
+          "name": "Coaches and admins can update books",
+          "as": "PERMISSIVE",
+          "for": "UPDATE",
+          "to": [
+            "authenticated"
+          ],
+          "using": "is_coach_or_admin()",
+          "withCheck": "is_coach_or_admin()"
+        },
+        "Authenticated users can add books": {
+          "name": "Authenticated users can add books",
+          "as": "PERMISSIVE",
+          "for": "INSERT",
+          "to": [
+            "authenticated"
+          ],
+          "withCheck": "(created_by_profile_id = current_profile_id())"
+        },
+        "Authenticated users can view all books": {
+          "name": "Authenticated users can view all books",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": [
+            "authenticated"
+          ],
+          "using": "true"
+        }
+      },
+      "checkConstraints": {
+        "books_book_points_check": {
+          "name": "books_book_points_check",
+          "value": "(book_points IS NULL) OR ((book_points >= (0)::numeric) AND (book_points <= (3)::numeric))"
+        },
+        "books_archived_points_check": {
+          "name": "books_archived_points_check",
+          "value": "(list_status <> 'archived') OR (book_points = (0)::numeric)"
+        }
+      },
+      "isRLSEnabled": true
+    },
+    "public.highlight_categories": {
+      "name": "highlight_categories",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_by_profile_id": {
+          "name": "created_by_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_by_profile_id": {
+          "name": "updated_by_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "highlight_categories_created_by_profile_id_fkey": {
+          "name": "highlight_categories_created_by_profile_id_fkey",
+          "tableFrom": "highlight_categories",
+          "columnsFrom": [
+            "created_by_profile_id"
+          ],
+          "tableTo": "profiles",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "restrict"
+        },
+        "highlight_categories_updated_by_profile_id_fkey": {
+          "name": "highlight_categories_updated_by_profile_id_fkey",
+          "tableFrom": "highlight_categories",
+          "columnsFrom": [
+            "updated_by_profile_id"
+          ],
+          "tableTo": "profiles",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "restrict"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {
+        "Authenticated users can view highlight categories": {
+          "name": "Authenticated users can view highlight categories",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": [
+            "authenticated"
+          ],
+          "using": "true"
+        },
+        "Coaches and admins can add highlight categories": {
+          "name": "Coaches and admins can add highlight categories",
+          "as": "PERMISSIVE",
+          "for": "INSERT",
+          "to": [
+            "authenticated"
+          ],
+          "withCheck": "is_coach_or_admin()"
+        },
+        "Coaches and admins can update highlight categories": {
+          "name": "Coaches and admins can update highlight categories",
+          "as": "PERMISSIVE",
+          "for": "UPDATE",
+          "to": [
+            "authenticated"
+          ],
+          "using": "is_coach_or_admin()",
+          "withCheck": "is_coach_or_admin()"
+        },
+        "Coaches and admins can delete highlight categories": {
+          "name": "Coaches and admins can delete highlight categories",
+          "as": "PERMISSIVE",
+          "for": "DELETE",
+          "to": [
+            "authenticated"
+          ],
+          "using": "is_coach_or_admin()"
+        }
+      },
+      "checkConstraints": {},
+      "isRLSEnabled": true
+    },
+    "public.library_books": {
+      "name": "library_books",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "book_id": {
+          "name": "book_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "isbn_13": {
+          "name": "isbn_13",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_by_profile_id": {
+          "name": "created_by_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_by_profile_id": {
+          "name": "updated_by_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "library_books_book_id_idx": {
+          "name": "library_books_book_id_idx",
+          "columns": [
+            {
+              "expression": "book_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "uuid_ops"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "library_books_isbn_13_idx": {
+          "name": "library_books_isbn_13_idx",
+          "columns": [
+            {
+              "expression": "isbn_13",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "text_ops"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "where": "(isbn_13 IS NOT NULL)",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "library_books_book_id_fkey": {
+          "name": "library_books_book_id_fkey",
+          "tableFrom": "library_books",
+          "columnsFrom": [
+            "book_id"
+          ],
+          "tableTo": "books",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "restrict"
+        },
+        "library_books_created_by_profile_id_fkey": {
+          "name": "library_books_created_by_profile_id_fkey",
+          "tableFrom": "library_books",
+          "columnsFrom": [
+            "created_by_profile_id"
+          ],
+          "tableTo": "profiles",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "restrict"
+        },
+        "library_books_updated_by_profile_id_fkey": {
+          "name": "library_books_updated_by_profile_id_fkey",
+          "tableFrom": "library_books",
+          "columnsFrom": [
+            "updated_by_profile_id"
+          ],
+          "tableTo": "profiles",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "restrict"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {
+        "Authenticated users can view library books": {
+          "name": "Authenticated users can view library books",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": [
+            "authenticated"
+          ],
+          "using": "true"
+        },
+        "Coaches and admins can add library books": {
+          "name": "Coaches and admins can add library books",
+          "as": "PERMISSIVE",
+          "for": "INSERT",
+          "to": [
+            "authenticated"
+          ],
+          "withCheck": "is_coach_or_admin()"
+        },
+        "Coaches and admins can update library books": {
+          "name": "Coaches and admins can update library books",
+          "as": "PERMISSIVE",
+          "for": "UPDATE",
+          "to": [
+            "authenticated"
+          ],
+          "using": "is_coach_or_admin()",
+          "withCheck": "is_coach_or_admin()"
+        },
+        "Coaches and admins can delete library books": {
+          "name": "Coaches and admins can delete library books",
+          "as": "PERMISSIVE",
+          "for": "DELETE",
+          "to": [
+            "authenticated"
+          ],
+          "using": "is_coach_or_admin()"
+        }
+      },
+      "checkConstraints": {},
+      "isRLSEnabled": true
+    },
+    "public.tags": {
+      "name": "tags",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_by_profile_id": {
+          "name": "created_by_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_by_profile_id": {
+          "name": "updated_by_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "tags_created_by_profile_id_fkey": {
+          "name": "tags_created_by_profile_id_fkey",
+          "tableFrom": "tags",
+          "columnsFrom": [
+            "created_by_profile_id"
+          ],
+          "tableTo": "profiles",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "restrict"
+        },
+        "tags_updated_by_profile_id_fkey": {
+          "name": "tags_updated_by_profile_id_fkey",
+          "tableFrom": "tags",
+          "columnsFrom": [
+            "updated_by_profile_id"
+          ],
+          "tableTo": "profiles",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "restrict"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "tags_name_key": {
+          "name": "tags_name_key",
+          "columns": [
+            "name"
+          ],
+          "nullsNotDistinct": false
+        }
+      },
+      "policies": {
+        "Authenticated users can view tags": {
+          "name": "Authenticated users can view tags",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": [
+            "authenticated"
+          ],
+          "using": "true"
+        },
+        "Coaches and admins can add tags": {
+          "name": "Coaches and admins can add tags",
+          "as": "PERMISSIVE",
+          "for": "INSERT",
+          "to": [
+            "authenticated"
+          ],
+          "withCheck": "is_coach_or_admin()"
+        },
+        "Coaches and admins can update tags": {
+          "name": "Coaches and admins can update tags",
+          "as": "PERMISSIVE",
+          "for": "UPDATE",
+          "to": [
+            "authenticated"
+          ],
+          "using": "is_coach_or_admin()",
+          "withCheck": "is_coach_or_admin()"
+        },
+        "Coaches and admins can delete tags": {
+          "name": "Coaches and admins can delete tags",
+          "as": "PERMISSIVE",
+          "for": "DELETE",
+          "to": [
+            "authenticated"
+          ],
+          "using": "is_coach_or_admin()"
+        }
+      },
+      "checkConstraints": {},
+      "isRLSEnabled": true
+    },
+    "public.customer_meetings": {
+      "name": "customer_meetings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "profile_id": {
+          "name": "profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "meeting_at": {
+          "name": "meeting_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "company": {
+          "name": "company",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "contact_person": {
+          "name": "contact_person",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "position": {
+          "name": "position",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "objective": {
+          "name": "objective",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "post_mortem": {
+          "name": "post_mortem",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "team_share": {
+          "name": "team_share",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "removed_at": {
+          "name": "removed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_by_profile_id": {
+          "name": "created_by_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_by_profile_id": {
+          "name": "updated_by_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "customer_meetings_profile_idx": {
+          "name": "customer_meetings_profile_idx",
+          "columns": [
+            {
+              "expression": "profile_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "uuid_ops"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "customer_meetings_created_desc_idx": {
+          "name": "customer_meetings_created_desc_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "first",
+              "opclass": "timestamptz_ops"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "customer_meetings_profile_id_fkey": {
+          "name": "customer_meetings_profile_id_fkey",
+          "tableFrom": "customer_meetings",
+          "columnsFrom": [
+            "profile_id"
+          ],
+          "tableTo": "profiles",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        },
+        "customer_meetings_created_by_profile_id_fkey": {
+          "name": "customer_meetings_created_by_profile_id_fkey",
+          "tableFrom": "customer_meetings",
+          "columnsFrom": [
+            "created_by_profile_id"
+          ],
+          "tableTo": "profiles",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "restrict"
+        },
+        "customer_meetings_updated_by_profile_id_fkey": {
+          "name": "customer_meetings_updated_by_profile_id_fkey",
+          "tableFrom": "customer_meetings",
+          "columnsFrom": [
+            "updated_by_profile_id"
+          ],
+          "tableTo": "profiles",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "restrict"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {
+        "Users can view their own customer meetings": {
+          "name": "Users can view their own customer meetings",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": [
+            "authenticated"
+          ],
+          "using": "(profile_id = current_profile_id())"
+        },
+        "Users can create their own customer meetings": {
+          "name": "Users can create their own customer meetings",
+          "as": "PERMISSIVE",
+          "for": "INSERT",
+          "to": [
+            "authenticated"
+          ],
+          "withCheck": "(profile_id = current_profile_id())"
+        },
+        "Users can update their own customer meetings": {
+          "name": "Users can update their own customer meetings",
+          "as": "PERMISSIVE",
+          "for": "UPDATE",
+          "to": [
+            "authenticated"
+          ],
+          "using": "(profile_id = current_profile_id())",
+          "withCheck": "(profile_id = current_profile_id())"
+        },
+        "Users can delete their own customer meetings": {
+          "name": "Users can delete their own customer meetings",
+          "as": "PERMISSIVE",
+          "for": "DELETE",
+          "to": [
+            "authenticated"
+          ],
+          "using": "(profile_id = current_profile_id())"
+        }
+      },
+      "checkConstraints": {},
+      "isRLSEnabled": true
+    },
+    "public.dashboard_layouts": {
+      "name": "dashboard_layouts",
+      "schema": "",
+      "columns": {
+        "profile_id": {
+          "name": "profile_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "widgets": {
+          "name": "widgets",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_by_profile_id": {
+          "name": "created_by_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_by_profile_id": {
+          "name": "updated_by_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "dashboard_layouts_profile_id_fkey": {
+          "name": "dashboard_layouts_profile_id_fkey",
+          "tableFrom": "dashboard_layouts",
+          "columnsFrom": [
+            "profile_id"
+          ],
+          "tableTo": "profiles",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        },
+        "dashboard_layouts_created_by_profile_id_fkey": {
+          "name": "dashboard_layouts_created_by_profile_id_fkey",
+          "tableFrom": "dashboard_layouts",
+          "columnsFrom": [
+            "created_by_profile_id"
+          ],
+          "tableTo": "profiles",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "restrict"
+        },
+        "dashboard_layouts_updated_by_profile_id_fkey": {
+          "name": "dashboard_layouts_updated_by_profile_id_fkey",
+          "tableFrom": "dashboard_layouts",
+          "columnsFrom": [
+            "updated_by_profile_id"
+          ],
+          "tableTo": "profiles",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "restrict"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {
+        "Users can delete their own dashboard layout": {
+          "name": "Users can delete their own dashboard layout",
+          "as": "PERMISSIVE",
+          "for": "DELETE",
+          "to": [
+            "public"
+          ],
+          "using": "(profile_id = current_profile_id())"
+        },
+        "Users can update their own dashboard layout": {
+          "name": "Users can update their own dashboard layout",
+          "as": "PERMISSIVE",
+          "for": "UPDATE",
+          "to": [
+            "public"
+          ],
+          "using": "(profile_id = current_profile_id())",
+          "withCheck": "(profile_id = current_profile_id())"
+        },
+        "Users can insert their own dashboard layout": {
+          "name": "Users can insert their own dashboard layout",
+          "as": "PERMISSIVE",
+          "for": "INSERT",
+          "to": [
+            "public"
+          ],
+          "withCheck": "(profile_id = current_profile_id())"
+        },
+        "Users can view their own dashboard layout": {
+          "name": "Users can view their own dashboard layout",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": [
+            "public"
+          ],
+          "using": "(profile_id = current_profile_id())"
+        }
+      },
+      "checkConstraints": {},
+      "isRLSEnabled": true
+    },
+    "public.essay_coach_reads": {
+      "name": "essay_coach_reads",
+      "schema": "",
+      "columns": {
+        "essay_id": {
+          "name": "essay_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "coach_profile_id": {
+          "name": "coach_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "read_at": {
+          "name": "read_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_by_profile_id": {
+          "name": "created_by_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_by_profile_id": {
+          "name": "updated_by_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "essay_coach_reads_coach_idx": {
+          "name": "essay_coach_reads_coach_idx",
+          "columns": [
+            {
+              "expression": "coach_profile_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "uuid_ops"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "essay_coach_reads_essay_id_fkey": {
+          "name": "essay_coach_reads_essay_id_fkey",
+          "tableFrom": "essay_coach_reads",
+          "columnsFrom": [
+            "essay_id"
+          ],
+          "tableTo": "essays",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        },
+        "essay_coach_reads_coach_profile_id_fkey": {
+          "name": "essay_coach_reads_coach_profile_id_fkey",
+          "tableFrom": "essay_coach_reads",
+          "columnsFrom": [
+            "coach_profile_id"
+          ],
+          "tableTo": "profiles",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        },
+        "essay_coach_reads_created_by_profile_id_fkey": {
+          "name": "essay_coach_reads_created_by_profile_id_fkey",
+          "tableFrom": "essay_coach_reads",
+          "columnsFrom": [
+            "created_by_profile_id"
+          ],
+          "tableTo": "profiles",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "restrict"
+        },
+        "essay_coach_reads_updated_by_profile_id_fkey": {
+          "name": "essay_coach_reads_updated_by_profile_id_fkey",
+          "tableFrom": "essay_coach_reads",
+          "columnsFrom": [
+            "updated_by_profile_id"
+          ],
+          "tableTo": "profiles",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "restrict"
+        }
+      },
+      "compositePrimaryKeys": {
+        "essay_coach_reads_pkey": {
+          "name": "essay_coach_reads_pkey",
+          "columns": [
+            "essay_id",
+            "coach_profile_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {
+        "Coaches remove own reads": {
+          "name": "Coaches remove own reads",
+          "as": "PERMISSIVE",
+          "for": "DELETE",
+          "to": [
+            "authenticated"
+          ],
+          "using": "(coach_profile_id = current_profile_id())"
+        },
+        "Coaches mark own reads within their team": {
+          "name": "Coaches mark own reads within their team",
+          "as": "PERMISSIVE",
+          "for": "INSERT",
+          "to": [
+            "authenticated"
+          ],
+          "withCheck": "((coach_profile_id = current_profile_id()) AND coach_can_review_essay(essay_id))"
+        },
+        "Coach sees own reads; author sees reads of own essays": {
+          "name": "Coach sees own reads; author sees reads of own essays",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": [
+            "authenticated"
+          ],
+          "using": "((coach_profile_id = current_profile_id()) OR (EXISTS ( SELECT 1\n   FROM essays e\n  WHERE ((e.id = essay_coach_reads.essay_id) AND (e.author_profile_id = current_profile_id())))))"
+        }
+      },
+      "checkConstraints": {},
+      "isRLSEnabled": true
+    },
+    "public.essay_comments": {
+      "name": "essay_comments",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "essay_id": {
+          "name": "essay_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "author_profile_id": {
+          "name": "author_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "parent_id": {
+          "name": "parent_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "removed_at": {
+          "name": "removed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_by_profile_id": {
+          "name": "created_by_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_by_profile_id": {
+          "name": "updated_by_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "essay_comments_author_idx": {
+          "name": "essay_comments_author_idx",
+          "columns": [
+            {
+              "expression": "author_profile_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "uuid_ops"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "essay_comments_essay_idx": {
+          "name": "essay_comments_essay_idx",
+          "columns": [
+            {
+              "expression": "essay_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "uuid_ops"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "essay_comments_essay_id_fkey": {
+          "name": "essay_comments_essay_id_fkey",
+          "tableFrom": "essay_comments",
+          "columnsFrom": [
+            "essay_id"
+          ],
+          "tableTo": "essays",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        },
+        "essay_comments_author_profile_id_fkey": {
+          "name": "essay_comments_author_profile_id_fkey",
+          "tableFrom": "essay_comments",
+          "columnsFrom": [
+            "author_profile_id"
+          ],
+          "tableTo": "profiles",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        },
+        "essay_comments_created_by_profile_id_fkey": {
+          "name": "essay_comments_created_by_profile_id_fkey",
+          "tableFrom": "essay_comments",
+          "columnsFrom": [
+            "created_by_profile_id"
+          ],
+          "tableTo": "profiles",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "restrict"
+        },
+        "essay_comments_updated_by_profile_id_fkey": {
+          "name": "essay_comments_updated_by_profile_id_fkey",
+          "tableFrom": "essay_comments",
+          "columnsFrom": [
+            "updated_by_profile_id"
+          ],
+          "tableTo": "profiles",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "restrict"
+        },
+        "essay_comments_parent_id_fkey": {
+          "name": "essay_comments_parent_id_fkey",
+          "tableFrom": "essay_comments",
+          "columnsFrom": [
+            "parent_id"
+          ],
+          "tableTo": "essay_comments",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "set null"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {
+        "Authors and admins can delete essay comments": {
+          "name": "Authors and admins can delete essay comments",
+          "as": "PERMISSIVE",
+          "for": "DELETE",
+          "to": [
+            "authenticated"
+          ],
+          "using": "((author_profile_id = current_profile_id()) OR is_admin())"
+        },
+        "Authors can update their own essay comments": {
+          "name": "Authors can update their own essay comments",
+          "as": "PERMISSIVE",
+          "for": "UPDATE",
+          "to": [
+            "authenticated"
+          ],
+          "using": "(author_profile_id = current_profile_id())",
+          "withCheck": "(author_profile_id = current_profile_id())"
+        },
+        "Authenticated users can add essay comments": {
+          "name": "Authenticated users can add essay comments",
+          "as": "PERMISSIVE",
+          "for": "INSERT",
+          "to": [
+            "authenticated"
+          ],
+          "withCheck": "(author_profile_id = current_profile_id())"
+        },
+        "Authenticated users can view essay comments": {
+          "name": "Authenticated users can view essay comments",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": [
+            "authenticated"
+          ],
+          "using": "true"
+        }
+      },
+      "checkConstraints": {
+        "essay_comments_body_check": {
+          "name": "essay_comments_body_check",
+          "value": "(char_length(body) >= 1) AND (char_length(body) <= 4000)"
+        }
+      },
+      "isRLSEnabled": true
+    },
+    "public.essay_revisions": {
+      "name": "essay_revisions",
+      "schema": "",
+      "columns": {
+        "essay_id": {
+          "name": "essay_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "revision_no": {
+          "name": "revision_no",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content_json": {
+          "name": "content_json",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "invalid_since": {
+          "name": "invalid_since",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_by_profile_id": {
+          "name": "created_by_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_by_profile_id": {
+          "name": "updated_by_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "essay_revisions_essay_id_fkey": {
+          "name": "essay_revisions_essay_id_fkey",
+          "tableFrom": "essay_revisions",
+          "columnsFrom": [
+            "essay_id"
+          ],
+          "tableTo": "essays",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        },
+        "essay_revisions_created_by_profile_id_fkey": {
+          "name": "essay_revisions_created_by_profile_id_fkey",
+          "tableFrom": "essay_revisions",
+          "columnsFrom": [
+            "created_by_profile_id"
+          ],
+          "tableTo": "profiles",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "restrict"
+        },
+        "essay_revisions_updated_by_profile_id_fkey": {
+          "name": "essay_revisions_updated_by_profile_id_fkey",
+          "tableFrom": "essay_revisions",
+          "columnsFrom": [
+            "updated_by_profile_id"
+          ],
+          "tableTo": "profiles",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "restrict"
+        }
+      },
+      "compositePrimaryKeys": {
+        "essay_revisions_pkey": {
+          "name": "essay_revisions_pkey",
+          "columns": [
+            "essay_id",
+            "revision_no"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {
+        "Authenticated users can view essay revisions": {
+          "name": "Authenticated users can view essay revisions",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": [
+            "authenticated"
+          ],
+          "using": "(EXISTS ( SELECT 1\n   FROM essays e\n  WHERE ((e.id = essay_revisions.essay_id) AND ((e.published_at IS NOT NULL) OR (e.author_profile_id = ( SELECT current_profile_id())) OR ( SELECT is_admin())))))"
+        },
+        "Authors can create essay revisions": {
+          "name": "Authors can create essay revisions",
+          "as": "PERMISSIVE",
+          "for": "INSERT",
+          "to": [
+            "authenticated"
+          ],
+          "withCheck": "(created_by_profile_id = current_profile_id())"
+        },
+        "Authors can update their newest recent essay revision": {
+          "name": "Authors can update their newest recent essay revision",
+          "as": "PERMISSIVE",
+          "for": "UPDATE",
+          "to": [
+            "authenticated"
+          ],
+          "using": "((created_by_profile_id = ( SELECT current_profile_id())) AND (created_at > (now() - '00:30:00'::interval)))",
+          "withCheck": "(created_by_profile_id = ( SELECT current_profile_id()))"
+        },
+        "Essay revisions cannot be deleted": {
+          "name": "Essay revisions cannot be deleted",
+          "as": "PERMISSIVE",
+          "for": "DELETE",
+          "to": [
+            "authenticated"
+          ],
+          "using": "false"
+        }
+      },
+      "checkConstraints": {},
+      "isRLSEnabled": true
+    },
+    "public.essay_views": {
+      "name": "essay_views",
+      "schema": "",
+      "columns": {
+        "essay_id": {
+          "name": "essay_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "viewer_profile_id": {
+          "name": "viewer_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "first_viewed_at": {
+          "name": "first_viewed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_viewed_at": {
+          "name": "last_viewed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_by_profile_id": {
+          "name": "created_by_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_by_profile_id": {
+          "name": "updated_by_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "essay_views_viewer_idx": {
+          "name": "essay_views_viewer_idx",
+          "columns": [
+            {
+              "expression": "viewer_profile_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "uuid_ops"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "essay_views_essay_id_fkey": {
+          "name": "essay_views_essay_id_fkey",
+          "tableFrom": "essay_views",
+          "columnsFrom": [
+            "essay_id"
+          ],
+          "tableTo": "essays",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        },
+        "essay_views_viewer_profile_id_fkey": {
+          "name": "essay_views_viewer_profile_id_fkey",
+          "tableFrom": "essay_views",
+          "columnsFrom": [
+            "viewer_profile_id"
+          ],
+          "tableTo": "profiles",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        },
+        "essay_views_created_by_profile_id_fkey": {
+          "name": "essay_views_created_by_profile_id_fkey",
+          "tableFrom": "essay_views",
+          "columnsFrom": [
+            "created_by_profile_id"
+          ],
+          "tableTo": "profiles",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "restrict"
+        },
+        "essay_views_updated_by_profile_id_fkey": {
+          "name": "essay_views_updated_by_profile_id_fkey",
+          "tableFrom": "essay_views",
+          "columnsFrom": [
+            "updated_by_profile_id"
+          ],
+          "tableTo": "profiles",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "restrict"
+        }
+      },
+      "compositePrimaryKeys": {
+        "essay_views_pkey": {
+          "name": "essay_views_pkey",
+          "columns": [
+            "essay_id",
+            "viewer_profile_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {
+        "No direct inserts to essay_views": {
+          "name": "No direct inserts to essay_views",
+          "as": "PERMISSIVE",
+          "for": "INSERT",
+          "to": [
+            "authenticated"
+          ],
+          "withCheck": "false"
+        },
+        "Authors see all viewers; others see own row": {
+          "name": "Authors see all viewers; others see own row",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": [
+            "authenticated"
+          ],
+          "using": "((viewer_profile_id = current_profile_id()) OR (EXISTS ( SELECT 1\n   FROM essays e\n  WHERE ((e.id = essay_views.essay_id) AND (e.author_profile_id = current_profile_id())))))"
+        }
+      },
+      "checkConstraints": {},
+      "isRLSEnabled": true
+    },
+    "public.essay_votes": {
+      "name": "essay_votes",
+      "schema": "",
+      "columns": {
+        "essay_id": {
+          "name": "essay_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "voter_profile_id": {
+          "name": "voter_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_by_profile_id": {
+          "name": "created_by_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_by_profile_id": {
+          "name": "updated_by_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "essay_votes_voter_idx": {
+          "name": "essay_votes_voter_idx",
+          "columns": [
+            {
+              "expression": "voter_profile_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "uuid_ops"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "essay_votes_essay_id_fkey": {
+          "name": "essay_votes_essay_id_fkey",
+          "tableFrom": "essay_votes",
+          "columnsFrom": [
+            "essay_id"
+          ],
+          "tableTo": "essays",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        },
+        "essay_votes_voter_profile_id_fkey": {
+          "name": "essay_votes_voter_profile_id_fkey",
+          "tableFrom": "essay_votes",
+          "columnsFrom": [
+            "voter_profile_id"
+          ],
+          "tableTo": "profiles",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        },
+        "essay_votes_created_by_profile_id_fkey": {
+          "name": "essay_votes_created_by_profile_id_fkey",
+          "tableFrom": "essay_votes",
+          "columnsFrom": [
+            "created_by_profile_id"
+          ],
+          "tableTo": "profiles",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "restrict"
+        },
+        "essay_votes_updated_by_profile_id_fkey": {
+          "name": "essay_votes_updated_by_profile_id_fkey",
+          "tableFrom": "essay_votes",
+          "columnsFrom": [
+            "updated_by_profile_id"
+          ],
+          "tableTo": "profiles",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "restrict"
+        }
+      },
+      "compositePrimaryKeys": {
+        "essay_votes_pkey": {
+          "name": "essay_votes_pkey",
+          "columns": [
+            "essay_id",
+            "voter_profile_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {
+        "Users can vote (not own essays)": {
+          "name": "Users can vote (not own essays)",
+          "as": "PERMISSIVE",
+          "for": "INSERT",
+          "to": [
+            "authenticated"
+          ],
+          "withCheck": "((voter_profile_id = current_profile_id()) AND (NOT (essay_id IN ( SELECT essays.id\n   FROM essays\n  WHERE (essays.author_profile_id = current_profile_id())))))"
+        },
+        "Authenticated users can view votes": {
+          "name": "Authenticated users can view votes",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": [
+            "authenticated"
+          ],
+          "using": "true"
+        },
+        "Users can remove own votes": {
+          "name": "Users can remove own votes",
+          "as": "PERMISSIVE",
+          "for": "DELETE",
+          "to": [
+            "authenticated"
+          ],
+          "using": "(voter_profile_id = current_profile_id())"
+        }
+      },
+      "checkConstraints": {},
+      "isRLSEnabled": true
+    },
+    "public.essays": {
+      "name": "essays",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "external_id": {
+          "name": "external_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "author_profile_id": {
+          "name": "author_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "book_id": {
+          "name": "book_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "published_at": {
+          "name": "published_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pinned_at": {
+          "name": "pinned_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pinned_by_profile_id": {
+          "name": "pinned_by_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "removed_at": {
+          "name": "removed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_by_profile_id": {
+          "name": "created_by_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_by_profile_id": {
+          "name": "updated_by_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "essays_author_idx": {
+          "name": "essays_author_idx",
+          "columns": [
+            {
+              "expression": "author_profile_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "uuid_ops"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "essays_book_idx": {
+          "name": "essays_book_idx",
+          "columns": [
+            {
+              "expression": "book_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "uuid_ops"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "essays_created_desc_idx": {
+          "name": "essays_created_desc_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "first",
+              "opclass": "timestamptz_ops"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "essays_author_profile_id_fkey": {
+          "name": "essays_author_profile_id_fkey",
+          "tableFrom": "essays",
+          "columnsFrom": [
+            "author_profile_id"
+          ],
+          "tableTo": "profiles",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        },
+        "essays_book_id_fkey": {
+          "name": "essays_book_id_fkey",
+          "tableFrom": "essays",
+          "columnsFrom": [
+            "book_id"
+          ],
+          "tableTo": "books",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "set null"
+        },
+        "essays_pinned_by_profile_id_fkey": {
+          "name": "essays_pinned_by_profile_id_fkey",
+          "tableFrom": "essays",
+          "columnsFrom": [
+            "pinned_by_profile_id"
+          ],
+          "tableTo": "profiles",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "set null"
+        },
+        "essays_created_by_profile_id_fkey": {
+          "name": "essays_created_by_profile_id_fkey",
+          "tableFrom": "essays",
+          "columnsFrom": [
+            "created_by_profile_id"
+          ],
+          "tableTo": "profiles",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "restrict"
+        },
+        "essays_updated_by_profile_id_fkey": {
+          "name": "essays_updated_by_profile_id_fkey",
+          "tableFrom": "essays",
+          "columnsFrom": [
+            "updated_by_profile_id"
+          ],
+          "tableTo": "profiles",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "restrict"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {
+        "Authors can create their own essays": {
+          "name": "Authors can create their own essays",
+          "as": "PERMISSIVE",
+          "for": "INSERT",
+          "to": [
+            "authenticated"
+          ],
+          "withCheck": "(author_profile_id = current_profile_id())"
+        },
+        "Authenticated users can view all essays": {
+          "name": "Authenticated users can view all essays",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": [
+            "authenticated"
+          ],
+          "using": "((published_at IS NOT NULL) OR (author_profile_id = ( SELECT current_profile_id())) OR ( SELECT is_admin()))"
+        },
+        "Authors and admins can delete essays": {
+          "name": "Authors and admins can delete essays",
+          "as": "PERMISSIVE",
+          "for": "DELETE",
+          "to": [
+            "authenticated"
+          ],
+          "using": "((author_profile_id = current_profile_id()) OR is_admin())"
+        },
+        "Authors can update their own essays": {
+          "name": "Authors can update their own essays",
+          "as": "PERMISSIVE",
+          "for": "UPDATE",
+          "to": [
+            "authenticated"
+          ],
+          "using": "(author_profile_id = current_profile_id())",
+          "withCheck": "(author_profile_id = current_profile_id())"
+        }
+      },
+      "checkConstraints": {},
+      "isRLSEnabled": true
+    },
+    "public.feedback": {
+      "name": "feedback",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "author_profile_id": {
+          "name": "author_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "resolved_at": {
+          "name": "resolved_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_by_profile_id": {
+          "name": "created_by_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_by_profile_id": {
+          "name": "updated_by_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "feedback_active_created_idx": {
+          "name": "feedback_active_created_idx",
+          "columns": [
+            {
+              "expression": "resolved_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "timestamptz_ops"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "first",
+              "opclass": "timestamptz_ops"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "feedback_author_idx": {
+          "name": "feedback_author_idx",
+          "columns": [
+            {
+              "expression": "author_profile_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "uuid_ops"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "feedback_author_profile_id_fkey": {
+          "name": "feedback_author_profile_id_fkey",
+          "tableFrom": "feedback",
+          "columnsFrom": [
+            "author_profile_id"
+          ],
+          "tableTo": "profiles",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        },
+        "feedback_created_by_profile_id_fkey": {
+          "name": "feedback_created_by_profile_id_fkey",
+          "tableFrom": "feedback",
+          "columnsFrom": [
+            "created_by_profile_id"
+          ],
+          "tableTo": "profiles",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "restrict"
+        },
+        "feedback_updated_by_profile_id_fkey": {
+          "name": "feedback_updated_by_profile_id_fkey",
+          "tableFrom": "feedback",
+          "columnsFrom": [
+            "updated_by_profile_id"
+          ],
+          "tableTo": "profiles",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "restrict"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {
+        "Authenticated users can view feedback": {
+          "name": "Authenticated users can view feedback",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": [
+            "authenticated"
+          ],
+          "using": "true"
+        },
+        "Authenticated users can create feedback": {
+          "name": "Authenticated users can create feedback",
+          "as": "PERMISSIVE",
+          "for": "INSERT",
+          "to": [
+            "authenticated"
+          ],
+          "withCheck": "(author_profile_id = current_profile_id())"
+        },
+        "Admins can update feedback": {
+          "name": "Admins can update feedback",
+          "as": "PERMISSIVE",
+          "for": "UPDATE",
+          "to": [
+            "authenticated"
+          ],
+          "using": "is_admin()",
+          "withCheck": "is_admin()"
+        },
+        "Authors and admins can delete feedback": {
+          "name": "Authors and admins can delete feedback",
+          "as": "PERMISSIVE",
+          "for": "DELETE",
+          "to": [
+            "authenticated"
+          ],
+          "using": "((author_profile_id = current_profile_id()) OR is_admin())"
+        }
+      },
+      "checkConstraints": {
+        "feedback_body_check": {
+          "name": "feedback_body_check",
+          "value": "(char_length(body) >= 1) AND (char_length(body) <= 4000)"
+        }
+      },
+      "isRLSEnabled": true
+    },
+    "public.individual_coaching_sessions": {
+      "name": "individual_coaching_sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "profile_id": {
+          "name": "profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "session_at": {
+          "name": "session_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "coach_profile_id": {
+          "name": "coach_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "external_coach_name": {
+          "name": "external_coach_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "key_takeaways": {
+          "name": "key_takeaways",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "action_steps": {
+          "name": "action_steps",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "removed_at": {
+          "name": "removed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_by_profile_id": {
+          "name": "created_by_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_by_profile_id": {
+          "name": "updated_by_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "individual_coaching_sessions_profile_idx": {
+          "name": "individual_coaching_sessions_profile_idx",
+          "columns": [
+            {
+              "expression": "profile_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "uuid_ops"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "individual_coaching_sessions_coach_idx": {
+          "name": "individual_coaching_sessions_coach_idx",
+          "columns": [
+            {
+              "expression": "coach_profile_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "uuid_ops"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "individual_coaching_sessions_created_desc_idx": {
+          "name": "individual_coaching_sessions_created_desc_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "first",
+              "opclass": "timestamptz_ops"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "individual_coaching_sessions_profile_id_fkey": {
+          "name": "individual_coaching_sessions_profile_id_fkey",
+          "tableFrom": "individual_coaching_sessions",
+          "columnsFrom": [
+            "profile_id"
+          ],
+          "tableTo": "profiles",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        },
+        "individual_coaching_sessions_coach_profile_id_fkey": {
+          "name": "individual_coaching_sessions_coach_profile_id_fkey",
+          "tableFrom": "individual_coaching_sessions",
+          "columnsFrom": [
+            "coach_profile_id"
+          ],
+          "tableTo": "profiles",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "set null"
+        },
+        "individual_coaching_sessions_created_by_profile_id_fkey": {
+          "name": "individual_coaching_sessions_created_by_profile_id_fkey",
+          "tableFrom": "individual_coaching_sessions",
+          "columnsFrom": [
+            "created_by_profile_id"
+          ],
+          "tableTo": "profiles",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "restrict"
+        },
+        "individual_coaching_sessions_updated_by_profile_id_fkey": {
+          "name": "individual_coaching_sessions_updated_by_profile_id_fkey",
+          "tableFrom": "individual_coaching_sessions",
+          "columnsFrom": [
+            "updated_by_profile_id"
+          ],
+          "tableTo": "profiles",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "restrict"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {
+        "Users can view their own coaching sessions": {
+          "name": "Users can view their own coaching sessions",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": [
+            "authenticated"
+          ],
+          "using": "(profile_id = current_profile_id())"
+        },
+        "Users can create their own coaching sessions": {
+          "name": "Users can create their own coaching sessions",
+          "as": "PERMISSIVE",
+          "for": "INSERT",
+          "to": [
+            "authenticated"
+          ],
+          "withCheck": "(profile_id = current_profile_id())"
+        },
+        "Users can update their own coaching sessions": {
+          "name": "Users can update their own coaching sessions",
+          "as": "PERMISSIVE",
+          "for": "UPDATE",
+          "to": [
+            "authenticated"
+          ],
+          "using": "(profile_id = current_profile_id())",
+          "withCheck": "(profile_id = current_profile_id())"
+        },
+        "Users can delete their own coaching sessions": {
+          "name": "Users can delete their own coaching sessions",
+          "as": "PERMISSIVE",
+          "for": "DELETE",
+          "to": [
+            "authenticated"
+          ],
+          "using": "(profile_id = current_profile_id())"
+        }
+      },
+      "checkConstraints": {
+        "individual_coaching_sessions_coach_xor": {
+          "name": "individual_coaching_sessions_coach_xor",
+          "value": "(coach_profile_id IS NOT NULL) <> (external_coach_name IS NOT NULL)"
+        }
+      },
+      "isRLSEnabled": true
+    },
+    "public.notification_preferences": {
+      "name": "notification_preferences",
+      "schema": "",
+      "columns": {
+        "profile_id": {
+          "name": "profile_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "essay_coach_read_email": {
+          "name": "essay_coach_read_email",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "essay_comment_email": {
+          "name": "essay_comment_email",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "essay_vote_email": {
+          "name": "essay_vote_email",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "book_submitted_email": {
+          "name": "book_submitted_email",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_by_profile_id": {
+          "name": "created_by_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_by_profile_id": {
+          "name": "updated_by_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "notification_preferences_profile_id_fkey": {
+          "name": "notification_preferences_profile_id_fkey",
+          "tableFrom": "notification_preferences",
+          "columnsFrom": [
+            "profile_id"
+          ],
+          "tableTo": "profiles",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        },
+        "notification_preferences_created_by_profile_id_fkey": {
+          "name": "notification_preferences_created_by_profile_id_fkey",
+          "tableFrom": "notification_preferences",
+          "columnsFrom": [
+            "created_by_profile_id"
+          ],
+          "tableTo": "profiles",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "restrict"
+        },
+        "notification_preferences_updated_by_profile_id_fkey": {
+          "name": "notification_preferences_updated_by_profile_id_fkey",
+          "tableFrom": "notification_preferences",
+          "columnsFrom": [
+            "updated_by_profile_id"
+          ],
+          "tableTo": "profiles",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "restrict"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {
+        "Users can view their own notification preferences": {
+          "name": "Users can view their own notification preferences",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": [
+            "authenticated"
+          ],
+          "using": "(profile_id = current_profile_id())"
+        },
+        "Users can insert their own notification preferences": {
+          "name": "Users can insert their own notification preferences",
+          "as": "PERMISSIVE",
+          "for": "INSERT",
+          "to": [
+            "authenticated"
+          ],
+          "withCheck": "(profile_id = current_profile_id())"
+        },
+        "Users can update their own notification preferences": {
+          "name": "Users can update their own notification preferences",
+          "as": "PERMISSIVE",
+          "for": "UPDATE",
+          "to": [
+            "authenticated"
+          ],
+          "using": "(profile_id = current_profile_id())",
+          "withCheck": "(profile_id = current_profile_id())"
+        }
+      },
+      "checkConstraints": {},
+      "isRLSEnabled": true
+    },
+    "public.personality_tests": {
+      "name": "personality_tests",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "profile_id": {
+          "name": "profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "test_type": {
+          "name": "test_type",
+          "type": "personality_test_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "test_type_other": {
+          "name": "test_type_other",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tested_on": {
+          "name": "tested_on",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "file_path": {
+          "name": "file_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "file_name": {
+          "name": "file_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "file_size": {
+          "name": "file_size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "removed_at": {
+          "name": "removed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_by_profile_id": {
+          "name": "created_by_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_by_profile_id": {
+          "name": "updated_by_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "personality_tests_profile_tested_on_idx": {
+          "name": "personality_tests_profile_tested_on_idx",
+          "columns": [
+            {
+              "expression": "profile_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "uuid_ops"
+            },
+            {
+              "expression": "tested_on",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "date_ops"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "personality_tests_profile_id_fkey": {
+          "name": "personality_tests_profile_id_fkey",
+          "tableFrom": "personality_tests",
+          "columnsFrom": [
+            "profile_id"
+          ],
+          "tableTo": "profiles",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        },
+        "personality_tests_created_by_profile_id_fkey": {
+          "name": "personality_tests_created_by_profile_id_fkey",
+          "tableFrom": "personality_tests",
+          "columnsFrom": [
+            "created_by_profile_id"
+          ],
+          "tableTo": "profiles",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "restrict"
+        },
+        "personality_tests_updated_by_profile_id_fkey": {
+          "name": "personality_tests_updated_by_profile_id_fkey",
+          "tableFrom": "personality_tests",
+          "columnsFrom": [
+            "updated_by_profile_id"
+          ],
+          "tableTo": "profiles",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "restrict"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {
+        "Verified users can view personality tests": {
+          "name": "Verified users can view personality tests",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": [
+            "authenticated"
+          ],
+          "using": "(EXISTS (SELECT 1 FROM users WHERE (users.auth_user_id = (SELECT auth.uid()) AND users.verified_work_email IS NOT NULL)))"
+        },
+        "Users can create their own personality tests": {
+          "name": "Users can create their own personality tests",
+          "as": "PERMISSIVE",
+          "for": "INSERT",
+          "to": [
+            "authenticated"
+          ],
+          "withCheck": "(profile_id = current_profile_id())"
+        },
+        "Users can update their own personality tests": {
+          "name": "Users can update their own personality tests",
+          "as": "PERMISSIVE",
+          "for": "UPDATE",
+          "to": [
+            "authenticated"
+          ],
+          "using": "(profile_id = current_profile_id())",
+          "withCheck": "(profile_id = current_profile_id())"
+        },
+        "Users can delete their own personality tests": {
+          "name": "Users can delete their own personality tests",
+          "as": "PERMISSIVE",
+          "for": "DELETE",
+          "to": [
+            "authenticated"
+          ],
+          "using": "(profile_id = current_profile_id())"
+        }
+      },
+      "checkConstraints": {
+        "personality_tests_other_type_required": {
+          "name": "personality_tests_other_type_required",
+          "value": "(test_type <> 'other' OR (test_type_other IS NOT NULL AND length(trim(test_type_other)) > 0))"
+        }
+      },
+      "isRLSEnabled": true
+    },
+    "public.profiles": {
+      "name": "profiles",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "picture": {
+          "name": "picture",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "work_email": {
+          "name": "work_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "profile_role",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'student'"
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "phone_number": {
+          "name": "phone_number",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "personal_email": {
+          "name": "personal_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "date_of_birth": {
+          "name": "date_of_birth",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_removed_at": {
+          "name": "access_removed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_removed_by_profile_id": {
+          "name": "access_removed_by_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "beta_access_granted_at": {
+          "name": "beta_access_granted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_by_profile_id": {
+          "name": "created_by_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_by_profile_id": {
+          "name": "updated_by_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "profiles_team_id_idx": {
+          "name": "profiles_team_id_idx",
+          "columns": [
+            {
+              "expression": "team_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "uuid_ops"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "profiles_team_id_user_id_idx": {
+          "name": "profiles_team_id_user_id_idx",
+          "columns": [
+            {
+              "expression": "team_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "uuid_ops"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "uuid_ops"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "profiles_user_id_idx": {
+          "name": "profiles_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "uuid_ops"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "profiles_work_email_idx": {
+          "name": "profiles_work_email_idx",
+          "columns": [
+            {
+              "expression": "work_email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "text_ops"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "profiles_user_id_fkey": {
+          "name": "profiles_user_id_fkey",
+          "tableFrom": "profiles",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "tableTo": "users",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "set null"
+        },
+        "profiles_team_id_fkey": {
+          "name": "profiles_team_id_fkey",
+          "tableFrom": "profiles",
+          "columnsFrom": [
+            "team_id"
+          ],
+          "tableTo": "teams",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "set null"
+        },
+        "profiles_access_removed_by_profile_id_fkey": {
+          "name": "profiles_access_removed_by_profile_id_fkey",
+          "tableFrom": "profiles",
+          "columnsFrom": [
+            "access_removed_by_profile_id"
+          ],
+          "tableTo": "profiles",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "set null"
+        },
+        "profiles_created_by_profile_id_fkey": {
+          "name": "profiles_created_by_profile_id_fkey",
+          "tableFrom": "profiles",
+          "columnsFrom": [
+            "created_by_profile_id"
+          ],
+          "tableTo": "profiles",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "set null"
+        },
+        "profiles_updated_by_profile_id_fkey": {
+          "name": "profiles_updated_by_profile_id_fkey",
+          "tableFrom": "profiles",
+          "columnsFrom": [
+            "updated_by_profile_id"
+          ],
+          "tableTo": "profiles",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "set null"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "profiles_user_id_key": {
+          "name": "profiles_user_id_key",
+          "columns": [
+            "user_id"
+          ],
+          "nullsNotDistinct": false
+        },
+        "profiles_work_email_key": {
+          "name": "profiles_work_email_key",
+          "columns": [
+            "work_email"
+          ],
+          "nullsNotDistinct": false
+        }
+      },
+      "policies": {
+        "Verified users can view all profiles": {
+          "name": "Verified users can view all profiles",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": [
+            "authenticated"
+          ],
+          "using": "((access_removed_at IS NULL) AND (EXISTS ( SELECT 1\n   FROM users\n  WHERE ((users.auth_user_id = ( SELECT auth.uid() AS uid)) AND (users.verified_work_email IS NOT NULL)))))"
+        },
+        "Users can update their own profile picture": {
+          "name": "Users can update their own profile picture",
+          "as": "PERMISSIVE",
+          "for": "UPDATE",
+          "to": [
+            "authenticated"
+          ],
+          "using": "(user_id IN ( SELECT users.id\n   FROM users\n  WHERE (users.auth_user_id = ( SELECT auth.uid() AS uid))))",
+          "withCheck": "(user_id IN ( SELECT users.id\n   FROM users\n  WHERE (users.auth_user_id = ( SELECT auth.uid() AS uid))))"
+        }
+      },
+      "checkConstraints": {
+        "valid_czu_domain": {
+          "name": "valid_czu_domain",
+          "value": "(lower(split_part(work_email, '@'::text, 2)) = ANY (ARRAY['pef.czu.cz'::text, 'studenti.czu.cz'::text, 'rektorat.czu.cz'::text]))"
+        }
+      },
+      "isRLSEnabled": true
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "auth_user_id": {
+          "name": "auth_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "google_email": {
+          "name": "google_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "suggested_work_email": {
+          "name": "suggested_work_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "verified_work_email": {
+          "name": "verified_work_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "verified_work_email_at": {
+          "name": "verified_work_email_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_otp_sent_at": {
+          "name": "last_otp_sent_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "users_google_email_idx": {
+          "name": "users_google_email_idx",
+          "columns": [
+            {
+              "expression": "google_email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "text_ops"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "users_suggested_work_email_idx": {
+          "name": "users_suggested_work_email_idx",
+          "columns": [
+            {
+              "expression": "suggested_work_email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "text_ops"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "users_auth_user_id_fkey": {
+          "name": "users_auth_user_id_fkey",
+          "tableFrom": "users",
+          "columnsFrom": [
+            "auth_user_id"
+          ],
+          "tableTo": "users",
+          "schemaTo": "auth",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_auth_user_id_key": {
+          "name": "users_auth_user_id_key",
+          "columns": [
+            "auth_user_id"
+          ],
+          "nullsNotDistinct": false
+        },
+        "users_google_email_key": {
+          "name": "users_google_email_key",
+          "columns": [
+            "google_email"
+          ],
+          "nullsNotDistinct": false
+        }
+      },
+      "policies": {
+        "Users can update only suggested_work_email": {
+          "name": "Users can update only suggested_work_email",
+          "as": "PERMISSIVE",
+          "for": "UPDATE",
+          "to": [
+            "authenticated"
+          ],
+          "using": "(( SELECT auth.uid() AS uid) = auth_user_id)",
+          "withCheck": "(( SELECT auth.uid() AS uid) = auth_user_id)"
+        },
+        "Users can insert their own user record": {
+          "name": "Users can insert their own user record",
+          "as": "PERMISSIVE",
+          "for": "INSERT",
+          "to": [
+            "authenticated"
+          ],
+          "withCheck": "(( SELECT auth.uid() AS uid) = auth_user_id)"
+        },
+        "Users can view their own user record": {
+          "name": "Users can view their own user record",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": [
+            "authenticated"
+          ],
+          "using": "(( SELECT auth.uid() AS uid) = auth_user_id)"
+        }
+      },
+      "checkConstraints": {},
+      "isRLSEnabled": true
+    },
+    "public.recurring_schedules": {
+      "name": "recurring_schedules",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "room_id": {
+          "name": "room_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "schedule_type": {
+          "name": "schedule_type",
+          "type": "schedule_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "day_of_week": {
+          "name": "day_of_week",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "start_time": {
+          "name": "start_time",
+          "type": "time",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "end_time": {
+          "name": "end_time",
+          "type": "time",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "valid_from": {
+          "name": "valid_from",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "valid_until": {
+          "name": "valid_until",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "removed_at": {
+          "name": "removed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_by_profile_id": {
+          "name": "created_by_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_by_profile_id": {
+          "name": "updated_by_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "idx_recurring_schedules_day": {
+          "name": "idx_recurring_schedules_day",
+          "columns": [
+            {
+              "expression": "day_of_week",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "int2_ops"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "idx_recurring_schedules_room": {
+          "name": "idx_recurring_schedules_room",
+          "columns": [
+            {
+              "expression": "room_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "uuid_ops"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "idx_recurring_schedules_team": {
+          "name": "idx_recurring_schedules_team",
+          "columns": [
+            {
+              "expression": "team_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "uuid_ops"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "idx_recurring_schedules_type": {
+          "name": "idx_recurring_schedules_type",
+          "columns": [
+            {
+              "expression": "schedule_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "enum_ops"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "idx_recurring_schedules_valid": {
+          "name": "idx_recurring_schedules_valid",
+          "columns": [
+            {
+              "expression": "valid_from",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "date_ops"
+            },
+            {
+              "expression": "valid_until",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "date_ops"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "recurring_schedules_room_id_fkey": {
+          "name": "recurring_schedules_room_id_fkey",
+          "tableFrom": "recurring_schedules",
+          "columnsFrom": [
+            "room_id"
+          ],
+          "tableTo": "rooms",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        },
+        "recurring_schedules_team_id_fkey": {
+          "name": "recurring_schedules_team_id_fkey",
+          "tableFrom": "recurring_schedules",
+          "columnsFrom": [
+            "team_id"
+          ],
+          "tableTo": "teams",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        },
+        "recurring_schedules_created_by_profile_id_fkey": {
+          "name": "recurring_schedules_created_by_profile_id_fkey",
+          "tableFrom": "recurring_schedules",
+          "columnsFrom": [
+            "created_by_profile_id"
+          ],
+          "tableTo": "profiles",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "restrict"
+        },
+        "recurring_schedules_updated_by_profile_id_fkey": {
+          "name": "recurring_schedules_updated_by_profile_id_fkey",
+          "tableFrom": "recurring_schedules",
+          "columnsFrom": [
+            "updated_by_profile_id"
+          ],
+          "tableTo": "profiles",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "restrict"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {
+        "Coaches can manage recurring_schedules": {
+          "name": "Coaches can manage recurring_schedules",
+          "as": "PERMISSIVE",
+          "for": "ALL",
+          "to": [
+            "authenticated"
+          ],
+          "using": "(EXISTS ( SELECT 1\n   FROM profiles\n  WHERE ((profiles.user_id IN ( SELECT users.id\n           FROM users\n          WHERE (users.auth_user_id = ( SELECT auth.uid() AS uid)))) AND (profiles.role = ANY (ARRAY['coach'::profile_role, 'admin'::profile_role])))))",
+          "withCheck": "(EXISTS ( SELECT 1\n   FROM profiles\n  WHERE ((profiles.user_id IN ( SELECT users.id\n           FROM users\n          WHERE (users.auth_user_id = ( SELECT auth.uid() AS uid)))) AND (profiles.role = ANY (ARRAY['coach'::profile_role, 'admin'::profile_role])))))"
+        },
+        "Authenticated can read recurring_schedules": {
+          "name": "Authenticated can read recurring_schedules",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": [
+            "authenticated"
+          ],
+          "using": "true"
+        }
+      },
+      "checkConstraints": {
+        "recurring_schedules_day_of_week_check": {
+          "name": "recurring_schedules_day_of_week_check",
+          "value": "(day_of_week >= 0) AND (day_of_week <= 6)"
+        },
+        "valid_time_range": {
+          "name": "valid_time_range",
+          "value": "end_time > start_time"
+        },
+        "valid_schedule_dates": {
+          "name": "valid_schedule_dates",
+          "value": "(valid_until IS NULL) OR (valid_until >= valid_from)"
+        },
+        "recurring_schedules_team_for_ts": {
+          "name": "recurring_schedules_team_for_ts",
+          "value": "(schedule_type <> 'training_session'::schedule_type) OR (team_id IS NOT NULL)"
+        }
+      },
+      "isRLSEnabled": true
+    },
+    "public.reservations": {
+      "name": "reservations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "room_id": {
+          "name": "room_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "owner_profile_id": {
+          "name": "owner_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "person_count": {
+          "name": "person_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "start_at": {
+          "name": "start_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "end_at": {
+          "name": "end_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cancelled_at": {
+          "name": "cancelled_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cancelled_by_profile_id": {
+          "name": "cancelled_by_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_by_profile_id": {
+          "name": "created_by_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_by_profile_id": {
+          "name": "updated_by_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "idx_reservations_room_time": {
+          "name": "idx_reservations_room_time",
+          "columns": [
+            {
+              "expression": "room_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "uuid_ops"
+            },
+            {
+              "expression": "start_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "timestamptz_ops"
+            },
+            {
+              "expression": "end_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "timestamptz_ops"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "idx_reservations_start": {
+          "name": "idx_reservations_start",
+          "columns": [
+            {
+              "expression": "start_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "timestamptz_ops"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "idx_reservations_owner": {
+          "name": "idx_reservations_owner",
+          "columns": [
+            {
+              "expression": "owner_profile_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "uuid_ops"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "reservations_room_id_fkey": {
+          "name": "reservations_room_id_fkey",
+          "tableFrom": "reservations",
+          "columnsFrom": [
+            "room_id"
+          ],
+          "tableTo": "rooms",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        },
+        "reservations_owner_profile_id_fkey": {
+          "name": "reservations_owner_profile_id_fkey",
+          "tableFrom": "reservations",
+          "columnsFrom": [
+            "owner_profile_id"
+          ],
+          "tableTo": "profiles",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "set null"
+        },
+        "reservations_cancelled_by_profile_id_fkey": {
+          "name": "reservations_cancelled_by_profile_id_fkey",
+          "tableFrom": "reservations",
+          "columnsFrom": [
+            "cancelled_by_profile_id"
+          ],
+          "tableTo": "profiles",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "set null"
+        },
+        "reservations_created_by_profile_id_fkey": {
+          "name": "reservations_created_by_profile_id_fkey",
+          "tableFrom": "reservations",
+          "columnsFrom": [
+            "created_by_profile_id"
+          ],
+          "tableTo": "profiles",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "restrict"
+        },
+        "reservations_updated_by_profile_id_fkey": {
+          "name": "reservations_updated_by_profile_id_fkey",
+          "tableFrom": "reservations",
+          "columnsFrom": [
+            "updated_by_profile_id"
+          ],
+          "tableTo": "profiles",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "restrict"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {
+        "Authenticated can read reservations": {
+          "name": "Authenticated can read reservations",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": [
+            "authenticated"
+          ],
+          "using": "true"
+        },
+        "Users can delete own reservations": {
+          "name": "Users can delete own reservations",
+          "as": "PERMISSIVE",
+          "for": "DELETE",
+          "to": [
+            "authenticated"
+          ],
+          "using": "(owner_profile_id IN ( SELECT profiles.id\n   FROM profiles\n  WHERE (profiles.user_id IN ( SELECT users.id\n           FROM users\n          WHERE (users.auth_user_id = ( SELECT auth.uid() AS uid))))))"
+        },
+        "Users can update own reservations": {
+          "name": "Users can update own reservations",
+          "as": "PERMISSIVE",
+          "for": "UPDATE",
+          "to": [
+            "authenticated"
+          ],
+          "using": "(owner_profile_id IN ( SELECT profiles.id\n   FROM profiles\n  WHERE (profiles.user_id IN ( SELECT users.id\n           FROM users\n          WHERE (users.auth_user_id = ( SELECT auth.uid() AS uid))))))",
+          "withCheck": "(owner_profile_id IN ( SELECT profiles.id\n   FROM profiles\n  WHERE (profiles.user_id IN ( SELECT users.id\n           FROM users\n          WHERE (users.auth_user_id = ( SELECT auth.uid() AS uid))))))"
+        },
+        "Users can create own reservations": {
+          "name": "Users can create own reservations",
+          "as": "PERMISSIVE",
+          "for": "INSERT",
+          "to": [
+            "authenticated"
+          ],
+          "withCheck": "(owner_profile_id IN ( SELECT profiles.id\n   FROM profiles\n  WHERE (profiles.user_id IN ( SELECT users.id\n           FROM users\n          WHERE (users.auth_user_id = ( SELECT auth.uid() AS uid))))))"
+        }
+      },
+      "checkConstraints": {
+        "valid_reservation_time": {
+          "name": "valid_reservation_time",
+          "value": "end_at > start_at"
+        }
+      },
+      "isRLSEnabled": true
+    },
+    "public.rooms": {
+      "name": "rooms",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "code": {
+          "name": "code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "available_days": {
+          "name": "available_days",
+          "type": "integer[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "can_have_ts": {
+          "name": "can_have_ts",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "removed_at": {
+          "name": "removed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_by_profile_id": {
+          "name": "created_by_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_by_profile_id": {
+          "name": "updated_by_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "idx_rooms_code": {
+          "name": "idx_rooms_code",
+          "columns": [
+            {
+              "expression": "code",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "text_ops"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "rooms_created_by_profile_id_fkey": {
+          "name": "rooms_created_by_profile_id_fkey",
+          "tableFrom": "rooms",
+          "columnsFrom": [
+            "created_by_profile_id"
+          ],
+          "tableTo": "profiles",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "restrict"
+        },
+        "rooms_updated_by_profile_id_fkey": {
+          "name": "rooms_updated_by_profile_id_fkey",
+          "tableFrom": "rooms",
+          "columnsFrom": [
+            "updated_by_profile_id"
+          ],
+          "tableTo": "profiles",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "restrict"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "rooms_code_key": {
+          "name": "rooms_code_key",
+          "columns": [
+            "code"
+          ],
+          "nullsNotDistinct": false
+        }
+      },
+      "policies": {
+        "Admins can manage rooms": {
+          "name": "Admins can manage rooms",
+          "as": "PERMISSIVE",
+          "for": "ALL",
+          "to": [
+            "authenticated"
+          ],
+          "using": "(EXISTS ( SELECT 1\n   FROM profiles\n  WHERE ((profiles.user_id IN ( SELECT users.id\n           FROM users\n          WHERE (users.auth_user_id = ( SELECT auth.uid() AS uid)))) AND (profiles.role = 'admin'::profile_role))))",
+          "withCheck": "(EXISTS ( SELECT 1\n   FROM profiles\n  WHERE ((profiles.user_id IN ( SELECT users.id\n           FROM users\n          WHERE (users.auth_user_id = ( SELECT auth.uid() AS uid)))) AND (profiles.role = 'admin'::profile_role))))"
+        },
+        "Authenticated can read rooms": {
+          "name": "Authenticated can read rooms",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": [
+            "authenticated"
+          ],
+          "using": "true"
+        }
+      },
+      "checkConstraints": {},
+      "isRLSEnabled": true
+    },
+    "public.schedule_breaks": {
+      "name": "schedule_breaks",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "start_date": {
+          "name": "start_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "end_date": {
+          "name": "end_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_by_profile_id": {
+          "name": "created_by_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_by_profile_id": {
+          "name": "updated_by_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "idx_schedule_breaks_dates": {
+          "name": "idx_schedule_breaks_dates",
+          "columns": [
+            {
+              "expression": "start_date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "date_ops"
+            },
+            {
+              "expression": "end_date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "date_ops"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "schedule_breaks_created_by_profile_id_fkey": {
+          "name": "schedule_breaks_created_by_profile_id_fkey",
+          "tableFrom": "schedule_breaks",
+          "columnsFrom": [
+            "created_by_profile_id"
+          ],
+          "tableTo": "profiles",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "restrict"
+        },
+        "schedule_breaks_updated_by_profile_id_fkey": {
+          "name": "schedule_breaks_updated_by_profile_id_fkey",
+          "tableFrom": "schedule_breaks",
+          "columnsFrom": [
+            "updated_by_profile_id"
+          ],
+          "tableTo": "profiles",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "restrict"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {
+        "Coaches can manage schedule_breaks": {
+          "name": "Coaches can manage schedule_breaks",
+          "as": "PERMISSIVE",
+          "for": "ALL",
+          "to": [
+            "authenticated"
+          ],
+          "using": "(EXISTS ( SELECT 1\n   FROM profiles\n  WHERE ((profiles.user_id IN ( SELECT users.id\n           FROM users\n          WHERE (users.auth_user_id = ( SELECT auth.uid() AS uid)))) AND (profiles.role = ANY (ARRAY['coach'::profile_role, 'admin'::profile_role])))))",
+          "withCheck": "(EXISTS ( SELECT 1\n   FROM profiles\n  WHERE ((profiles.user_id IN ( SELECT users.id\n           FROM users\n          WHERE (users.auth_user_id = ( SELECT auth.uid() AS uid)))) AND (profiles.role = ANY (ARRAY['coach'::profile_role, 'admin'::profile_role])))))"
+        },
+        "Authenticated can read schedule_breaks": {
+          "name": "Authenticated can read schedule_breaks",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": [
+            "authenticated"
+          ],
+          "using": "true"
+        }
+      },
+      "checkConstraints": {
+        "valid_break_date_range": {
+          "name": "valid_break_date_range",
+          "value": "end_date >= start_date"
+        }
+      },
+      "isRLSEnabled": true
+    },
+    "public.team_activities": {
+      "name": "team_activities",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "occurred_at": {
+          "name": "occurred_at",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "activity_type": {
+          "name": "activity_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "participants": {
+          "name": "participants",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reflection": {
+          "name": "reflection",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "removed_at": {
+          "name": "removed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_by_profile_id": {
+          "name": "created_by_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_by_profile_id": {
+          "name": "updated_by_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "team_activities_team_occurred_at_idx": {
+          "name": "team_activities_team_occurred_at_idx",
+          "columns": [
+            {
+              "expression": "team_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "uuid_ops"
+            },
+            {
+              "expression": "occurred_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "date_ops"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "team_activities_team_id_fkey": {
+          "name": "team_activities_team_id_fkey",
+          "tableFrom": "team_activities",
+          "columnsFrom": [
+            "team_id"
+          ],
+          "tableTo": "teams",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        },
+        "team_activities_created_by_profile_id_fkey": {
+          "name": "team_activities_created_by_profile_id_fkey",
+          "tableFrom": "team_activities",
+          "columnsFrom": [
+            "created_by_profile_id"
+          ],
+          "tableTo": "profiles",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "restrict"
+        },
+        "team_activities_updated_by_profile_id_fkey": {
+          "name": "team_activities_updated_by_profile_id_fkey",
+          "tableFrom": "team_activities",
+          "columnsFrom": [
+            "updated_by_profile_id"
+          ],
+          "tableTo": "profiles",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "restrict"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {
+        "Team members can view activities": {
+          "name": "Team members can view activities",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": [
+            "authenticated"
+          ],
+          "using": "team_id IN (SELECT team_id FROM profiles WHERE id = current_profile_id() AND access_removed_at IS NULL)"
+        },
+        "Team members can create activities": {
+          "name": "Team members can create activities",
+          "as": "PERMISSIVE",
+          "for": "INSERT",
+          "to": [
+            "authenticated"
+          ],
+          "withCheck": "team_id IN (SELECT team_id FROM profiles WHERE id = current_profile_id() AND access_removed_at IS NULL)"
+        },
+        "Team members can update activities": {
+          "name": "Team members can update activities",
+          "as": "PERMISSIVE",
+          "for": "UPDATE",
+          "to": [
+            "authenticated"
+          ],
+          "using": "team_id IN (SELECT team_id FROM profiles WHERE id = current_profile_id() AND access_removed_at IS NULL)",
+          "withCheck": "team_id IN (SELECT team_id FROM profiles WHERE id = current_profile_id() AND access_removed_at IS NULL)"
+        },
+        "Team members can delete activities": {
+          "name": "Team members can delete activities",
+          "as": "PERMISSIVE",
+          "for": "DELETE",
+          "to": [
+            "authenticated"
+          ],
+          "using": "team_id IN (SELECT team_id FROM profiles WHERE id = current_profile_id() AND access_removed_at IS NULL)"
+        }
+      },
+      "checkConstraints": {},
+      "isRLSEnabled": true
+    },
+    "public.team_document_versions": {
+      "name": "team_document_versions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "document_id": {
+          "name": "document_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "version_no": {
+          "name": "version_no",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "file_path": {
+          "name": "file_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "file_name": {
+          "name": "file_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "file_size": {
+          "name": "file_size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "effective_from": {
+          "name": "effective_from",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "change_note": {
+          "name": "change_note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_by_profile_id": {
+          "name": "created_by_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "team_document_versions_document_version_idx": {
+          "name": "team_document_versions_document_version_idx",
+          "columns": [
+            {
+              "expression": "document_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "uuid_ops"
+            },
+            {
+              "expression": "version_no",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "int4_ops"
+            }
+          ],
+          "isUnique": true,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "team_document_versions_document_id_fkey": {
+          "name": "team_document_versions_document_id_fkey",
+          "tableFrom": "team_document_versions",
+          "columnsFrom": [
+            "document_id"
+          ],
+          "tableTo": "team_documents",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        },
+        "team_document_versions_created_by_profile_id_fkey": {
+          "name": "team_document_versions_created_by_profile_id_fkey",
+          "tableFrom": "team_document_versions",
+          "columnsFrom": [
+            "created_by_profile_id"
+          ],
+          "tableTo": "profiles",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "restrict"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {
+        "Team members can view document versions": {
+          "name": "Team members can view document versions",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": [
+            "authenticated"
+          ],
+          "using": "document_id IN (\n\t\t\tSELECT team_documents.id\n\t\t\tFROM team_documents\n\t\t\tWHERE team_documents.team_id IN (\n\t\t\t\tSELECT team_id FROM profiles WHERE id = current_profile_id() AND access_removed_at IS NULL\n\t\t\t)\n\t\t)"
+        },
+        "Team members can create document versions": {
+          "name": "Team members can create document versions",
+          "as": "PERMISSIVE",
+          "for": "INSERT",
+          "to": [
+            "authenticated"
+          ],
+          "withCheck": "created_by_profile_id = current_profile_id() AND document_id IN (\n\t\t\tSELECT team_documents.id\n\t\t\tFROM team_documents\n\t\t\tWHERE team_documents.removed_at IS NULL\n\t\t\t\tAND team_documents.team_id IN (\n\t\t\t\t\tSELECT team_id FROM profiles WHERE id = current_profile_id() AND access_removed_at IS NULL\n\t\t\t\t)\n\t\t)"
+        }
+      },
+      "checkConstraints": {
+        "team_document_versions_version_positive": {
+          "name": "team_document_versions_version_positive",
+          "value": "version_no > 0"
+        },
+        "team_document_versions_file_size_positive": {
+          "name": "team_document_versions_file_size_positive",
+          "value": "file_size > 0"
+        }
+      },
+      "isRLSEnabled": true
+    },
+    "public.team_documents": {
+      "name": "team_documents",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "doc_type": {
+          "name": "doc_type",
+          "type": "team_document_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "removed_at": {
+          "name": "removed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_by_profile_id": {
+          "name": "created_by_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_by_profile_id": {
+          "name": "updated_by_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "team_documents_featured_team_type_idx": {
+          "name": "team_documents_featured_team_type_idx",
+          "columns": [
+            {
+              "expression": "team_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "uuid_ops"
+            },
+            {
+              "expression": "doc_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "enum_ops"
+            }
+          ],
+          "isUnique": true,
+          "with": {},
+          "method": "btree",
+          "where": "doc_type IN ('team_contract', 'financial_policy') AND removed_at IS NULL",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "team_documents_team_id_fkey": {
+          "name": "team_documents_team_id_fkey",
+          "tableFrom": "team_documents",
+          "columnsFrom": [
+            "team_id"
+          ],
+          "tableTo": "teams",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        },
+        "team_documents_created_by_profile_id_fkey": {
+          "name": "team_documents_created_by_profile_id_fkey",
+          "tableFrom": "team_documents",
+          "columnsFrom": [
+            "created_by_profile_id"
+          ],
+          "tableTo": "profiles",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "restrict"
+        },
+        "team_documents_updated_by_profile_id_fkey": {
+          "name": "team_documents_updated_by_profile_id_fkey",
+          "tableFrom": "team_documents",
+          "columnsFrom": [
+            "updated_by_profile_id"
+          ],
+          "tableTo": "profiles",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "restrict"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {
+        "Team members can view documents": {
+          "name": "Team members can view documents",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": [
+            "authenticated"
+          ],
+          "using": "team_id IN (SELECT team_id FROM profiles WHERE id = current_profile_id() AND access_removed_at IS NULL)"
+        },
+        "Team members can create documents": {
+          "name": "Team members can create documents",
+          "as": "PERMISSIVE",
+          "for": "INSERT",
+          "to": [
+            "authenticated"
+          ],
+          "withCheck": "team_id IN (SELECT team_id FROM profiles WHERE id = current_profile_id() AND access_removed_at IS NULL) AND created_by_profile_id = current_profile_id() AND updated_by_profile_id = current_profile_id()"
+        },
+        "Team members can update custom documents": {
+          "name": "Team members can update custom documents",
+          "as": "PERMISSIVE",
+          "for": "UPDATE",
+          "to": [
+            "authenticated"
+          ],
+          "using": "doc_type = 'other' AND team_id IN (SELECT team_id FROM profiles WHERE id = current_profile_id() AND access_removed_at IS NULL)",
+          "withCheck": "doc_type = 'other' AND team_id IN (SELECT team_id FROM profiles WHERE id = current_profile_id() AND access_removed_at IS NULL) AND updated_by_profile_id = current_profile_id()"
+        }
+      },
+      "checkConstraints": {
+        "team_documents_title_matches_type": {
+          "name": "team_documents_title_matches_type",
+          "value": "(\n\t\t(doc_type = 'other' AND title IS NOT NULL AND length(trim(title)) > 0)\n\t\tOR (doc_type <> 'other' AND title IS NULL)\n\t)"
+        }
+      },
+      "isRLSEnabled": true
+    },
+    "public.team_reflections": {
+      "name": "team_reflections",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "month": {
+          "name": "month",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "what_went_well": {
+          "name": "what_went_well",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "what_didnt_go_well": {
+          "name": "what_didnt_go_well",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "what_we_do_differently": {
+          "name": "what_we_do_differently",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "planned_action_steps": {
+          "name": "planned_action_steps",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "responsible_person": {
+          "name": "responsible_person",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "removed_at": {
+          "name": "removed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_by_profile_id": {
+          "name": "created_by_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_by_profile_id": {
+          "name": "updated_by_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "team_reflections_team_month_idx": {
+          "name": "team_reflections_team_month_idx",
+          "columns": [
+            {
+              "expression": "team_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "uuid_ops"
+            },
+            {
+              "expression": "month",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "date_ops"
+            }
+          ],
+          "isUnique": true,
+          "with": {},
+          "method": "btree",
+          "where": "(removed_at IS NULL)",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "team_reflections_team_id_fkey": {
+          "name": "team_reflections_team_id_fkey",
+          "tableFrom": "team_reflections",
+          "columnsFrom": [
+            "team_id"
+          ],
+          "tableTo": "teams",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        },
+        "team_reflections_created_by_profile_id_fkey": {
+          "name": "team_reflections_created_by_profile_id_fkey",
+          "tableFrom": "team_reflections",
+          "columnsFrom": [
+            "created_by_profile_id"
+          ],
+          "tableTo": "profiles",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "restrict"
+        },
+        "team_reflections_updated_by_profile_id_fkey": {
+          "name": "team_reflections_updated_by_profile_id_fkey",
+          "tableFrom": "team_reflections",
+          "columnsFrom": [
+            "updated_by_profile_id"
+          ],
+          "tableTo": "profiles",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "restrict"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {
+        "Team members can view reflections": {
+          "name": "Team members can view reflections",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": [
+            "authenticated"
+          ],
+          "using": "team_id IN (SELECT team_id FROM profiles WHERE id = current_profile_id() AND access_removed_at IS NULL)"
+        },
+        "Team members can create reflections": {
+          "name": "Team members can create reflections",
+          "as": "PERMISSIVE",
+          "for": "INSERT",
+          "to": [
+            "authenticated"
+          ],
+          "withCheck": "team_id IN (SELECT team_id FROM profiles WHERE id = current_profile_id() AND access_removed_at IS NULL)"
+        },
+        "Team members can update reflections": {
+          "name": "Team members can update reflections",
+          "as": "PERMISSIVE",
+          "for": "UPDATE",
+          "to": [
+            "authenticated"
+          ],
+          "using": "team_id IN (SELECT team_id FROM profiles WHERE id = current_profile_id() AND access_removed_at IS NULL)",
+          "withCheck": "team_id IN (SELECT team_id FROM profiles WHERE id = current_profile_id() AND access_removed_at IS NULL)"
+        },
+        "Team members can delete reflections": {
+          "name": "Team members can delete reflections",
+          "as": "PERMISSIVE",
+          "for": "DELETE",
+          "to": [
+            "authenticated"
+          ],
+          "using": "team_id IN (SELECT team_id FROM profiles WHERE id = current_profile_id() AND access_removed_at IS NULL)"
+        }
+      },
+      "checkConstraints": {},
+      "isRLSEnabled": true
+    },
+    "public.team_semester_reflection_entries": {
+      "name": "team_semester_reflection_entries",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "semester_reflection_id": {
+          "name": "semester_reflection_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "topic": {
+          "name": "topic",
+          "type": "semester_reflection_topic",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "what_went_well": {
+          "name": "what_went_well",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "what_didnt_go_well": {
+          "name": "what_didnt_go_well",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "what_next_time": {
+          "name": "what_next_time",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_by_profile_id": {
+          "name": "updated_by_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "team_semester_reflection_entries_reflection_topic_idx": {
+          "name": "team_semester_reflection_entries_reflection_topic_idx",
+          "columns": [
+            {
+              "expression": "semester_reflection_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "uuid_ops"
+            },
+            {
+              "expression": "topic",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "enum_ops"
+            }
+          ],
+          "isUnique": true,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "team_semester_reflection_entries_reflection_idx": {
+          "name": "team_semester_reflection_entries_reflection_idx",
+          "columns": [
+            {
+              "expression": "semester_reflection_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "uuid_ops"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "team_semester_reflection_entries_semester_reflection_id_fkey": {
+          "name": "team_semester_reflection_entries_semester_reflection_id_fkey",
+          "tableFrom": "team_semester_reflection_entries",
+          "columnsFrom": [
+            "semester_reflection_id"
+          ],
+          "tableTo": "team_semester_reflections",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        },
+        "team_semester_reflection_entries_updated_by_profile_id_fkey": {
+          "name": "team_semester_reflection_entries_updated_by_profile_id_fkey",
+          "tableFrom": "team_semester_reflection_entries",
+          "columnsFrom": [
+            "updated_by_profile_id"
+          ],
+          "tableTo": "profiles",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "restrict"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {
+        "Team members can view semester reflection entries": {
+          "name": "Team members can view semester reflection entries",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": [
+            "authenticated"
+          ],
+          "using": "EXISTS (SELECT 1 FROM team_semester_reflections tsr WHERE tsr.id = team_semester_reflection_entries.semester_reflection_id AND tsr.team_id IN (SELECT team_id FROM profiles WHERE id = current_profile_id() AND access_removed_at IS NULL))"
+        },
+        "Team members can create semester reflection entries": {
+          "name": "Team members can create semester reflection entries",
+          "as": "PERMISSIVE",
+          "for": "INSERT",
+          "to": [
+            "authenticated"
+          ],
+          "withCheck": "EXISTS (SELECT 1 FROM team_semester_reflections tsr WHERE tsr.id = team_semester_reflection_entries.semester_reflection_id AND tsr.team_id IN (SELECT team_id FROM profiles WHERE id = current_profile_id() AND access_removed_at IS NULL))"
+        },
+        "Team members can update semester reflection entries": {
+          "name": "Team members can update semester reflection entries",
+          "as": "PERMISSIVE",
+          "for": "UPDATE",
+          "to": [
+            "authenticated"
+          ],
+          "using": "EXISTS (SELECT 1 FROM team_semester_reflections tsr WHERE tsr.id = team_semester_reflection_entries.semester_reflection_id AND tsr.team_id IN (SELECT team_id FROM profiles WHERE id = current_profile_id() AND access_removed_at IS NULL))",
+          "withCheck": "EXISTS (SELECT 1 FROM team_semester_reflections tsr WHERE tsr.id = team_semester_reflection_entries.semester_reflection_id AND tsr.team_id IN (SELECT team_id FROM profiles WHERE id = current_profile_id() AND access_removed_at IS NULL))"
+        }
+      },
+      "checkConstraints": {},
+      "isRLSEnabled": true
+    },
+    "public.team_semester_reflections": {
+      "name": "team_semester_reflections",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "semester_month": {
+          "name": "semester_month",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "removed_at": {
+          "name": "removed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_by_profile_id": {
+          "name": "created_by_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_by_profile_id": {
+          "name": "updated_by_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "team_semester_reflections_team_month_idx": {
+          "name": "team_semester_reflections_team_month_idx",
+          "columns": [
+            {
+              "expression": "team_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "uuid_ops"
+            },
+            {
+              "expression": "semester_month",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "date_ops"
+            }
+          ],
+          "isUnique": true,
+          "with": {},
+          "method": "btree",
+          "where": "(removed_at IS NULL)",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "team_semester_reflections_team_id_fkey": {
+          "name": "team_semester_reflections_team_id_fkey",
+          "tableFrom": "team_semester_reflections",
+          "columnsFrom": [
+            "team_id"
+          ],
+          "tableTo": "teams",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        },
+        "team_semester_reflections_created_by_profile_id_fkey": {
+          "name": "team_semester_reflections_created_by_profile_id_fkey",
+          "tableFrom": "team_semester_reflections",
+          "columnsFrom": [
+            "created_by_profile_id"
+          ],
+          "tableTo": "profiles",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "restrict"
+        },
+        "team_semester_reflections_updated_by_profile_id_fkey": {
+          "name": "team_semester_reflections_updated_by_profile_id_fkey",
+          "tableFrom": "team_semester_reflections",
+          "columnsFrom": [
+            "updated_by_profile_id"
+          ],
+          "tableTo": "profiles",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "restrict"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {
+        "Team members can view semester reflections": {
+          "name": "Team members can view semester reflections",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": [
+            "authenticated"
+          ],
+          "using": "team_id IN (SELECT team_id FROM profiles WHERE id = current_profile_id() AND access_removed_at IS NULL)"
+        },
+        "Team members can create semester reflections": {
+          "name": "Team members can create semester reflections",
+          "as": "PERMISSIVE",
+          "for": "INSERT",
+          "to": [
+            "authenticated"
+          ],
+          "withCheck": "team_id IN (SELECT team_id FROM profiles WHERE id = current_profile_id() AND access_removed_at IS NULL)"
+        },
+        "Team members can update semester reflections": {
+          "name": "Team members can update semester reflections",
+          "as": "PERMISSIVE",
+          "for": "UPDATE",
+          "to": [
+            "authenticated"
+          ],
+          "using": "team_id IN (SELECT team_id FROM profiles WHERE id = current_profile_id() AND access_removed_at IS NULL)",
+          "withCheck": "team_id IN (SELECT team_id FROM profiles WHERE id = current_profile_id() AND access_removed_at IS NULL)"
+        },
+        "Team members can delete semester reflections": {
+          "name": "Team members can delete semester reflections",
+          "as": "PERMISSIVE",
+          "for": "DELETE",
+          "to": [
+            "authenticated"
+          ],
+          "using": "team_id IN (SELECT team_id FROM profiles WHERE id = current_profile_id() AND access_removed_at IS NULL)"
+        }
+      },
+      "checkConstraints": {
+        "team_semester_reflections_month_check": {
+          "name": "team_semester_reflections_month_check",
+          "value": "EXTRACT(MONTH FROM semester_month) IN (1, 5)"
+        }
+      },
+      "isRLSEnabled": true
+    },
+    "public.teams": {
+      "name": "teams",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "picture": {
+          "name": "picture",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "color": {
+          "name": "color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "onboardingYear": {
+          "name": "onboardingYear",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "removed_at": {
+          "name": "removed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_by_profile_id": {
+          "name": "created_by_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_by_profile_id": {
+          "name": "updated_by_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {
+        "Authenticated users can read teams": {
+          "name": "Authenticated users can read teams",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": [
+            "authenticated"
+          ],
+          "using": "true"
+        }
+      },
+      "checkConstraints": {},
+      "isRLSEnabled": true
+    },
+    "public.tools_techniques": {
+      "name": "tools_techniques",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "profile_id": {
+          "name": "profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tool_type": {
+          "name": "tool_type",
+          "type": "tool_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reflection": {
+          "name": "reflection",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "removed_at": {
+          "name": "removed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_by_profile_id": {
+          "name": "created_by_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_by_profile_id": {
+          "name": "updated_by_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "tools_techniques_profile_idx": {
+          "name": "tools_techniques_profile_idx",
+          "columns": [
+            {
+              "expression": "profile_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "uuid_ops"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "tools_techniques_profile_id_fkey": {
+          "name": "tools_techniques_profile_id_fkey",
+          "tableFrom": "tools_techniques",
+          "columnsFrom": [
+            "profile_id"
+          ],
+          "tableTo": "profiles",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        },
+        "tools_techniques_created_by_profile_id_fkey": {
+          "name": "tools_techniques_created_by_profile_id_fkey",
+          "tableFrom": "tools_techniques",
+          "columnsFrom": [
+            "created_by_profile_id"
+          ],
+          "tableTo": "profiles",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "restrict"
+        },
+        "tools_techniques_updated_by_profile_id_fkey": {
+          "name": "tools_techniques_updated_by_profile_id_fkey",
+          "tableFrom": "tools_techniques",
+          "columnsFrom": [
+            "updated_by_profile_id"
+          ],
+          "tableTo": "profiles",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "restrict"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {
+        "Users can view their own tools and techniques": {
+          "name": "Users can view their own tools and techniques",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": [
+            "authenticated"
+          ],
+          "using": "(profile_id = current_profile_id())"
+        },
+        "Users can create their own tools and techniques": {
+          "name": "Users can create their own tools and techniques",
+          "as": "PERMISSIVE",
+          "for": "INSERT",
+          "to": [
+            "authenticated"
+          ],
+          "withCheck": "(profile_id = current_profile_id())"
+        },
+        "Users can update their own tools and techniques": {
+          "name": "Users can update their own tools and techniques",
+          "as": "PERMISSIVE",
+          "for": "UPDATE",
+          "to": [
+            "authenticated"
+          ],
+          "using": "(profile_id = current_profile_id())",
+          "withCheck": "(profile_id = current_profile_id())"
+        },
+        "Users can delete their own tools and techniques": {
+          "name": "Users can delete their own tools and techniques",
+          "as": "PERMISSIVE",
+          "for": "DELETE",
+          "to": [
+            "authenticated"
+          ],
+          "using": "(profile_id = current_profile_id())"
+        }
+      },
+      "checkConstraints": {},
+      "isRLSEnabled": true
+    }
+  },
+  "enums": {
+    "public.book_list_status": {
+      "name": "book_list_status",
+      "schema": "public",
+      "values": [
+        "processing",
+        "shortlist",
+        "longlist",
+        "archived"
+      ]
+    },
+    "public.book_source": {
+      "name": "book_source",
+      "schema": "public",
+      "values": [
+        "manual",
+        "google_books",
+        "open_library"
+      ]
+    },
+    "public.personality_test_type": {
+      "name": "personality_test_type",
+      "schema": "public",
+      "values": [
+        "gallup",
+        "mbti",
+        "disc",
+        "big_five",
+        "enneagram",
+        "belbin",
+        "other"
+      ]
+    },
+    "public.profile_role": {
+      "name": "profile_role",
+      "schema": "public",
+      "values": [
+        "student",
+        "mentor",
+        "coach",
+        "admin"
+      ]
+    },
+    "public.schedule_type": {
+      "name": "schedule_type",
+      "schema": "public",
+      "values": [
+        "training_session",
+        "houston_calling"
+      ]
+    },
+    "public.team_document_type": {
+      "name": "team_document_type",
+      "schema": "public",
+      "values": [
+        "team_contract",
+        "financial_policy",
+        "other"
+      ]
+    },
+    "public.semester_reflection_topic": {
+      "name": "semester_reflection_topic",
+      "schema": "public",
+      "values": [
+        "predmety_zkousky_vyucujici",
+        "metodika_a_metriky",
+        "kouci_a_mentori",
+        "tymy_a_tymove_spolecnosti",
+        "individualni_prinos",
+        "komunita",
+        "komunitni_role",
+        "komunitni_akce",
+        "komunitni_a_cross_projekty",
+        "zacleneni_tucnaku",
+        "dalsi"
+      ]
+    },
+    "public.tool_type": {
+      "name": "tool_type",
+      "schema": "public",
+      "values": [
+        "model",
+        "technique",
+        "tool"
+      ]
+    }
+  },
+  "schemas": {},
+  "views": {
+    "public.books_with_essay_count": {
+      "name": "books_with_essay_count",
+      "schema": "public",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "title_cs": {
+          "name": "title_cs",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "title_en": {
+          "name": "title_en",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "author": {
+          "name": "author",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "isbn_13": {
+          "name": "isbn_13",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "google_books_cover_url": {
+          "name": "google_books_cover_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "book_points": {
+          "name": "book_points",
+          "type": "numeric(3, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "page_count": {
+          "name": "page_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "preview_link": {
+          "name": "preview_link",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source": {
+          "name": "source",
+          "type": "book_source",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "external_id": {
+          "name": "external_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "list_status": {
+          "name": "list_status",
+          "type": "book_list_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "list_status_changed_at": {
+          "name": "list_status_changed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "list_status_changed_by_profile_id": {
+          "name": "list_status_changed_by_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "list_status_reason": {
+          "name": "list_status_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "highlight_category_id": {
+          "name": "highlight_category_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_rocket_model": {
+          "name": "is_rocket_model",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by_profile_id": {
+          "name": "created_by_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_by_profile_id": {
+          "name": "updated_by_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "essay_count": {
+          "name": "essay_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "definition": "SELECT b.id, b.title_cs, b.title_en, b.author, b.isbn_13, b.description, b.google_books_cover_url, b.book_points, b.page_count, b.preview_link, b.source, b.external_id, b.list_status, b.list_status_changed_at, b.list_status_changed_by_profile_id, b.list_status_reason, b.highlight_category_id, b.is_rocket_model, b.created_at, b.updated_at, b.created_by_profile_id, b.updated_by_profile_id, COALESCE(ec.essay_count, 0) AS essay_count FROM books b LEFT JOIN ( SELECT essays.book_id, count(*)::integer AS essay_count FROM essays WHERE essays.book_id IS NOT NULL AND essays.published_at IS NOT NULL AND essays.removed_at IS NULL GROUP BY essays.book_id) ec ON ec.book_id = b.id",
+      "materialized": false,
+      "isExisting": false
+    }
+  },
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/supabase/migrations/meta/_journal.json
+++ b/supabase/migrations/meta/_journal.json
@@ -337,6 +337,20 @@
       "when": 1787080277879,
       "tag": "20260818191117_gorgeous_cammi",
       "breakpoints": true
+    },
+    {
+      "idx": 48,
+      "version": "7",
+      "when": 1787094289942,
+      "tag": "20260818230449_aspiring_meggan",
+      "breakpoints": true
+    },
+    {
+      "idx": 49,
+      "version": "7",
+      "when": 1787094298871,
+      "tag": "20260818230458_careless_killmonger",
+      "breakpoints": true
     }
   ]
 }

--- a/tests/e2e/team-documents.spec.ts
+++ b/tests/e2e/team-documents.spec.ts
@@ -1,0 +1,82 @@
+import { expect, test } from "@playwright/test"
+
+import {
+  cleanupTestData,
+  createTestTeam,
+  getSetupSessionCookie,
+  grantBetaAccess,
+  setAuthCookie,
+} from "./fixtures/auth"
+
+const FIRST_PDF = {
+  name: "pravidla-v1.pdf",
+  mimeType: "application/pdf",
+  buffer: Buffer.from("%PDF-1.4 first team document"),
+}
+
+const SECOND_PDF = {
+  name: "pravidla-v2.pdf",
+  mimeType: "application/pdf",
+  buffer: Buffer.from("%PDF-1.4 second team document"),
+}
+
+test.describe("týmové dokumenty - bez přihlášení", () => {
+  test("přesměrují na přihlášení", async ({ page }) => {
+    await page.goto("/tymove-dokumenty")
+    await expect(page).toHaveURL(/\/auth\/login/)
+  })
+})
+
+test.describe("týmové dokumenty - členství v týmu", () => {
+  test.describe.configure({ mode: "serial" })
+
+  let cookieValue: string
+
+  test.beforeAll(async () => {
+    const teamId = await createTestTeam()
+    const user = await getSetupSessionCookie(teamId)
+    await grantBetaAccess(user.profileId)
+    cookieValue = user.cookie
+  })
+
+  test.beforeEach(async ({ context }) => {
+    await setAuthCookie(context, cookieValue)
+  })
+
+  test.afterAll(async () => {
+    await cleanupTestData()
+  })
+
+  test("zobrazí oba zvýrazněné dokumenty a prázdnou vlastní sekci", async ({ page }) => {
+    await page.goto("/tymove-dokumenty")
+
+    await expect(page.getByRole("heading", { name: "Týmové dokumenty" })).toBeVisible()
+    await expect(page.getByRole("heading", { name: "Týmová smlouva" })).toBeVisible()
+    await expect(page.getByRole("heading", { name: "Finanční směrnice" })).toBeVisible()
+    await expect(page.getByText("Zatím žádné další dokumenty")).toBeVisible()
+  })
+
+  test("vytvoří vlastní dokument a přidá druhou verzi", async ({ page }) => {
+    const title = `E2E pravidla ${Date.now()}`
+    await page.goto("/tymove-dokumenty")
+
+    await page.getByRole("button", { name: "Přidat dokument" }).click()
+    let dialog = page.getByRole("dialog")
+    await dialog.getByLabel("Název dokumentu").fill(title)
+    await dialog.getByLabel("Soubor PDF").setInputFiles(FIRST_PDF)
+    await dialog.getByRole("button", { name: "Nahrát verzi" }).click()
+
+    await expect(dialog).toHaveCount(0)
+    await expect(page.getByRole("heading", { name: title })).toBeVisible()
+    await expect(page.getByText("pravidla-v1.pdf")).toBeVisible()
+
+    await page.getByRole("button", { name: "Nahrát novou verzi" }).click()
+    dialog = page.getByRole("dialog")
+    await dialog.getByLabel("Soubor PDF").setInputFiles(SECOND_PDF)
+    await dialog.getByRole("button", { name: "Nahrát verzi" }).click()
+
+    await expect(dialog).toHaveCount(0)
+    await expect(page.getByText("pravidla-v2.pdf").first()).toBeVisible()
+    await expect(page.getByText("Historie verzí (2)")).toBeVisible()
+  })
+})

--- a/tests/integration/team-documents.int.test.ts
+++ b/tests/integration/team-documents.int.test.ts
@@ -1,0 +1,275 @@
+import type { PoolClient } from "pg"
+import { describe, expect, it } from "vitest"
+
+import { insertAuthUser } from "@/tests/setup/factories"
+import { asClaims } from "@/tests/setup/rls"
+import { withRollback } from "@/tests/setup/tx"
+
+async function seed(client: PoolClient) {
+  const memberAuth = await insertAuthUser(client)
+  const teammateAuth = await insertAuthUser(client)
+  const outsiderAuth = await insertAuthUser(client)
+
+  const { rows: userRows } = await client.query(
+    "select id, auth_user_id from public.users where auth_user_id = any($1)",
+    [[memberAuth.id, teammateAuth.id, outsiderAuth.id]],
+  )
+  const userIdByAuthId = new Map<string, string>(
+    userRows.map((row: { id: string; auth_user_id: string }) => [row.auth_user_id, row.id]),
+  )
+  await client.query(
+    "update public.users set verified_work_email = google_email, verified_work_email_at = now() where id = any($1)",
+    [[...userIdByAuthId.values()]],
+  )
+
+  const { rows: teamRows } = await client.query(
+    "insert into public.teams (name) values ('Document Team'), ('Other Team') returning id",
+  )
+  const teamId = teamRows[0].id as string
+  const otherTeamId = teamRows[1].id as string
+
+  const { rows: profileRows } = await client.query(
+    `insert into public.profiles (name, work_email, user_id, team_id, role)
+     values
+       ('Member', 'documents-member@studenti.czu.cz', $1, $4, 'student'),
+       ('Teammate', 'documents-teammate@studenti.czu.cz', $2, $4, 'student'),
+       ('Outsider', 'documents-outsider@studenti.czu.cz', $3, $5, 'student')
+     returning id, name`,
+    [
+      userIdByAuthId.get(memberAuth.id),
+      userIdByAuthId.get(teammateAuth.id),
+      userIdByAuthId.get(outsiderAuth.id),
+      teamId,
+      otherTeamId,
+    ],
+  )
+  const profileIdByName = new Map<string, string>(
+    profileRows.map((row: { id: string; name: string }) => [row.name, row.id]),
+  )
+
+  return {
+    teamId,
+    otherTeamId,
+    memberAuthId: memberAuth.id,
+    teammateAuthId: teammateAuth.id,
+    outsiderAuthId: outsiderAuth.id,
+    memberProfileId: profileIdByName.get("Member")!,
+    teammateProfileId: profileIdByName.get("Teammate")!,
+    outsiderProfileId: profileIdByName.get("Outsider")!,
+  }
+}
+
+async function insertDocument(
+  client: PoolClient,
+  teamId: string,
+  profileId: string,
+  documentType: "team_contract" | "financial_policy" | "other",
+  title: string | null = null,
+) {
+  const { rows } = await client.query(
+    `insert into public.team_documents
+       (team_id, doc_type, title, created_by_profile_id, updated_by_profile_id)
+     values ($1, $2, $3, $4, $4)
+     returning id`,
+    [teamId, documentType, title, profileId],
+  )
+  return rows[0].id as string
+}
+
+async function insertVersion(
+  client: PoolClient,
+  documentId: string,
+  profileId: string,
+  versionNumber = 1,
+) {
+  const { rows } = await client.query(
+    `insert into public.team_document_versions
+       (document_id, version_no, file_path, file_name, file_size, created_by_profile_id)
+     values ($1, $2, $3, $4, 1024, $5)
+     returning id`,
+    [
+      documentId,
+      versionNumber,
+      `team-document/${documentId}/version-${versionNumber}.pdf`,
+      `version-${versionNumber}.pdf`,
+      profileId,
+    ],
+  )
+  return rows[0].id as string
+}
+
+describe("team documents schema and RLS", () => {
+  it("lets team members create and read their team's documents", async () => {
+    await withRollback(async (client) => {
+      const { teamId, memberAuthId, memberProfileId, teammateAuthId } = await seed(client)
+
+      await asClaims(client, { sub: memberAuthId })
+      await insertDocument(client, teamId, memberProfileId, "team_contract")
+
+      await asClaims(client, { sub: teammateAuthId })
+      const { rows } = await client.query(
+        "select doc_type from public.team_documents where team_id = $1",
+        [teamId],
+      )
+
+      expect(rows).toEqual([{ doc_type: "team_contract" }])
+    })
+  })
+
+  it("isolates documents from members of other teams", async () => {
+    await withRollback(async (client) => {
+      const { teamId, memberProfileId, outsiderAuthId, outsiderProfileId } = await seed(client)
+      await insertDocument(client, teamId, memberProfileId, "team_contract")
+
+      await asClaims(client, { sub: outsiderAuthId })
+      const { rows } = await client.query(
+        "select id from public.team_documents where team_id = $1",
+        [teamId],
+      )
+      expect(rows).toHaveLength(0)
+
+      await expect(
+        insertDocument(client, teamId, outsiderProfileId, "other", "Cizí dokument"),
+      ).rejects.toThrow()
+    })
+  })
+
+  it("allows one featured document of each type and multiple custom documents", async () => {
+    await withRollback(async (client) => {
+      const { teamId, memberAuthId, memberProfileId } = await seed(client)
+      await asClaims(client, { sub: memberAuthId })
+
+      await insertDocument(client, teamId, memberProfileId, "team_contract")
+      await insertDocument(client, teamId, memberProfileId, "financial_policy")
+      await insertDocument(client, teamId, memberProfileId, "other", "Pravidla porad")
+      await insertDocument(client, teamId, memberProfileId, "other", "Zápisy")
+
+      const { rows } = await client.query(
+        "select doc_type, title from public.team_documents where team_id = $1 order by created_at",
+        [teamId],
+      )
+      expect(rows).toHaveLength(4)
+
+      await expect(
+        insertDocument(client, teamId, memberProfileId, "team_contract"),
+      ).rejects.toThrow()
+    })
+  })
+
+  it("requires a non-empty title for custom documents", async () => {
+    await withRollback(async (client) => {
+      const { teamId, memberAuthId, memberProfileId } = await seed(client)
+      await asClaims(client, { sub: memberAuthId })
+
+      await expect(
+        insertDocument(client, teamId, memberProfileId, "other", "   "),
+      ).rejects.toThrow()
+    })
+  })
+
+  it("lets team members add and read immutable document versions", async () => {
+    await withRollback(async (client) => {
+      const {
+        teamId,
+        memberProfileId,
+        teammateAuthId,
+        teammateProfileId,
+        outsiderAuthId,
+      } = await seed(client)
+      const documentId = await insertDocument(
+        client,
+        teamId,
+        memberProfileId,
+        "other",
+        "Týmová pravidla",
+      )
+
+      await asClaims(client, { sub: teammateAuthId })
+      const versionId = await insertVersion(client, documentId, teammateProfileId)
+
+      const { rows } = await client.query(
+        "select version_no from public.team_document_versions where document_id = $1",
+        [documentId],
+      )
+      expect(rows).toEqual([{ version_no: 1 }])
+
+      const updateResult = await client.query(
+        "update public.team_document_versions set change_note = 'Změněno' where id = $1",
+        [versionId],
+      )
+      expect(updateResult.rowCount).toBe(0)
+
+      const deleteResult = await client.query(
+        "delete from public.team_document_versions where id = $1",
+        [versionId],
+      )
+      expect(deleteResult.rowCount).toBe(0)
+
+      await asClaims(client, { sub: outsiderAuthId })
+      const { rows: outsiderRows } = await client.query(
+        "select id from public.team_document_versions where document_id = $1",
+        [documentId],
+      )
+      expect(outsiderRows).toHaveLength(0)
+    })
+  })
+
+  it("allows renaming and archiving only custom documents", async () => {
+    await withRollback(async (client) => {
+      const { teamId, memberAuthId, memberProfileId } = await seed(client)
+      const customId = await insertDocument(
+        client,
+        teamId,
+        memberProfileId,
+        "other",
+        "Původní název",
+      )
+      const featuredId = await insertDocument(
+        client,
+        teamId,
+        memberProfileId,
+        "team_contract",
+      )
+
+      await asClaims(client, { sub: memberAuthId })
+      const customUpdate = await client.query(
+        `update public.team_documents
+         set title = 'Nový název', removed_at = now(), updated_by_profile_id = $2
+         where id = $1`,
+        [customId, memberProfileId],
+      )
+      expect(customUpdate.rowCount).toBe(1)
+
+      const featuredUpdate = await client.query(
+        "update public.team_documents set removed_at = now() where id = $1",
+        [featuredId],
+      )
+      expect(featuredUpdate.rowCount).toBe(0)
+    })
+  })
+
+  it("cascades document history when a team is deleted", async () => {
+    await withRollback(async (client) => {
+      const { teamId, memberProfileId } = await seed(client)
+      const documentId = await insertDocument(
+        client,
+        teamId,
+        memberProfileId,
+        "other",
+        "Archiv",
+      )
+      await insertVersion(client, documentId, memberProfileId)
+
+      await client.query("set local role service_role")
+      await client.query("delete from public.teams where id = $1", [teamId])
+
+      const { rows } = await client.query(
+        `select
+           (select count(*)::int from public.team_documents where team_id = $1) as documents,
+           (select count(*)::int from public.team_document_versions where document_id = $2) as versions`,
+        [teamId, documentId],
+      )
+      expect(rows[0]).toEqual({ documents: 0, versions: 0 })
+    })
+  })
+})


### PR DESCRIPTION
## Summary
- add team-scoped document and immutable PDF version schema with RLS, constraints, generated types, and migrations
- add private document uploads, signed downloads, validation, typed queries, and authenticated API routes
- add the beta-gated Team Documents page with featured Team Contract and Financial Policy slots, custom documents, version history, and responsive management flows
- simplify the visual hierarchy to keep featured cards while flattening nested version, history, and empty-state surfaces

## Scope
- Implements the document-library portions of #51 and #52
- Structured Leading Thoughts, legal signing, and inline document editing remain deferred

## Test Plan
- [x] `pnpm test` (474 tests)
- [x] `pnpm test:integration` (80 tests)
- [x] `pnpm test:e2e tests/e2e/team-documents.spec.ts` (3 tests)
- [x] `pnpm typecheck`
- [x] `pnpm lint`
- [x] `pnpm build`

## Database
- Schema source of truth: `db/schema/team-documents.ts`
- Generated migrations contain no unintended table or column drops
