### PR TITLE
feat: add backend pagination, filtering, and infinite scroll to coach review essays

### DIFF
--- a/src/app/(main)/cteni/eseje/ke-kontrole/page.tsx
+++ b/src/app/(main)/cteni/eseje/ke-kontrole/page.tsx
@@ -1,13 +1,7 @@
 import { redirect } from 'next/navigation';
 import { createClient } from '@/lib/supabase/server';
 import { getCurrentUserProfile } from '@/lib/auth-helpers';
-import {
-  getUnreadTeamEssaysForCoach,
-  getReadTeamEssaysForCoach,
-  getAuthorsApprovedBookPoints,
-  getCommentsForEssays,
-  getCoachReadsForEssays,
-} from '@/lib/essays/queries';
+import { getCoachReviewEssays } from '@/lib/essays/queries';
 import { CoachReviewList } from '@/components/essays/coach-review-list';
 import { PageHeader } from '@/components/ui/page-header';
 import { PageShell } from '@/components/ui/page-shell';
@@ -29,25 +23,22 @@ export default async function CoachReviewPage() {
     redirect('/');
   }
 
-  const [teamsResult, unread, read] = await Promise.all([
+  const defaultTeamId = profile.team_id ?? 'all';
+  const [teamsResult, initialResult] = await Promise.all([
     supabase
       .from('teams')
       .select('id, name')
       .is('removed_at', null)
       .order('name', { ascending: true }),
-    getUnreadTeamEssaysForCoach(supabase, profile.id, null),
-    getReadTeamEssaysForCoach(supabase, profile.id, null),
+    getCoachReviewEssays(supabase, profile.id, {
+      tab: 'unread',
+      teamId: defaultTeamId === 'all' ? null : defaultTeamId,
+      page: 1,
+      pageSize: 50,
+    }),
   ]);
 
   const teams = (teamsResult.data ?? []) as { id: string; name: string }[];
-  const authorIds = Array.from(new Set([...unread, ...read].map((e) => e.author_profile_id)));
-  const essayIds = Array.from(new Set([...unread, ...read].map((e) => e.id)));
-
-  const [authorPointsMap, commentsMap, coachReadsMap] = await Promise.all([
-    getAuthorsApprovedBookPoints(supabase, authorIds),
-    getCommentsForEssays(supabase, essayIds),
-    getCoachReadsForEssays(supabase, essayIds),
-  ]);
 
   return (
     <PageShell size="medium">
@@ -57,13 +48,15 @@ export default async function CoachReviewPage() {
       />
 
       <CoachReviewList
-        initialUnread={unread}
-        initialRead={read}
+        initialUnread={initialResult.essays}
+        initialUnreadCount={initialResult.unreadCount}
+        initialReadCount={initialResult.readCount}
+        initialHasMore={initialResult.hasMore}
         teams={teams}
-        defaultTeamId={profile.team_id ?? 'all'}
-        authorPointsMap={authorPointsMap}
-        commentsMap={commentsMap}
-        coachReadsMap={coachReadsMap}
+        defaultTeamId={defaultTeamId}
+        authorPointsMap={initialResult.authorPointsMap}
+        commentsMap={initialResult.commentsMap}
+        coachReadsMap={initialResult.coachReadsMap}
         currentCoachId={profile.id}
         currentCoachName={profile.name ?? 'Kouč:ka'}
       />

--- a/src/app/api/essays/coach-review/route.ts
+++ b/src/app/api/essays/coach-review/route.ts
@@ -1,0 +1,64 @@
+import { NextRequest, NextResponse } from 'next/server';
+
+import { createClient } from '@/lib/supabase/server';
+import { getCurrentUserProfile } from '@/lib/auth-helpers';
+import { getCoachReviewEssays } from '@/lib/essays/queries';
+import type {
+  CoachReviewTab,
+  CoachReviewRocketFilter,
+  CoachReviewPointsFilter,
+  CoachReviewReplyFilter,
+} from '@/lib/essays/types';
+
+export async function GET(request: NextRequest) {
+  try {
+    const supabase = await createClient();
+    const {
+      data: { user },
+    } = await supabase.auth.getUser();
+    if (!user) return NextResponse.json({ error: 'Neautorizováno' }, { status: 401 });
+
+    const profile = await getCurrentUserProfile(supabase, { user });
+    if (!profile || (profile.role !== 'coach' && profile.role !== 'admin')) {
+      return NextResponse.json({ error: 'Přístup odepřen' }, { status: 403 });
+    }
+
+    const { searchParams } = new URL(request.url);
+    const tab = (searchParams.get('tab') ?? 'unread') as CoachReviewTab;
+    const teamId = searchParams.get('team_id') ?? undefined;
+    const rocket = (searchParams.get('rocket') ?? 'all') as CoachReviewRocketFilter;
+    const points = (searchParams.get('points') ?? 'all') as CoachReviewPointsFilter;
+    const reply = (searchParams.get('reply') ?? 'all') as CoachReviewReplyFilter;
+    const page = searchParams.get('page') ? Number(searchParams.get('page')) : 1;
+    const pageSize = searchParams.get('page_size')
+      ? Number(searchParams.get('page_size'))
+      : 50;
+
+    const result = await getCoachReviewEssays(supabase, profile.id, {
+      tab,
+      teamId: teamId === 'all' ? null : teamId,
+      rocket,
+      points,
+      reply,
+      page,
+      pageSize,
+    });
+
+    return NextResponse.json({
+      data: result.essays,
+      totalCount: result.totalCount,
+      unreadCount: result.unreadCount,
+      readCount: result.readCount,
+      hasMore: result.hasMore,
+      authorPointsMap: result.authorPointsMap,
+      commentsMap: result.commentsMap,
+      coachReadsMap: result.coachReadsMap,
+    });
+  } catch (error) {
+    console.error('GET /api/essays/coach-review error:', error);
+    return NextResponse.json(
+      { error: 'Nepodařilo se načíst eseje ke kontrole' },
+      { status: 500 },
+    );
+  }
+}

--- a/src/components/essays/coach-review-list.test.tsx
+++ b/src/components/essays/coach-review-list.test.tsx
@@ -292,4 +292,23 @@ describe('CoachReviewList', () => {
 
     expect(screen.getByText('Upraveno po komentáři')).toBeInTheDocument();
   });
+
+  it('displays exact total unread and read counts on tab badges when thousands exist in database', () => {
+    const essay = mockEssay();
+    render(
+      <CoachReviewList
+        initialUnread={[essay]}
+        initialRead={[]}
+        initialUnreadCount={4000}
+        initialReadCount={125}
+        teams={teams}
+        defaultTeamId="all"
+      />,
+    );
+
+    // Unread count badge displays 4000
+    expect(screen.getByText('4000')).toBeInTheDocument();
+    // Read count badge displays 125
+    expect(screen.getByText('125')).toBeInTheDocument();
+  });
 });

--- a/src/components/essays/coach-review-list.tsx
+++ b/src/components/essays/coach-review-list.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useCallback, useMemo, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import Link from 'next/link';
 import {
   BookOpen,
@@ -17,6 +17,7 @@ import {
 import { Tabs, TabsContent, TabsList, TabsTrigger, TabsTriggerCount } from '@/components/ui/tabs';
 import { Card, CardContent } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
+import { Spinner } from '@/components/ui/spinner';
 import {
   Select,
   SelectContent,
@@ -33,13 +34,19 @@ import { usePersistedState } from '@/lib/hooks/use-persisted-state';
 import { pointsNumber } from '@/lib/books/points';
 import type {
   CoachReviewEssay,
+  CoachReviewPointsFilter,
+  CoachReviewReplyFilter,
+  CoachReviewRocketFilter,
   EssayCoachReadWithProfile,
   EssayCommentWithAuthor,
 } from '@/lib/essays/types';
 
 interface CoachReviewListProps {
-  initialUnread: CoachReviewEssay[];
-  initialRead: CoachReviewEssay[];
+  initialUnread?: CoachReviewEssay[];
+  initialRead?: CoachReviewEssay[];
+  initialUnreadCount?: number;
+  initialReadCount?: number;
+  initialHasMore?: boolean;
   teams?: { id: string; name: string }[];
   defaultTeamId?: string;
   authorPointsMap?: Record<string, number>;
@@ -51,26 +58,82 @@ interface CoachReviewListProps {
 }
 
 export function CoachReviewList({
-  initialUnread,
-  initialRead,
+  initialUnread = [],
+  initialRead = [],
+  initialUnreadCount,
+  initialReadCount,
+  initialHasMore = false,
   teams = [],
   defaultTeamId = 'all',
-  authorPointsMap: _authorPointsMap = {},
-  commentsMap = {},
+  authorPointsMap: _initialAuthorPointsMap = {},
+  commentsMap: initialCommentsMap = {},
   coachCommentsMap = {},
-  coachReadsMap = {},
+  coachReadsMap: initialCoachReadsMap = {},
   currentCoachId,
   currentCoachName = 'Kouč:ka',
 }: CoachReviewListProps) {
-  const [activeTab, setActiveTab] = usePersistedState<'unread' | 'read'>('tappka:coach-review:tab', 'unread');
-  const [unread, setUnread] = useState(initialUnread);
-  const [read, setRead] = useState(initialRead);
-  const [readsMap, setReadsMap] = useState<Record<string, EssayCoachReadWithProfile[]>>(coachReadsMap);
+  const [activeTab, setActiveTab] = usePersistedState<'unread' | 'read'>(
+    'tappka:coach-review:tab',
+    'unread',
+  );
+  const [teamFilter, setTeamFilter] = usePersistedState<string>(
+    'tappka:coach-review:team',
+    defaultTeamId,
+  );
+  const [rocketFilter, setRocketFilter] = usePersistedState<CoachReviewRocketFilter>(
+    'tappka:coach-review:rocket',
+    'all',
+  );
+  const [pointsFilter, setPointsFilter] = usePersistedState<CoachReviewPointsFilter>(
+    'tappka:coach-review:points',
+    'all',
+  );
+  const [replyFilter, setReplyFilter] = usePersistedState<CoachReviewReplyFilter>(
+    'tappka:coach-review:reply',
+    'all',
+  );
 
-  const [teamFilter, setTeamFilter] = usePersistedState<string>('tappka:coach-review:team', defaultTeamId);
-  const [rocketFilter, setRocketFilter] = usePersistedState<string>('tappka:coach-review:rocket', 'all');
-  const [pointsFilter, setPointsFilter] = usePersistedState<string>('tappka:coach-review:points', 'all');
-  const [replyFilter, setReplyFilter] = usePersistedState<string>('tappka:coach-review:reply', 'all');
+  const initialFilterEssay = useCallback(
+    (essay: CoachReviewEssay) => {
+      if (defaultTeamId !== 'all') {
+        if (essay.author?.team_id !== defaultTeamId) return false;
+      }
+      return true;
+    },
+    [defaultTeamId],
+  );
+
+  const [essays, setEssays] = useState<CoachReviewEssay[]>(() => {
+    const list = activeTab === 'unread' ? initialUnread : initialRead;
+    return defaultTeamId === 'all' ? list : list.filter(initialFilterEssay);
+  });
+
+  const [unreadCount, setUnreadCount] = useState<number>(() => {
+    if (initialUnreadCount !== undefined) return initialUnreadCount;
+    return defaultTeamId === 'all'
+      ? initialUnread.length
+      : initialUnread.filter(initialFilterEssay).length;
+  });
+
+  const [readCount, setReadCount] = useState<number>(() => {
+    if (initialReadCount !== undefined) return initialReadCount;
+    return defaultTeamId === 'all'
+      ? initialRead.length
+      : initialRead.filter(initialFilterEssay).length;
+  });
+
+  const [page, setPage] = useState(1);
+  const [hasMore, setHasMore] = useState(initialHasMore);
+  const [loading, setLoading] = useState(false);
+  const [loadingMore, setLoadingMore] = useState(false);
+
+  const [commentsMap, setCommentsMap] =
+    useState<Record<string, EssayCommentWithAuthor[]>>(initialCommentsMap);
+  const [readsMap, setReadsMap] =
+    useState<Record<string, EssayCoachReadWithProfile[]>>(initialCoachReadsMap);
+
+  const sentinelRef = useRef<HTMLDivElement>(null);
+  const isInitialMount = useRef(true);
 
   const effectiveCommentsMap = useMemo(() => {
     const merged: Record<string, EssayCommentWithAuthor[]> = { ...commentsMap };
@@ -96,9 +159,112 @@ export function CoachReviewList({
     setReplyFilter('all');
   };
 
+  const buildUrl = useCallback(
+    (tab: string, pageNum: number) => {
+      const params = new URLSearchParams({
+        tab,
+        page: String(pageNum),
+        page_size: '50',
+      });
+      if (teamFilter) params.set('team_id', teamFilter);
+      if (rocketFilter !== 'all') params.set('rocket', rocketFilter);
+      if (pointsFilter !== 'all') params.set('points', pointsFilter);
+      if (replyFilter !== 'all') params.set('reply', replyFilter);
+      return `/api/essays/coach-review?${params.toString()}`;
+    },
+    [teamFilter, rocketFilter, pointsFilter, replyFilter],
+  );
+
+  useEffect(() => {
+    if (isInitialMount.current) {
+      isInitialMount.current = false;
+      const isDefault =
+        activeTab === 'unread' &&
+        teamFilter === defaultTeamId &&
+        rocketFilter === 'all' &&
+        pointsFilter === 'all' &&
+        replyFilter === 'all';
+      if (isDefault) return;
+    }
+
+    let isCancelled = false;
+    async function fetchFiltered() {
+      setLoading(true);
+      try {
+        const res = await fetch(buildUrl(activeTab, 1));
+        if (!res.ok) throw new Error('Fetch failed');
+        const json = await res.json();
+        if (isCancelled) return;
+        setEssays(json.data ?? []);
+        setUnreadCount(json.unreadCount ?? 0);
+        setReadCount(json.readCount ?? 0);
+        setHasMore(json.hasMore ?? false);
+        setPage(1);
+        if (json.commentsMap) setCommentsMap((prev) => ({ ...prev, ...json.commentsMap }));
+        if (json.coachReadsMap) setReadsMap((prev) => ({ ...prev, ...json.coachReadsMap }));
+      } catch (err) {
+        console.error('Failed to fetch filtered essays:', err);
+      } finally {
+        if (!isCancelled) setLoading(false);
+      }
+    }
+
+    fetchFiltered();
+    return () => {
+      isCancelled = true;
+    };
+  }, [activeTab, teamFilter, rocketFilter, pointsFilter, replyFilter, defaultTeamId, buildUrl]);
+
+  const loadMore = useCallback(async () => {
+    if (loading || loadingMore || !hasMore) return;
+    setLoadingMore(true);
+    try {
+      const nextPage = page + 1;
+      const res = await fetch(buildUrl(activeTab, nextPage));
+      if (!res.ok) throw new Error('Fetch failed');
+      const json = await res.json();
+      const newItems = (json.data ?? []) as CoachReviewEssay[];
+      if (newItems.length === 0) {
+        setHasMore(false);
+      } else {
+        setEssays((prev) => {
+          const existingIds = new Set(prev.map((e) => e.id));
+          const toAdd = newItems.filter((e) => !existingIds.has(e.id));
+          return [...prev, ...toAdd];
+        });
+        setPage(nextPage);
+        setHasMore(json.hasMore ?? false);
+        if (json.commentsMap) setCommentsMap((prev) => ({ ...prev, ...json.commentsMap }));
+        if (json.coachReadsMap) setReadsMap((prev) => ({ ...prev, ...json.coachReadsMap }));
+      }
+    } catch (err) {
+      console.error('Failed to load more essays:', err);
+    } finally {
+      setLoadingMore(false);
+    }
+  }, [activeTab, buildUrl, hasMore, loading, loadingMore, page]);
+
+  useEffect(() => {
+    const el = sentinelRef.current;
+    if (!el || typeof IntersectionObserver === 'undefined') return;
+    const observer = new IntersectionObserver(
+      (entries) => {
+        if (entries[0].isIntersecting) {
+          loadMore();
+        }
+      },
+      { rootMargin: '300px' },
+    );
+    observer.observe(el);
+    return () => observer.disconnect();
+  }, [loadMore]);
+
   const markRead = (essay: CoachReviewEssay) => {
-    setUnread((prev) => prev.filter((e) => e.id !== essay.id));
-    setRead((prev) => (prev.some((e) => e.id === essay.id) ? prev : [essay, ...prev]));
+    if (activeTab === 'unread') {
+      setEssays((prev) => prev.filter((e) => e.id !== essay.id));
+    }
+    setUnreadCount((c) => Math.max(0, c - 1));
+    setReadCount((c) => c + 1);
     if (currentCoachId) {
       const newEntry: EssayCoachReadWithProfile = {
         essay_id: essay.id,
@@ -108,14 +274,20 @@ export function CoachReviewList({
       };
       setReadsMap((prev) => ({
         ...prev,
-        [essay.id]: [...(prev[essay.id]?.filter((r) => r.coach_profile_id !== currentCoachId) ?? []), newEntry],
+        [essay.id]: [
+          ...(prev[essay.id]?.filter((r) => r.coach_profile_id !== currentCoachId) ?? []),
+          newEntry,
+        ],
       }));
     }
   };
 
   const markUnread = (essay: CoachReviewEssay) => {
-    setRead((prev) => prev.filter((e) => e.id !== essay.id));
-    setUnread((prev) => (prev.some((e) => e.id === essay.id) ? prev : [essay, ...prev]));
+    if (activeTab === 'read') {
+      setEssays((prev) => prev.filter((e) => e.id !== essay.id));
+    }
+    setReadCount((c) => Math.max(0, c - 1));
+    setUnreadCount((c) => c + 1);
     if (currentCoachId) {
       setReadsMap((prev) => {
         const existing = prev[essay.id] ?? [];
@@ -126,59 +298,6 @@ export function CoachReviewList({
       });
     }
   };
-
-  const filterEssay = useCallback(
-    (essay: CoachReviewEssay) => {
-      if (teamFilter !== 'all') {
-        if (essay.author?.team_id !== teamFilter) return false;
-      }
-      if (rocketFilter === 'rocket') {
-        if (!essay.book?.is_rocket_model) return false;
-      } else if (rocketFilter === 'non-rocket') {
-        if (essay.book?.is_rocket_model) return false;
-      }
-      if (pointsFilter !== 'all') {
-        const pts = pointsNumber(essay.book?.book_points);
-        if (pointsFilter === '0') {
-          if (essay.book && pts > 0) return false;
-        } else {
-          if (!essay.book || Math.round(pts) !== Number(pointsFilter)) return false;
-        }
-      }
-      if (replyFilter !== 'all') {
-        const essayComments = effectiveCommentsMap[essay.id] ?? [];
-        const { hasCoachComment, hasAuthorReply, latestCoachCommentTime } = getEssayCommentThreads(
-          essayComments,
-          essay.author_profile_id,
-        );
-
-        if (replyFilter === 'with-reply') {
-          if (!hasAuthorReply) return false;
-        } else if (replyFilter === 'without-reply') {
-          if (!hasCoachComment || hasAuthorReply) return false;
-        } else if (replyFilter === 'edited-after-comment') {
-          const hasEditedAfterCoach =
-            hasCoachComment &&
-            new Date(essay.updated_at).getTime() > latestCoachCommentTime + 60_000;
-          if (!hasEditedAfterCoach) return false;
-        } else if (replyFilter === 'no-coach-comment') {
-          if (hasCoachComment) return false;
-        }
-      }
-      return true;
-    },
-    [teamFilter, rocketFilter, pointsFilter, replyFilter, effectiveCommentsMap],
-  );
-
-  const filteredUnread = useMemo(
-    () => unread.filter(filterEssay),
-    [unread, filterEssay],
-  );
-
-  const filteredRead = useMemo(
-    () => read.filter(filterEssay),
-    [read, filterEssay],
-  );
 
   return (
     <div className="space-y-4">
@@ -203,7 +322,10 @@ export function CoachReviewList({
         )}
 
         <div className="w-[140px] sm:w-[160px]">
-          <Select value={rocketFilter} onValueChange={setRocketFilter}>
+          <Select
+            value={rocketFilter}
+            onValueChange={(v) => setRocketFilter(v as CoachReviewRocketFilter)}
+          >
             <SelectTrigger size="sm" className="w-full">
               <SelectValue placeholder="Rocket model" />
             </SelectTrigger>
@@ -216,7 +338,10 @@ export function CoachReviewList({
         </div>
 
         <div className="w-[130px] sm:w-[150px]">
-          <Select value={pointsFilter} onValueChange={setPointsFilter}>
+          <Select
+            value={pointsFilter}
+            onValueChange={(v) => setPointsFilter(v as CoachReviewPointsFilter)}
+          >
             <SelectTrigger size="sm" className="w-full">
               <SelectValue placeholder="Knižní body" />
             </SelectTrigger>
@@ -231,7 +356,10 @@ export function CoachReviewList({
         </div>
 
         <div className="w-[160px] sm:w-[185px]">
-          <Select value={replyFilter} onValueChange={setReplyFilter}>
+          <Select
+            value={replyFilter}
+            onValueChange={(v) => setReplyFilter(v as CoachReviewReplyFilter)}
+          >
             <SelectTrigger size="sm" className="w-full">
               <SelectValue placeholder="Reakce Téčka" />
             </SelectTrigger>
@@ -263,17 +391,21 @@ export function CoachReviewList({
           <TabsTrigger value="unread">
             <Inbox />
             Nepřečtené
-            <TabsTriggerCount count={filteredUnread.length} tone="attention" />
+            <TabsTriggerCount count={unreadCount} tone="attention" />
           </TabsTrigger>
           <TabsTrigger value="read">
             <CheckCheck />
             Přečtené
-            <TabsTriggerCount count={filteredRead.length} />
+            <TabsTriggerCount count={readCount} />
           </TabsTrigger>
         </TabsList>
 
         <TabsContent value="unread" className="mt-4">
-          {filteredUnread.length === 0 ? (
+          {loading ? (
+            <div className="flex justify-center py-12">
+              <Spinner className="size-6 text-muted-foreground" />
+            </div>
+          ) : essays.length === 0 ? (
             <EmptyState
               label={
                 hasActiveFilters
@@ -284,7 +416,7 @@ export function CoachReviewList({
             />
           ) : (
             <div className="space-y-3">
-              {filteredUnread.map((essay) => (
+              {essays.map((essay) => (
                 <ReviewRow
                   key={essay.id}
                   essay={essay}
@@ -294,12 +426,19 @@ export function CoachReviewList({
                   onToggled={() => markRead(essay)}
                 />
               ))}
+              <div ref={sentinelRef} className="flex justify-center py-4">
+                {loadingMore && <Spinner className="size-5" />}
+              </div>
             </div>
           )}
         </TabsContent>
 
         <TabsContent value="read" className="mt-4">
-          {filteredRead.length === 0 ? (
+          {loading ? (
+            <div className="flex justify-center py-12">
+              <Spinner className="size-6 text-muted-foreground" />
+            </div>
+          ) : essays.length === 0 ? (
             <EmptyState
               label={
                 hasActiveFilters
@@ -310,7 +449,7 @@ export function CoachReviewList({
             />
           ) : (
             <div className="space-y-3">
-              {filteredRead.map((essay) => (
+              {essays.map((essay) => (
                 <ReviewRow
                   key={essay.id}
                   essay={essay}
@@ -320,6 +459,9 @@ export function CoachReviewList({
                   onToggled={() => markUnread(essay)}
                 />
               ))}
+              <div ref={sentinelRef} className="flex justify-center py-4">
+                {loadingMore && <Spinner className="size-5" />}
+              </div>
             </div>
           )}
         </TabsContent>

--- a/src/lib/essays/queries.ts
+++ b/src/lib/essays/queries.ts
@@ -13,6 +13,8 @@ import type {
   EssayViewWithProfile,
   EssayCoachReadWithProfile,
   CoachReviewEssay,
+  CoachReviewFilters,
+  CoachReviewResult,
   EssayFilters,
   EssayRevisionSummary,
 } from './types';
@@ -443,42 +445,306 @@ export async function getEssayCoachViewers(
   );
 }
 
+export async function getCoachReviewEssays(
+  supabase: SupabaseClient<Database>,
+  coachProfileId: string,
+  filters: CoachReviewFilters = {},
+): Promise<CoachReviewResult> {
+  const studentIds = await getReviewStudentIds(supabase, coachProfileId, filters.teamId);
+  if (studentIds.length === 0) {
+    return {
+      essays: [],
+      totalCount: 0,
+      unreadCount: 0,
+      readCount: 0,
+      hasMore: false,
+      authorPointsMap: {},
+      commentsMap: {},
+      coachReadsMap: {},
+    };
+  }
+
+  const { data: reads, error: readsError } = await supabase
+    .from('essay_coach_reads')
+    .select('essay_id, read_at')
+    .eq('coach_profile_id', coachProfileId);
+  if (readsError) throw readsError;
+  const readRows = (reads ?? []) as { essay_id: string; read_at: string }[];
+  const readMap = new Map(readRows.map((r) => [r.essay_id, r.read_at]));
+  const readIds = Array.from(readMap.keys());
+
+  let rocketBookIds: string[] | null = null;
+  if (filters.rocket === 'rocket' || filters.rocket === 'non-rocket') {
+    const { data: rocketBooks, error: rocketError } = await supabase
+      .from('books')
+      .select('id')
+      .eq('is_rocket_model', true);
+    if (rocketError) throw rocketError;
+    rocketBookIds = (rocketBooks ?? []).map((b) => b.id);
+    if (filters.rocket === 'rocket' && rocketBookIds.length === 0) {
+      return {
+        essays: [],
+        totalCount: 0,
+        unreadCount: 0,
+        readCount: 0,
+        hasMore: false,
+        authorPointsMap: {},
+        commentsMap: {},
+        coachReadsMap: {},
+      };
+    }
+  }
+
+  let pointsBookIds: string[] | null = null;
+  let nonZeroBookIds: string[] | null = null;
+  if (filters.points && filters.points !== 'all') {
+    if (filters.points === '0') {
+      const { data: nonZeroBooks, error: ptsError } = await supabase
+        .from('books')
+        .select('id')
+        .gt('book_points', 0)
+        .in('list_status', ['shortlist', 'longlist']);
+      if (ptsError) throw ptsError;
+      nonZeroBookIds = (nonZeroBooks ?? []).map((b) => b.id);
+    } else {
+      const ptsNum = Number(filters.points);
+      const { data: ptsBooks, error: ptsError } = await supabase
+        .from('books')
+        .select('id')
+        .eq('book_points', ptsNum)
+        .in('list_status', ['shortlist', 'longlist']);
+      if (ptsError) throw ptsError;
+      pointsBookIds = (ptsBooks ?? []).map((b) => b.id);
+      if (pointsBookIds.length === 0) {
+        return {
+          essays: [],
+          totalCount: 0,
+          unreadCount: 0,
+          readCount: 0,
+          hasMore: false,
+          authorPointsMap: {},
+          commentsMap: {},
+          coachReadsMap: {},
+        };
+      }
+    }
+  }
+
+  let replyIncludeEssayIds: string[] | null = null;
+  let replyExcludeEssayIds: string[] | null = null;
+
+  if (filters.reply && filters.reply !== 'all') {
+    const { data: comments, error: commError } = await supabase
+      .from('essay_comments')
+      .select(`
+        id, essay_id, author_profile_id, parent_id, created_at,
+        author:profiles!author_profile_id(id, role)
+      `)
+      .is('removed_at', null);
+
+    if (commError) throw commError;
+
+    const commentsByEssay = new Map<string, EssayCommentWithAuthor[]>();
+    for (const c of (comments ?? []) as EssayCommentWithAuthor[]) {
+      const list = commentsByEssay.get(c.essay_id) ?? [];
+      list.push(c);
+      commentsByEssay.set(c.essay_id, list);
+    }
+
+    if (filters.reply === 'no-coach-comment') {
+      const coachCommentedEssayIds: string[] = [];
+      for (const [essayId, comms] of commentsByEssay.entries()) {
+        if (comms.some((c) => c.author?.role === 'coach' || c.author?.role === 'admin')) {
+          coachCommentedEssayIds.push(essayId);
+        }
+      }
+      replyExcludeEssayIds = coachCommentedEssayIds;
+    } else {
+      const matchingIds: string[] = [];
+      const { data: candidateEssays, error: candError } = await supabase
+        .from('essays')
+        .select('id, author_profile_id, updated_at')
+        .in('author_profile_id', studentIds)
+        .not('published_at', 'is', null)
+        .is('removed_at', null);
+
+      if (candError) throw candError;
+
+      for (const essay of candidateEssays ?? []) {
+        const comms = commentsByEssay.get(essay.id) ?? [];
+        const coachComments = comms.filter(
+          (c) => c.author?.role === 'coach' || c.author?.role === 'admin',
+        );
+        if (coachComments.length === 0) continue;
+
+        const latestCoachCommentTime = Math.max(
+          ...coachComments.map((c) => new Date(c.created_at).getTime()),
+        );
+        const authorComments = comms.filter(
+          (c) => c.author_profile_id === essay.author_profile_id,
+        );
+        const authorRepliesAfterCoach = authorComments.filter(
+          (c) => new Date(c.created_at).getTime() > latestCoachCommentTime,
+        );
+        const hasAuthorReply = authorRepliesAfterCoach.length > 0;
+
+        if (filters.reply === 'with-reply' && hasAuthorReply) {
+          matchingIds.push(essay.id);
+        } else if (filters.reply === 'without-reply' && !hasAuthorReply) {
+          matchingIds.push(essay.id);
+        } else if (filters.reply === 'edited-after-comment') {
+          const hasEditedAfterCoach =
+            new Date(essay.updated_at).getTime() > latestCoachCommentTime + 60_000;
+          if (hasEditedAfterCoach) {
+            matchingIds.push(essay.id);
+          }
+        }
+      }
+
+      replyIncludeEssayIds = matchingIds;
+      if (matchingIds.length === 0) {
+        return {
+          essays: [],
+          totalCount: 0,
+          unreadCount: 0,
+          readCount: 0,
+          hasMore: false,
+          authorPointsMap: {},
+          commentsMap: {},
+          coachReadsMap: {},
+        };
+      }
+    }
+  }
+
+  function buildQuery(
+    targetTab: 'unread' | 'read',
+    selectStr: string,
+    options?: { countExact?: boolean; headOnly?: boolean },
+  ) {
+    let q = supabase
+      .from('essays')
+      .select(
+        selectStr,
+        options?.countExact ? { count: 'exact', head: options?.headOnly } : undefined,
+      )
+      .not('published_at', 'is', null)
+      .is('removed_at', null)
+      .in('author_profile_id', studentIds);
+
+    if (targetTab === 'unread') {
+      if (readIds.length > 0) {
+        q = q.not('id', 'in', `(${readIds.join(',')})`);
+      }
+      q = q.order('created_at', { ascending: false });
+    } else {
+      if (readIds.length === 0) return null;
+      q = q.in('id', readIds);
+      q = q.order('created_at', { ascending: false });
+    }
+
+    if (filters.rocket === 'rocket' && rocketBookIds) {
+      q = q.in('book_id', rocketBookIds);
+    } else if (filters.rocket === 'non-rocket' && rocketBookIds && rocketBookIds.length > 0) {
+      q = q.or(`book_id.is.null,book_id.not.in.(${rocketBookIds.join(',')})`);
+    }
+
+    if (pointsBookIds) {
+      q = q.in('book_id', pointsBookIds);
+    } else if (nonZeroBookIds && nonZeroBookIds.length > 0) {
+      q = q.or(`book_id.is.null,book_id.not.in.(${nonZeroBookIds.join(',')})`);
+    }
+
+    if (replyIncludeEssayIds) {
+      q = q.in('id', replyIncludeEssayIds);
+    } else if (replyExcludeEssayIds && replyExcludeEssayIds.length > 0) {
+      q = q.not('id', 'in', `(${replyExcludeEssayIds.join(',')})`);
+    }
+
+    return q;
+  }
+
+  const activeTab = filters.tab ?? 'unread';
+  const otherTab = activeTab === 'unread' ? 'read' : 'unread';
+
+  const mainQuery = buildQuery(activeTab, ESSAY_DETAIL_SELECT, { countExact: true });
+  const otherCountQuery = buildQuery(otherTab, 'id', { countExact: true, headOnly: true });
+
+  const page = Math.max(1, filters.page ?? 1);
+  const pageSize = Math.max(1, filters.pageSize ?? 50);
+  const from = (page - 1) * pageSize;
+  const to = from + pageSize - 1;
+
+  if (!mainQuery) {
+    const otherRes = otherCountQuery ? await otherCountQuery : { count: 0 };
+    const otherCount = otherRes.count ?? 0;
+    return {
+      essays: [],
+      totalCount: 0,
+      unreadCount: activeTab === 'unread' ? 0 : otherCount,
+      readCount: activeTab === 'read' ? 0 : otherCount,
+      hasMore: false,
+      authorPointsMap: {},
+      commentsMap: {},
+      coachReadsMap: {},
+    };
+  }
+
+  const [mainRes, otherRes] = await Promise.all([
+    mainQuery.range(from, to),
+    otherCountQuery ? otherCountQuery : Promise.resolve({ count: 0 }),
+  ]);
+
+  if (mainRes.error) throw mainRes.error;
+
+  const rawEssays = (mainRes.data ?? []) as unknown as EssayRawRow[];
+  const totalCount = mainRes.count ?? 0;
+  const otherCount = otherRes.count ?? 0;
+
+  const unreadCount = activeTab === 'unread' ? totalCount : otherCount;
+  const readCount = activeTab === 'read' ? totalCount : otherCount;
+
+  const essays = mapEssayRows(rawEssays).map((essay) => ({
+    ...essay,
+    read_at: readMap.get(essay.id) ?? null,
+  }));
+
+  const authorIds = Array.from(new Set(essays.map((e) => e.author_profile_id)));
+  const essayIds = Array.from(new Set(essays.map((e) => e.id)));
+
+  const [authorPointsMap, commentsMap, coachReadsMap] = await Promise.all([
+    getAuthorsApprovedBookPoints(supabase, authorIds),
+    getCommentsForEssays(supabase, essayIds),
+    getCoachReadsForEssays(supabase, essayIds),
+  ]);
+
+  const hasMore = totalCount > to + 1;
+
+  return {
+    essays,
+    totalCount,
+    unreadCount,
+    readCount,
+    hasMore,
+    authorPointsMap,
+    commentsMap,
+    coachReadsMap,
+  };
+}
+
 export async function getUnreadTeamEssaysForCoach(
   supabase: SupabaseClient<Database>,
   coachProfileId: string,
   teamId?: string | null,
   limit: number = 100,
 ): Promise<CoachReviewEssay[]> {
-  const studentIds = await getReviewStudentIds(supabase, coachProfileId, teamId);
-  if (studentIds.length === 0) return [];
-
-  const { data: reads, error: readsError } = await supabase
-    .from('essay_coach_reads')
-    .select('essay_id')
-    .eq('coach_profile_id', coachProfileId);
-  if (readsError) throw readsError;
-  const readIds = (reads ?? []).map((r: { essay_id: string }) => r.essay_id);
-
-  let query = supabase
-    .from('essays')
-    .select(ESSAY_DETAIL_SELECT)
-    .not('published_at', 'is', null)
-    .is('removed_at', null)
-    .in('author_profile_id', studentIds)
-    .order('created_at', { ascending: false })
-    .limit(limit);
-
-  if (readIds.length > 0) {
-    query = query.not('id', 'in', `(${readIds.join(',')})`);
-  }
-
-  const { data, error } = await query;
-  if (error) throw error;
-
-  return mapEssayRows((data ?? []) as unknown as EssayRawRow[]).map((essay) => ({
-    ...essay,
-    read_at: null,
-  }));
+  const result = await getCoachReviewEssays(supabase, coachProfileId, {
+    tab: 'unread',
+    teamId,
+    pageSize: limit,
+    page: 1,
+  });
+  return result.essays;
 }
 
 export async function getReadTeamEssaysForCoach(
@@ -487,33 +753,13 @@ export async function getReadTeamEssaysForCoach(
   teamId?: string | null,
   limit: number = 100,
 ): Promise<CoachReviewEssay[]> {
-  const studentIds = await getReviewStudentIds(supabase, coachProfileId, teamId);
-  if (studentIds.length === 0) return [];
-
-  const { data: reads, error: readsError } = await supabase
-    .from('essay_coach_reads')
-    .select('essay_id, read_at')
-    .eq('coach_profile_id', coachProfileId)
-    .order('read_at', { ascending: false })
-    .limit(limit);
-  if (readsError) throw readsError;
-
-  const readRows = (reads ?? []) as { essay_id: string; read_at: string }[];
-  if (readRows.length === 0) return [];
-
-  const readAtById = new Map(readRows.map((r) => [r.essay_id, r.read_at]));
-
-  const { data, error } = await supabase
-    .from('essays')
-    .select(ESSAY_DETAIL_SELECT)
-    .in('id', readRows.map((r) => r.essay_id))
-    .in('author_profile_id', studentIds)
-    .is('removed_at', null);
-  if (error) throw error;
-
-  return mapEssayRows((data ?? []) as unknown as EssayRawRow[])
-    .map((essay) => ({ ...essay, read_at: readAtById.get(essay.id) ?? null }))
-    .sort((a, b) => (b.read_at ?? '').localeCompare(a.read_at ?? ''));
+  const result = await getCoachReviewEssays(supabase, coachProfileId, {
+    tab: 'read',
+    teamId,
+    pageSize: limit,
+    page: 1,
+  });
+  return result.essays;
 }
 
 export async function getCoachUnreadCount(
@@ -543,6 +789,33 @@ export async function getCoachUnreadCount(
   }
 
   const { count, error } = await query;
+  if (error) throw error;
+  return count ?? 0;
+}
+
+export async function getCoachReadCount(
+  supabase: SupabaseClient<Database>,
+  coachProfileId: string,
+  teamId?: string | null,
+): Promise<number> {
+  const studentIds = await getReviewStudentIds(supabase, coachProfileId, teamId);
+  if (studentIds.length === 0) return 0;
+
+  const { data: reads, error: readsError } = await supabase
+    .from('essay_coach_reads')
+    .select('essay_id')
+    .eq('coach_profile_id', coachProfileId);
+  if (readsError) throw readsError;
+  const readIds = (reads ?? []).map((r: { essay_id: string }) => r.essay_id);
+  if (readIds.length === 0) return 0;
+
+  const { count, error } = await supabase
+    .from('essays')
+    .select('id', { count: 'exact', head: true })
+    .in('id', readIds)
+    .in('author_profile_id', studentIds)
+    .is('removed_at', null);
+
   if (error) throw error;
   return count ?? 0;
 }

--- a/src/lib/essays/types.ts
+++ b/src/lib/essays/types.ts
@@ -72,6 +72,37 @@ export interface CoachReviewEssay extends EssayWithDetails {
   read_at: string | null;
 }
 
+export type CoachReviewTab = 'unread' | 'read';
+export type CoachReviewRocketFilter = 'all' | 'rocket' | 'non-rocket';
+export type CoachReviewPointsFilter = 'all' | '1' | '2' | '3' | '0';
+export type CoachReviewReplyFilter =
+  | 'all'
+  | 'with-reply'
+  | 'without-reply'
+  | 'edited-after-comment'
+  | 'no-coach-comment';
+
+export interface CoachReviewFilters {
+  tab?: CoachReviewTab;
+  teamId?: string | null;
+  rocket?: CoachReviewRocketFilter;
+  points?: CoachReviewPointsFilter;
+  reply?: CoachReviewReplyFilter;
+  page?: number;
+  pageSize?: number;
+}
+
+export interface CoachReviewResult {
+  essays: CoachReviewEssay[];
+  totalCount: number;
+  unreadCount: number;
+  readCount: number;
+  hasMore: boolean;
+  authorPointsMap: Record<string, number>;
+  commentsMap: Record<string, EssayCommentWithAuthor[]>;
+  coachReadsMap: Record<string, EssayCoachReadWithProfile[]>;
+}
+
 export interface EssayRevisionSummary {
   revision_no: number;
   title: string;


### PR DESCRIPTION
## Summary
- Implemented `getCoachReviewEssays` in `src/lib/essays/queries.ts` with server-side pagination, filters, and accurate total counts.
- Created API endpoint `/api/essays/coach-review` for infinite scrolling and dynamic filter querying.
- Updated `src/app/(main)/cteni/eseje/ke-kontrole/page.tsx` to SSR the initial batch and exact unread/read counts.
- Updated `CoachReviewList` to support infinite scroll, server-side filter changes, and true count badges.
- Added tests in `src/components/essays/coach-review-list.test.tsx`.