### PR TITLE
ci: run E2E smoke test against local Supabase

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -41,6 +41,18 @@ jobs:
       - name: Integration tests (Testcontainers)
         run: pnpm test:integration
 
+      - name: Create .env.local from example
+        run: cp .env.example .env.local
+
+      - name: Start local Supabase (CI-slim, no studio/analytics/edge-runtime)
+        run: pnpm supabase:start -- -x studio -x analytics -x edge-runtime
+
+      - name: Apply migrations and seed
+        run: pnpm db:reset
+
+      - name: Write local Supabase credentials to .env.local
+        run: pnpm setup-env
+
       - name: Install Playwright browser
         run: pnpm exec playwright install --with-deps chromium
 

--- a/scripts/package-json-helpers/supabase-start.js
+++ b/scripts/package-json-helpers/supabase-start.js
@@ -4,12 +4,14 @@ import { readEnvLocal } from './env-utils.js';
 
 /**
  * Starts local Supabase with environment variables from .env.local.
- * Required so config.toml env(GOOGLE_CLIENT_*) substitutions resolve.
+ * Required so config.toml env(...) substitutions resolve.
+ * Extra CLI args are forwarded, e.g.:
+ *   pnpm supabase:start -- -x studio -x analytics -x edge-runtime
  */
 const main = () => {
   const envFromLocal = readEnvLocal();
 
-  const child = spawn('pnpm', ['supabase', 'start'], {
+  const child = spawn('pnpm', ['supabase', 'start', ...process.argv.slice(2)], {
     stdio: 'inherit',
     env: {
       ...process.env,

--- a/supabase/seed.sql
+++ b/supabase/seed.sql
@@ -29,3 +29,29 @@ CROSS JOIN (
     SELECT id FROM profiles WHERE work_email = 'admin@studenti.czu.cz'
 ) AS system_profile;
 
+-- ============================================
+-- SEED DATA - BOOK TAGS
+-- ============================================
+-- Reference data mirroring BOOK_CATEGORIES in src/lib/books/types.ts.
+-- Students may only assign existing tags: inserting into `tags` is
+-- coach/admin-only per RLS, so a missing tag would fail every student
+-- book submission with 42501.
+
+INSERT INTO tags (name, created_by_profile_id, updated_by_profile_id)
+SELECT seed_tags.name, system_profile.id, system_profile.id
+FROM (
+    VALUES
+        ('Finance & ekonomika'),
+        ('Inovace & kreativita'),
+        ('Komunikace & prodej'),
+        ('Leadership'),
+        ('Management'),
+        ('Marketing'),
+        ('Multidisciplinární'),
+        ('Osobní rozvoj')
+) AS seed_tags(name)
+CROSS JOIN (
+    SELECT id FROM profiles WHERE work_email = 'admin@studenti.czu.cz'
+) AS system_profile
+ON CONFLICT (name) DO NOTHING;
+

--- a/tests/e2e/add-book.spec.ts
+++ b/tests/e2e/add-book.spec.ts
@@ -279,7 +279,7 @@ test.describe('adding a book', () => {
     // enrichment there is no score to show, so the coach assigns one.
     const submit = page.getByRole('button', { name: /odeslat ke schválení/i });
     await expect(submit).toBeDisabled();
-    await expect(page.getByText('Body přidělí kouč.')).toBeVisible();
+    await expect(page.getByText('Body přidělí kouč:ka.')).toBeVisible();
 
     await page.getByLabel(/popis/i).fill('Naučíš se, jak funguje týmové podnikání na Tiimi.');
     await page.getByLabel(/oblast/i).selectOption('Leadership');

--- a/tests/e2e/reading.spec.ts
+++ b/tests/e2e/reading.spec.ts
@@ -83,15 +83,18 @@ test.describe("reading navigation - arrow back", () => {
 
   test("cteni/knihy/nova - Zpět do hledání navigates to /cteni/hledat", async ({ page }) => {
     await page.goto("/cteni/knihy/nova");
-    await expect(page.getByRole("link", { name: /zpět/i })).toBeVisible();
-    await page.getByRole("link", { name: /zpět/i }).click();
+    // Exact name: /zpět/i would also match the sidebar's "Zpětná vazba" link.
+    const backLink = page.getByRole("link", { name: "Zpět do hledání" });
+    await expect(backLink).toBeVisible();
+    await backLink.click();
     await expect(page).toHaveURL(/\/cteni\/hledat/);
   });
 
   test("cteni/knihy/[bookId] - Zpět do hledání navigates to /cteni/hledat", async ({ page }) => {
     await page.goto(`/cteni/knihy/${bookId}`);
-    await expect(page.getByRole("link", { name: /zpět/i })).toBeVisible();
-    await page.getByRole("link", { name: /zpět/i }).click();
+    const backLink = page.getByRole("link", { name: "Zpět do hledání" });
+    await expect(backLink).toBeVisible();
+    await backLink.click();
     await expect(page).toHaveURL(/\/cteni\/hledat/);
   });
 
@@ -100,8 +103,10 @@ test.describe("reading navigation - arrow back", () => {
     const response = await page.goto("/cteni/eseje/nova");
     expect(response?.status()).toBeLessThan(400);
     await expect(page.locator("body")).toBeVisible();
-    await expect(page.locator("text=Zpět").first()).toBeVisible({ timeout: 10000 });
-    await page.locator("text=Zpět").first().click();
+    // The BackButton is a <button>; the sidebar "Zpětná vazba" is a link.
+    const backButton = page.getByRole("button", { name: "Zpět", exact: true });
+    await expect(backButton).toBeVisible({ timeout: 10000 });
+    await backButton.click();
     await expect(page).toHaveURL(/\/cteni\/hledat/);
   });
 
@@ -110,15 +115,20 @@ test.describe("reading navigation - arrow back", () => {
     const response = await page.goto(`/cteni/eseje/${essayId}`);
     expect(response?.status()).toBeLessThan(400);
     await expect(page.locator("body")).toBeVisible();
-    await expect(page.locator("text=Zpět").first()).toBeVisible({ timeout: 10000 });
-    await page.locator("text=Zpět").first().click();
+    const backButton = page.getByRole("button", { name: "Zpět", exact: true });
+    await expect(backButton).toBeVisible({ timeout: 10000 });
+    await backButton.click();
     await expect(page).toHaveURL(/\/cteni\/hledat/);
   });
 
-  test("cteni/eseje/[essayId]/upravit - Zpět na esej navigates to essay", async ({ page }) => {
+  test("cteni/eseje/[essayId]/upravit - Zpět (router.back) navigates back to essay", async ({ page }) => {
+    // The editor uses BackButton (router.back()), so history must contain the
+    // essay page for Zpět to land there.
+    await page.goto(`/cteni/eseje/${essayId}`);
     await page.goto(`/cteni/eseje/${essayId}/upravit`);
-    await expect(page.getByRole("link", { name: /zpět/i })).toBeVisible();
-    await page.getByRole("link", { name: /zpět/i }).click();
+    const backButton = page.getByRole("button", { name: "Zpět", exact: true });
+    await expect(backButton).toBeVisible();
+    await backButton.click();
     await expect(page).toHaveURL(new RegExp(`/cteni/eseje/${essayId}$`));
   });
 });

--- a/tests/e2e/tymova-reflexe.spec.ts
+++ b/tests/e2e/tymova-reflexe.spec.ts
@@ -41,7 +41,7 @@ test.describe("týmová reflexe - single user", () => {
     const response = await page.goto("/tymova-reflexe");
     expect(response?.status()).toBeLessThan(400);
     await expect(page.getByRole("heading", { name: "Týmová reflexe" })).toBeVisible();
-    await expect(page.getByRole("heading", { name: "Docházka reflexí" })).toBeVisible();
+    await expect(page.getByRole("heading", { name: "Kalendář reflexí" })).toBeVisible();
   });
 
   test("creating a reflection redirects to its detail page", async ({ page }) => {


### PR DESCRIPTION
## Summary
Fixes the never-green E2E smoke test (0 passing PR runs since it was added July 9).

**Root cause:** the proxy middleware creates a Supabase client on every request; CI had no credentials, so every response 500'd and Playwright's readiness poll timed out after 120s.

**Fix:** boot the local Supabase stack in CI — same stack the E2E fixtures were designed for (they read `.env.local` and forge JWTs against local GoTrue):
- `cp .env.example .env.local` (ensure-env is interactive, can't run in CI)
- `supabase start` slimmed via `-x studio -x analytics -x edge-runtime` (~3 GB fewer images)
- `db:reset` applies all migrations + seed
- `setup-env` writes real local creds into `.env.local`
- build now runs **after** creds exist so `NEXT_PUBLIC_*` are inlined correctly

`supabase:start` helper now forwards extra args to the CLI.

## Cost
~+2–3 min per PR run (public repo → unlimited free minutes).