### PR TITLE
fix: frozen book points survive archival and missing book links

### DIFF
--- a/src/app/(main)/cteni/eseje/[essayId]/page.tsx
+++ b/src/app/(main)/cteni/eseje/[essayId]/page.tsx
@@ -27,6 +27,7 @@ import { BookStatusBadges } from '@/components/books/book-status-badges';
 import { ContentSourceIllustration } from '@/components/content-sources/content-source-illustration';
 import { CONTENT_SOURCE_KIND_LABELS } from '@/lib/content-sources/types';
 import { getEssaySourceDisplay } from '@/lib/essays/source-display';
+import { LegacyPointsBadge } from '@/components/essays/legacy-points-badge';
 
 interface PageProps {
   params: Promise<{ essayId: string }>;
@@ -165,13 +166,12 @@ export default async function EssayDetailPage({ params }: PageProps) {
               <p className="text-xs text-muted-foreground truncate">{essay.book.author}</p>
             </div>
             {!source.isArchived && source.points > 0 && (
-              <Badge
-                variant="secondary"
-                className="shrink-0"
-                title={source.isFrozen ? 'Body za tuto esej jsou zamčené ze staršího systému.' : undefined}
-              >
-                {formatPoints(source.points)} b.
-              </Badge>
+              <div className="flex shrink-0 items-center gap-1.5">
+                {source.isFrozen && <LegacyPointsBadge />}
+                <Badge variant="secondary" className="shrink-0">
+                  {formatPoints(source.points)} b.
+                </Badge>
+              </div>
             )}
           </div>
         </Link>

--- a/src/app/(main)/komunita/profil/[id]/page.tsx
+++ b/src/app/(main)/komunita/profil/[id]/page.tsx
@@ -27,6 +27,7 @@ import { Tabs, TabsContent, TabsList, TabsTrigger, TabsTriggerCount } from '@/co
 import { ROLE_LABELS, ROLE_COLORS } from '@/lib/komunita/types';
 import { formatPointsWithLabel } from '@/lib/books/points';
 import { getEssaySourceDisplay } from '@/lib/essays/source-display';
+import { LegacyPointsBadge } from '@/components/essays/legacy-points-badge';
 import { cn } from '@/lib/utils';
 
 interface PageProps {
@@ -240,7 +241,14 @@ export default async function ProfilePage({ params, searchParams }: PageProps) {
                           <p className="flex items-center gap-1.5 text-xs text-muted-foreground truncate">
                             {source.title}
                             {essay.book && <BookStatusBadges book={essay.book} />}
-                            {source.points > 0 && <span className="ml-1 font-medium text-foreground">· {formatPointsWithLabel(source.points)}</span>}
+                            {source.points > 0 && (
+                              <>
+                                {source.isFrozen && <LegacyPointsBadge />}
+                                <span className="ml-1 font-medium text-foreground">
+                                  · {formatPointsWithLabel(source.points)}
+                                </span>
+                              </>
+                            )}
                           </p>
                           {excerpt && excerpt.length > 20 && (
                             <p className="text-xs text-muted-foreground/60 line-clamp-2 leading-relaxed">{excerpt}…</p>

--- a/src/components/essays/coach-review-list.tsx
+++ b/src/components/essays/coach-review-list.tsx
@@ -34,6 +34,7 @@ import { usePersistedState } from '@/lib/hooks/use-persisted-state';
 
 import { formatPoints, pointsLabel } from '@/lib/books/points';
 import { getEssaySourceDisplay } from '@/lib/essays/source-display';
+import { LegacyPointsBadge } from '@/components/essays/legacy-points-badge';
 import type {
   CoachReviewEssay,
   CoachReviewPointsFilter,
@@ -693,9 +694,12 @@ function ReviewRow({
                       {source.title}
                     </span>
                     {source.points > 0 && (
-                      <span className="rounded-full bg-primary/10 px-1.5 py-0.5 text-xs font-semibold tabular-nums text-primary">
-                        {formatPoints(source.points)} {pointsLabel(source.points)}
-                      </span>
+                      <>
+                        {source.isFrozen && <LegacyPointsBadge />}
+                        <span className="rounded-full bg-primary/10 px-1.5 py-0.5 text-xs font-semibold tabular-nums text-primary">
+                          {formatPoints(source.points)} {pointsLabel(source.points)}
+                        </span>
+                      </>
                     )}
                     {essay.book && <BookStatusBadges book={essay.book} />}
                   </>

--- a/src/components/essays/essay-card.tsx
+++ b/src/components/essays/essay-card.tsx
@@ -8,6 +8,7 @@ import { BookStatusBadges } from '@/components/books/book-status-badges';
 import { ContentSourceIllustration, CONTENT_SOURCE_KIND_ICONS } from '@/components/content-sources/content-source-illustration';
 import { formatPoints } from '@/lib/books/points';
 import { getEssaySourceDisplay } from '@/lib/essays/source-display';
+import { LegacyPointsBadge } from '@/components/essays/legacy-points-badge';
 import type { EssayWithDetails } from '@/lib/essays/types';
 
 interface EssayCardProps {
@@ -76,7 +77,12 @@ export function EssayCard({ essay, showVoteButton = false, initialVoted = false 
                 <span className="truncate">{source.title}</span>
                 {essay.book && <BookStatusBadges book={essay.book} />}
                 {!source.isArchived && source.points > 0 && (
-                  <span className="shrink-0 ml-auto font-medium text-foreground">{formatPoints(source.points)} b.</span>
+                  <div className="flex shrink-0 ml-auto items-center gap-1.5">
+                    {source.isFrozen && <LegacyPointsBadge />}
+                    <span className="shrink-0 font-medium text-foreground">
+                      {formatPoints(source.points)} b.
+                    </span>
+                  </div>
                 )}
                 {source.isArchived && (
                   <span className="shrink-0 ml-auto text-destructive">0 b.</span>

--- a/src/components/essays/essay-editor-form.tsx
+++ b/src/components/essays/essay-editor-form.tsx
@@ -31,6 +31,7 @@ import { ContentSourceIllustration } from '@/components/content-sources/content-
 import { useEssaySave, type EssaySaveStatus } from '@/lib/essays/use-essay-save';
 import { useUnsavedChangesGuard } from '@/lib/essays/use-unsaved-changes-guard';
 import { formatPoints, resolveEssayPoints } from '@/lib/books/points';
+import { LegacyPointsBadge } from '@/components/essays/legacy-points-badge';
 import { countWords, formatReadingTime, formatWordCount } from '@/lib/essays/text-stats';
 import { CONTENT_SOURCE_KIND_LABELS } from '@/lib/content-sources/types';
 import { cn } from '@/lib/utils';
@@ -302,12 +303,12 @@ export function EssayEditorForm({ initialEssay }: EssayEditorFormProps) {
   // swaps in a different book while editing, that value no longer applies to
   // the newly selected book, so only use it while selectedBook is still the
   // essay's original one.
+  const selectedBookIsOriginal = selectedBook?.id === initialEssay?.book?.id;
+  const selectedBookFrozenPoints = selectedBookIsOriginal ? initialEssay?.frozen_book_points : null;
   const selectedBookPoints = selectedBook
-    ? resolveEssayPoints({
-        frozenBookPoints: selectedBook.id === initialEssay?.book?.id ? initialEssay?.frozen_book_points : null,
-        book: selectedBook,
-      })
+    ? resolveEssayPoints({ frozenBookPoints: selectedBookFrozenPoints, book: selectedBook })
     : 0;
+  const selectedBookPointsFrozen = selectedBookFrozenPoints != null;
 
   return (
     <div className="space-y-4">
@@ -425,11 +426,14 @@ export function EssayEditorForm({ initialEssay }: EssayEditorFormProps) {
             </div>
 
             <div className="flex items-center gap-2 sm:gap-3 shrink-0">
-              {selectedBook.list_status !== 'archived' && (
-                <span className="inline-flex items-center rounded-full bg-primary/10 px-2.5 py-0.5 text-xs font-semibold text-primary">
-                  <span className="font-heading tabular-nums">{formatPoints(selectedBookPoints)}</span>
-                  <span className="ml-1 text-[11px] font-normal text-primary/80">b.</span>
-                </span>
+              {(selectedBook.list_status !== 'archived' || selectedBookPointsFrozen) && (
+                <>
+                  {selectedBookPointsFrozen && <LegacyPointsBadge />}
+                  <span className="inline-flex items-center rounded-full bg-primary/10 px-2.5 py-0.5 text-xs font-semibold text-primary">
+                    <span className="font-heading tabular-nums">{formatPoints(selectedBookPoints)}</span>
+                    <span className="ml-1 text-[11px] font-normal text-primary/80">b.</span>
+                  </span>
+                </>
               )}
 
               <Button

--- a/src/components/essays/legacy-points-badge.tsx
+++ b/src/components/essays/legacy-points-badge.tsx
@@ -1,0 +1,25 @@
+'use client';
+
+import { Lock } from 'lucide-react';
+
+import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip';
+
+/**
+ * Always-visible marker for essays whose points are frozen to the old
+ * system's scoring (pre-2026-09-03) — a bare `title` attribute needs a hover
+ * to discover at all, so this renders as its own small badge instead, with
+ * the fuller explanation still available on hover/focus.
+ */
+export function LegacyPointsBadge() {
+  return (
+    <Tooltip>
+      <TooltipTrigger asChild>
+        <span className="inline-flex items-center gap-1 rounded-full bg-warning/15 text-warning-strong px-1.5 py-0.5 text-[10px] font-medium leading-none">
+          <Lock className="size-2.5 shrink-0" />
+          staré bodování
+        </span>
+      </TooltipTrigger>
+      <TooltipContent>Body za tuto esej jsou zamčené ze staršího systému.</TooltipContent>
+    </Tooltip>
+  );
+}

--- a/src/components/essays/my-essay-list.tsx
+++ b/src/components/essays/my-essay-list.tsx
@@ -10,6 +10,7 @@ import { EssayVoteButton } from './essay-vote-button';
 
 import { formatPoints } from '@/lib/books/points';
 import { getEssaySourceDisplay } from '@/lib/essays/source-display';
+import { LegacyPointsBadge } from '@/components/essays/legacy-points-badge';
 import { isEssayPinned, type EssayWithDetails } from '@/lib/essays/types';
 
 interface MyEssayListProps {
@@ -96,9 +97,12 @@ export function MyEssayList({ essays, votedEssayIds = new Set() }: MyEssayListPr
                   </h3>
                 </div>
                 {hasPoints && (
-                  <span className="shrink-0 text-xs font-semibold tabular-nums bg-primary/10 text-primary px-1.5 py-0.5 rounded-full">
-                    {formatPoints(points)} b.
-                  </span>
+                  <div className="flex shrink-0 items-center gap-1.5">
+                    {source.isFrozen && <LegacyPointsBadge />}
+                    <span className="shrink-0 text-xs font-semibold tabular-nums bg-primary/10 text-primary px-1.5 py-0.5 rounded-full">
+                      {formatPoints(points)} b.
+                    </span>
+                  </div>
                 )}
                 {isRejected && (
                   <span className="shrink-0 text-xs font-semibold tabular-nums bg-destructive/10 text-destructive px-1.5 py-0.5 rounded-full">
@@ -113,7 +117,7 @@ export function MyEssayList({ essays, votedEssayIds = new Set() }: MyEssayListPr
                     {essay.book.title_cs}
                     <BookStatusBadges book={essay.book} />
                   </>
-                ) : source.kind === 'content_source' ? (
+                ) : source.kind === 'content_source' || source.kind === 'legacy' ? (
                   source.title
                 ) : (
                   <span className="flex items-center gap-1 text-amber-600 dark:text-amber-400">

--- a/src/components/essays/social-essay-feed-card.tsx
+++ b/src/components/essays/social-essay-feed-card.tsx
@@ -12,6 +12,7 @@ import { Button } from '@/components/ui/button';
 import { formatPoints } from '@/lib/books/points';
 import { CONTENT_SOURCE_KIND_LABELS } from '@/lib/content-sources/types';
 import { getEssaySourceDisplay } from '@/lib/essays/source-display';
+import { LegacyPointsBadge } from '@/components/essays/legacy-points-badge';
 import { countWords, formatReadingTime } from '@/lib/essays/text-stats';
 import { formatRelativeTime, isRecentEssay } from '@/lib/essays/date-helpers';
 import { cn } from '@/lib/utils';
@@ -179,13 +180,12 @@ export function SocialEssayFeedCard({
           </div>
 
           {!source.isArchived && source.points > 0 && (
-            <Badge
-              variant="secondary"
-              className="shrink-0 text-xs font-semibold"
-              title={source.isFrozen ? 'Body za tuto esej jsou zamčené ze staršího systému.' : undefined}
-            >
-              {formatPoints(source.points)} b.
-            </Badge>
+            <div className="flex shrink-0 items-center gap-1.5">
+              {source.isFrozen && <LegacyPointsBadge />}
+              <Badge variant="secondary" className="shrink-0 text-xs font-semibold">
+                {formatPoints(source.points)} b.
+              </Badge>
+            </div>
           )}
         </Link>
       ) : essay.content_source ? (

--- a/src/lib/books/points.ts
+++ b/src/lib/books/points.ts
@@ -33,19 +33,24 @@ export interface ResolveEssayPointsInput {
 
 /**
  * The single place that resolves what an essay's book-points contribution
- * actually is: prefer the frozen (legacy) value over the live one, but an
- * archived book always contributes 0 regardless of any frozen value —
- * matching `books_archived_points_check`, which forces `book_points = 0` on
- * archived books. Content-source essays have no freeze concept (frozen
- * points only apply to book-linked essays), so they just read the source's
- * live points.
+ * actually is. A frozen (legacy, pre-2026-09-03) value is baked into the
+ * essay for good: once earned, it's immune to anything that happens to the
+ * book afterward — a rescore, a book_id reassignment, archival, or even the
+ * essay never getting a book linked at all (some legacy essays reference a
+ * book that was never imported into the catalog; the frozen value still
+ * counts). Only a *live* (unfrozen) essay is zeroed when its book is
+ * archived, matching `books_archived_points_check`, which forces
+ * `book_points = 0` on archived books. Content-source essays have no freeze
+ * concept (frozen points only apply to book-linked essays), so they just
+ * read the source's live points.
  */
 export function resolveEssayPoints({ frozenBookPoints, book, contentSource }: ResolveEssayPointsInput): number {
+  if (contentSource) return pointsNumber(contentSource.points);
+  if (frozenBookPoints != null) return pointsNumber(frozenBookPoints);
   if (book) {
     if (book.list_status === 'archived') return 0;
-    return pointsNumber(frozenBookPoints ?? book.book_points);
+    return pointsNumber(book.book_points);
   }
-  if (contentSource) return pointsNumber(contentSource.points);
   return 0;
 }
 

--- a/src/lib/essays/queries.test.ts
+++ b/src/lib/essays/queries.test.ts
@@ -138,6 +138,69 @@ describe("getUserBookPointsStats", () => {
 
     expect(result.approved_points).toBe(1);
   });
+
+  it("counts a frozen essay even when its book is now archived — earned credit is immune to later archival", async () => {
+    const client = fakeSupabase({
+      essays: [
+        {
+          data: [
+            {
+              book_id: "book-1",
+              frozen_book_points: "2.00",
+              published_at: "2026-08-01T00:00:00Z",
+              books: { book_points: "0.00", list_status: "archived" },
+            },
+          ],
+        },
+        { data: [] },
+        { count: 1 },
+      ],
+    });
+
+    const result = await getUserBookPointsStats(client, "profile-1");
+
+    expect(result.approved_points).toBe(2);
+  });
+
+  it("still zeroes a live (unfrozen) essay when its book is archived", async () => {
+    const client = fakeSupabase({
+      essays: [
+        {
+          data: [
+            {
+              book_id: "book-1",
+              frozen_book_points: null,
+              published_at: "2026-09-05T00:00:00Z",
+              books: { book_points: "3.00", list_status: "archived" },
+            },
+          ],
+        },
+        { data: [] },
+        { count: 1 },
+      ],
+    });
+
+    const result = await getUserBookPointsStats(client, "profile-1");
+
+    expect(result.approved_points).toBe(0);
+  });
+
+  it("counts a frozen essay with no book_id at all — the old-system book was never imported", async () => {
+    const client = fakeSupabase({
+      essays: [
+        { data: [] }, // book essays (none)
+        { data: [] }, // content-source essays (none)
+        {
+          data: [{ id: "essay-1", frozen_book_points: "2.00", published_at: "2026-08-01T00:00:00Z" }],
+        },
+        { count: 1 },
+      ],
+    });
+
+    const result = await getUserBookPointsStats(client, "profile-1");
+
+    expect(result.approved_points).toBe(2);
+  });
 });
 
 describe("getAuthorsApprovedBookPoints", () => {
@@ -192,6 +255,22 @@ describe("getAuthorsApprovedBookPoints", () => {
     const result = await getAuthorsApprovedBookPoints(client, ["author-1"]);
 
     expect(result["author-1"]).toBe(3);
+  });
+
+  it("counts a frozen essay with no book_id at all — the old-system book was never imported", async () => {
+    const client = fakeSupabase({
+      essays: [
+        { data: [] }, // book essays (none)
+        { data: [] }, // content-source essays (none)
+        {
+          data: [{ id: "essay-1", author_profile_id: "author-1", frozen_book_points: "2.00" }],
+        },
+      ],
+    });
+
+    const result = await getAuthorsApprovedBookPoints(client, ["author-1"]);
+
+    expect(result["author-1"]).toBe(2);
   });
 });
 
@@ -300,6 +379,25 @@ describe("getTeamBookPointsStats", () => {
 
     expect(result).toEqual([
       { profile: { id: "profile-1", name: "Test Student", picture: null }, approved_points: 0, pending_points: 1 },
+    ]);
+  });
+
+  it("counts a frozen essay with no book_id at all — the old-system book was never imported", async () => {
+    const client = fakeSupabase({
+      profiles: [{ data: [{ id: "profile-1", name: "Test Student", picture: null }] }],
+      essays: [
+        { data: [] }, // book essays (none)
+        { data: [] }, // content-source essays (none)
+        {
+          data: [{ id: "essay-1", author_profile_id: "profile-1", frozen_book_points: "2.00" }],
+        },
+      ],
+    });
+
+    const result = await getTeamBookPointsStats(client, "team-1");
+
+    expect(result).toEqual([
+      { profile: { id: "profile-1", name: "Test Student", picture: null }, approved_points: 2, pending_points: 0 },
     ]);
   });
 });

--- a/src/lib/essays/queries.ts
+++ b/src/lib/essays/queries.ts
@@ -1312,6 +1312,20 @@ export async function getUserBookPointsStats(
 
   if (sourceError) throw sourceError;
 
+  // Frozen essays whose old-system book was never linked/imported at all —
+  // no book_id to key on, but the earned credit still counts.
+  const { data: orphanFrozenEssays, error: orphanError } = await supabase
+    .from('essays')
+    .select('id, frozen_book_points, published_at')
+    .eq('author_profile_id', profileId)
+    .not('published_at', 'is', null)
+    .is('removed_at', null)
+    .is('book_id', null)
+    .is('content_source_id', null)
+    .not('frozen_book_points', 'is', null);
+
+  if (orphanError) throw orphanError;
+
   type BookRow = {
     book_id: string;
     frozen_book_points: string | null;
@@ -1319,6 +1333,7 @@ export async function getUserBookPointsStats(
     books: { book_points: number | string; list_status: string };
   };
   type SourceRow = { content_source_id: string; published_at: string; content_sources: { points: number; status: string } };
+  type OrphanRow = { id: string; frozen_book_points: string; published_at: string };
 
   const ELIGIBLE = new Set<string>(POINTS_ELIGIBLE_LIST_STATUSES);
   const approved = new Map<string, number>();
@@ -1330,7 +1345,9 @@ export async function getUserBookPointsStats(
   for (const row of (bookEssays ?? []) as unknown as BookRow[]) {
     if (!row.book_id) continue;
     const key = `book:${row.book_id}`;
-    if (ELIGIBLE.has(row.books.list_status)) {
+    // A frozen essay counts regardless of the book's current list_status —
+    // once earned, credit is baked in and immune to a later archival.
+    if (ELIGIBLE.has(row.books.list_status) || row.frozen_book_points != null) {
       const existingAt = approvedAt.get(key);
       if (!existingAt || row.published_at < existingAt) {
         approved.set(key, pointsNumber(row.frozen_book_points ?? row.books.book_points));
@@ -1340,6 +1357,13 @@ export async function getUserBookPointsStats(
     } else if (row.books.list_status === 'processing') {
       pending.add(key);
     }
+  }
+
+  for (const row of (orphanFrozenEssays ?? []) as unknown as OrphanRow[]) {
+    // No book_id to dedupe on — each essay is its own credit.
+    const key = `orphan:${row.id}`;
+    approved.set(key, pointsNumber(row.frozen_book_points));
+    if (new Date(row.published_at) >= semesterStart) semesterApproved.add(key);
   }
 
   for (const row of (sourceEssays ?? []) as unknown as SourceRow[]) {
@@ -1401,6 +1425,20 @@ export async function getAuthorsApprovedBookPoints(
 
   if (sourceError) throw sourceError;
 
+  // Frozen essays whose old-system book was never linked/imported at all —
+  // no book_id to key on, but the earned credit still counts.
+  const { data: orphanFrozenEssays, error: orphanError } = await supabase
+    .from('essays')
+    .select('id, author_profile_id, frozen_book_points')
+    .in('author_profile_id', authorProfileIds)
+    .not('published_at', 'is', null)
+    .is('removed_at', null)
+    .is('book_id', null)
+    .is('content_source_id', null)
+    .not('frozen_book_points', 'is', null);
+
+  if (orphanError) throw orphanError;
+
   type BookRow = {
     author_profile_id: string;
     book_id: string;
@@ -1409,6 +1447,7 @@ export async function getAuthorsApprovedBookPoints(
     books: { book_points: number | string; list_status: string };
   };
   type SourceRow = { author_profile_id: string; content_source_id: string; content_sources: { points: number; status: string } };
+  type OrphanRow = { id: string; author_profile_id: string; frozen_book_points: string };
 
   const ELIGIBLE = new Set<string>(POINTS_ELIGIBLE_LIST_STATUSES);
   const pointsByAuthor: Record<string, Map<string, number>> = {};
@@ -1419,7 +1458,9 @@ export async function getAuthorsApprovedBookPoints(
   }
 
   for (const row of (bookEssays ?? []) as unknown as BookRow[]) {
-    if (!row.book_id || !ELIGIBLE.has(row.books.list_status)) continue;
+    // A frozen essay counts regardless of the book's current list_status —
+    // once earned, credit is baked in and immune to a later archival.
+    if (!row.book_id || (!ELIGIBLE.has(row.books.list_status) && row.frozen_book_points == null)) continue;
     const key = `book:${row.book_id}`;
     const at = atByAuthor[row.author_profile_id];
     const points = pointsByAuthor[row.author_profile_id];
@@ -1429,6 +1470,11 @@ export async function getAuthorsApprovedBookPoints(
       points.set(key, pointsNumber(row.frozen_book_points ?? row.books.book_points));
       at.set(key, row.published_at);
     }
+  }
+
+  for (const row of (orphanFrozenEssays ?? []) as unknown as OrphanRow[]) {
+    // No book_id to dedupe on — each essay is its own credit.
+    pointsByAuthor[row.author_profile_id]?.set(`orphan:${row.id}`, pointsNumber(row.frozen_book_points));
   }
 
   for (const row of (sourceEssays ?? []) as unknown as SourceRow[]) {
@@ -1479,6 +1525,20 @@ export async function getTeamBookPointsStats(
 
   if (sourceError) throw sourceError;
 
+  // Frozen essays whose old-system book was never linked/imported at all —
+  // no book_id to key on, but the earned credit still counts.
+  const { data: orphanFrozenEssays, error: orphanError } = await supabase
+    .from('essays')
+    .select('id, author_profile_id, frozen_book_points')
+    .in('author_profile_id', profileIds)
+    .not('published_at', 'is', null)
+    .is('removed_at', null)
+    .is('book_id', null)
+    .is('content_source_id', null)
+    .not('frozen_book_points', 'is', null);
+
+  if (orphanError) throw orphanError;
+
   type BookRow = {
     author_profile_id: string;
     book_id: string;
@@ -1487,6 +1547,7 @@ export async function getTeamBookPointsStats(
     books: { book_points: number | string; list_status: string };
   };
   type SourceRow = { author_profile_id: string; content_source_id: string; content_sources: { points: number; status: string } };
+  type OrphanRow = { id: string; author_profile_id: string; frozen_book_points: string };
 
   const ELIGIBLE = new Set<string>(POINTS_ELIGIBLE_LIST_STATUSES);
   const byProfile: Record<string, { approved: Map<string, number>; approvedAt: Map<string, string>; pending: Set<string> }> = {};
@@ -1498,7 +1559,9 @@ export async function getTeamBookPointsStats(
     const bucket = byProfile[essay.author_profile_id];
     if (!bucket || !essay.book_id) continue;
     const key = `book:${essay.book_id}`;
-    if (ELIGIBLE.has(essay.books.list_status)) {
+    // A frozen essay counts regardless of the book's current list_status —
+    // once earned, credit is baked in and immune to a later archival.
+    if (ELIGIBLE.has(essay.books.list_status) || essay.frozen_book_points != null) {
       const existingAt = bucket.approvedAt.get(key);
       if (!existingAt || essay.published_at < existingAt) {
         bucket.approved.set(key, pointsNumber(essay.frozen_book_points ?? essay.books.book_points));
@@ -1507,6 +1570,13 @@ export async function getTeamBookPointsStats(
     } else if (essay.books.list_status === 'processing') {
       bucket.pending.add(key);
     }
+  }
+
+  for (const essay of (orphanFrozenEssays ?? []) as unknown as OrphanRow[]) {
+    const bucket = byProfile[essay.author_profile_id];
+    if (!bucket) continue;
+    // No book_id to dedupe on — each essay is its own credit.
+    bucket.approved.set(`orphan:${essay.id}`, pointsNumber(essay.frozen_book_points));
   }
 
   for (const essay of (sourceEssays ?? []) as unknown as SourceRow[]) {

--- a/src/lib/essays/source-display.test.ts
+++ b/src/lib/essays/source-display.test.ts
@@ -61,7 +61,7 @@ describe('getEssaySourceDisplay', () => {
     expect(display.isFrozen).toBe(true);
   });
 
-  it('forces points to 0 for an archived book even when frozen_book_points is set', () => {
+  it('keeps a frozen value even when the book is later archived — earned credit is immune to archival', () => {
     const display = getEssaySourceDisplay({
       book: {
         id: 'b1', title_cs: 'Sprint', author: 'Jake Knapp', book_points: 0,
@@ -71,10 +71,35 @@ describe('getEssaySourceDisplay', () => {
       content_source: null,
       frozen_book_points: '2.00',
     });
+    expect(display.points).toBe(2);
+    expect(display.isArchived).toBe(false);
+    expect(display.isFrozen).toBe(true);
+  });
+
+  it('still counts a frozen value when the essay has no book or content source at all', () => {
+    const display = getEssaySourceDisplay({
+      book: null,
+      content_source: null,
+      frozen_book_points: '2.00',
+    });
+    expect(display.kind).toBe('legacy');
+    expect(display.points).toBe(2);
+    expect(display.isFrozen).toBe(true);
+    expect(display.isArchived).toBe(false);
+  });
+
+  it('forces points to 0 for an archived book when there is no frozen value (live points only)', () => {
+    const display = getEssaySourceDisplay({
+      book: {
+        id: 'b1', title_cs: 'Sprint', author: 'Jake Knapp', book_points: 3,
+        list_status: 'archived', is_rocket_model: false, google_books_cover_url: null,
+        highlight_category: null,
+      },
+      content_source: null,
+      frozen_book_points: null,
+    });
     expect(display.points).toBe(0);
     expect(display.isArchived).toBe(true);
-    // Legacy value still exists, so the badge concept ("isFrozen") stays true
-    // even though the archived book overrides its numeric contribution.
-    expect(display.isFrozen).toBe(true);
+    expect(display.isFrozen).toBe(false);
   });
 });

--- a/src/lib/essays/source-display.ts
+++ b/src/lib/essays/source-display.ts
@@ -2,10 +2,12 @@ import { resolveEssayPoints } from '@/lib/books/points';
 import type { EssayWithDetails } from './types';
 
 export interface EssaySourceDisplay {
-  kind: 'book' | 'content_source' | 'none';
+  /** 'legacy': a frozen pre-cutover essay whose old-system book was never linked/imported — earns points but has no title/author to show. */
+  kind: 'book' | 'content_source' | 'legacy' | 'none';
   title: string | null;
   author: string | null;
   points: number;
+  /** True when `points` is zeroed by archival — never true for a frozen essay, since archival can't touch a frozen value. */
   isArchived: boolean;
   /** True when `points` came from `frozen_book_points` rather than the live value. */
   isFrozen: boolean;
@@ -28,7 +30,7 @@ export function getEssaySourceDisplay(
       title: essay.book.title_cs,
       author: essay.book.author,
       points: resolveEssayPoints({ frozenBookPoints: essay.frozen_book_points, book: essay.book }),
-      isArchived: essay.book.list_status === 'archived',
+      isArchived: essay.book.list_status === 'archived' && essay.frozen_book_points == null,
       isFrozen: essay.frozen_book_points != null,
       illustrationKind: null,
     };
@@ -43,6 +45,22 @@ export function getEssaySourceDisplay(
       isArchived: essay.content_source.status === 'archived',
       isFrozen: false,
       illustrationKind: essay.content_source.kind,
+    };
+  }
+
+  // No book or content source linked at all. A frozen essay can still land
+  // here — some legacy essays reference an old-system book that was never
+  // imported into the catalog — so its points still count, just with
+  // nothing real to show as a title/author.
+  if (essay.frozen_book_points != null) {
+    return {
+      kind: 'legacy',
+      title: 'Esej ze starého systému',
+      author: null,
+      points: resolveEssayPoints({ frozenBookPoints: essay.frozen_book_points }),
+      isArchived: false,
+      isFrozen: true,
+      illustrationKind: null,
     };
   }
 

--- a/supabase/migrations/20260902190609_curious_matthew_murdock.sql
+++ b/supabase/migrations/20260902190609_curious_matthew_murdock.sql
@@ -1,0 +1,78 @@
+-- get_teams_with_member_stats(): a frozen essay now counts regardless of its
+-- book's current list_status, matching the same fix already applied to the
+-- TS aggregation functions (getUserBookPointsStats/getAuthorsApprovedBookPoints/
+-- getTeamBookPointsStats in src/lib/essays/queries.ts) and resolveEssayPoints
+-- in src/lib/books/points.ts.
+--
+-- Previously the book-points branch only joined books with
+-- list_status in ('shortlist', 'longlist'), so a frozen (pre-2026-09-03)
+-- essay whose book was later archived silently dropped out of the sum —
+-- contradicting the whole point of freezing: once earned, that credit is
+-- baked into the essay and immune to anything that happens to the book
+-- afterward (a rescore, a book_id reassignment, or archival).
+CREATE OR REPLACE FUNCTION public.get_teams_with_member_stats()
+ RETURNS TABLE(team_id uuid, team_name text, profile_id uuid, profile_name text, profile_picture text, essay_count bigint, book_points numeric)
+ LANGUAGE sql
+ STABLE SECURITY DEFINER
+ SET search_path TO ''
+AS $function$
+  with member_essays as (
+    select author_profile_id, count(id) as essay_count
+    from public.essays
+    where published_at is not null
+      and removed_at is null
+    group by author_profile_id
+  ),
+  earliest_book_essay as (
+    select distinct on (e.author_profile_id, e.book_id)
+      e.author_profile_id, e.book_id, e.frozen_book_points
+    from public.essays e
+    where e.book_id is not null
+      and e.published_at is not null
+      and e.removed_at is null
+    order by e.author_profile_id, e.book_id, e.published_at asc
+  ),
+  member_points as (
+    select
+      pts.author_profile_id,
+      coalesce(sum(pts.points), 0) as book_points
+    from (
+      select sub.author_profile_id, coalesce(sub.frozen_book_points, b.book_points) as points
+      from earliest_book_essay sub
+      join public.books b
+        on b.id = sub.book_id
+       and (b.list_status in ('shortlist', 'longlist') or sub.frozen_book_points is not null)
+
+      union all
+
+      select sub.author_profile_id, cs.points
+      from (
+        select distinct e.author_profile_id, e.content_source_id
+        from public.essays e
+        where e.content_source_id is not null
+          and e.published_at is not null
+          and e.removed_at is null
+      ) sub
+      join public.content_sources cs
+        on cs.id = sub.content_source_id
+       and cs.status = 'approved'
+    ) pts
+    group by pts.author_profile_id
+  )
+  select
+    t.id as team_id,
+    t.name as team_name,
+    p.id as profile_id,
+    p.name as profile_name,
+    p.picture as profile_picture,
+    coalesce(me.essay_count, 0) as essay_count,
+    coalesce(mp.book_points, 0) as book_points
+  from public.teams t
+  join public.profiles p
+    on p.team_id = t.id
+   and p.access_removed_at is null
+  left join member_essays me on me.author_profile_id = p.id
+  left join member_points mp on mp.author_profile_id = p.id
+  where t.removed_at is null
+  order by t.name, coalesce(mp.book_points, 0) desc, p.name;
+$function$;

--- a/supabase/migrations/20260902200442_giant_bloodaxe.sql
+++ b/supabase/migrations/20260902200442_giant_bloodaxe.sql
@@ -1,0 +1,85 @@
+-- get_teams_with_member_stats(): a frozen essay now counts even when it has
+-- no book_id (and no content_source_id) at all — some legacy essays
+-- reference an old-system book that was never imported into the catalog,
+-- but the earned credit still counts. Matches the same fix already applied
+-- to resolveEssayPoints/getEssaySourceDisplay and the three TS aggregation
+-- functions in src/lib/essays/queries.ts.
+CREATE OR REPLACE FUNCTION public.get_teams_with_member_stats()
+ RETURNS TABLE(team_id uuid, team_name text, profile_id uuid, profile_name text, profile_picture text, essay_count bigint, book_points numeric)
+ LANGUAGE sql
+ STABLE SECURITY DEFINER
+ SET search_path TO ''
+AS $function$
+  with member_essays as (
+    select author_profile_id, count(id) as essay_count
+    from public.essays
+    where published_at is not null
+      and removed_at is null
+    group by author_profile_id
+  ),
+  earliest_book_essay as (
+    select distinct on (e.author_profile_id, e.book_id)
+      e.author_profile_id, e.book_id, e.frozen_book_points
+    from public.essays e
+    where e.book_id is not null
+      and e.published_at is not null
+      and e.removed_at is null
+    order by e.author_profile_id, e.book_id, e.published_at asc
+  ),
+  member_points as (
+    select
+      pts.author_profile_id,
+      coalesce(sum(pts.points), 0) as book_points
+    from (
+      select sub.author_profile_id, coalesce(sub.frozen_book_points, b.book_points) as points
+      from earliest_book_essay sub
+      join public.books b
+        on b.id = sub.book_id
+       and (b.list_status in ('shortlist', 'longlist') or sub.frozen_book_points is not null)
+
+      union all
+
+      select sub.author_profile_id, cs.points
+      from (
+        select distinct e.author_profile_id, e.content_source_id
+        from public.essays e
+        where e.content_source_id is not null
+          and e.published_at is not null
+          and e.removed_at is null
+      ) sub
+      join public.content_sources cs
+        on cs.id = sub.content_source_id
+       and cs.status = 'approved'
+
+      union all
+
+      -- Frozen essays with no book_id and no content_source_id at all — the
+      -- old-system book was never linked/imported. No book to dedupe on, so
+      -- every qualifying essay is its own credit.
+      select e.author_profile_id, e.frozen_book_points as points
+      from public.essays e
+      where e.book_id is null
+        and e.content_source_id is null
+        and e.frozen_book_points is not null
+        and e.published_at is not null
+        and e.removed_at is null
+    ) pts
+    group by pts.author_profile_id
+  )
+  select
+    t.id as team_id,
+    t.name as team_name,
+    p.id as profile_id,
+    p.name as profile_name,
+    p.picture as profile_picture,
+    coalesce(me.essay_count, 0) as essay_count,
+    coalesce(mp.book_points, 0) as book_points
+  from public.teams t
+  join public.profiles p
+    on p.team_id = t.id
+   and p.access_removed_at is null
+  left join member_essays me on me.author_profile_id = p.id
+  left join member_points mp on mp.author_profile_id = p.id
+  where t.removed_at is null
+  order by t.name, coalesce(mp.book_points, 0) desc, p.name;
+$function$;

--- a/supabase/migrations/meta/20260902190609_snapshot.json
+++ b/supabase/migrations/meta/20260902190609_snapshot.json
@@ -1,0 +1,7622 @@
+{
+  "id": "ce87fa55-fca5-4861-b9e2-c2abd60cfc42",
+  "prevId": "d4b7052d-359e-4b43-bd99-4be27feeb055",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.birth_giving_events": {
+      "name": "birth_giving_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "customer": {
+          "name": "customer",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "starts_at": {
+          "name": "starts_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "duration": {
+          "name": "duration",
+          "type": "birth_giving_duration",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "birth_giving_event_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'draft'"
+        },
+        "organizer_profile_ids": {
+          "name": "organizer_profile_ids",
+          "type": "uuid[]",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "assignment_state": {
+          "name": "assignment_state",
+          "type": "birth_giving_assignment_state",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'none'"
+        },
+        "assignment_storage_path": {
+          "name": "assignment_storage_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "assignment_file_name": {
+          "name": "assignment_file_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "assignment_mime_type": {
+          "name": "assignment_mime_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "assignment_file_size": {
+          "name": "assignment_file_size",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "assignment_uploaded_at": {
+          "name": "assignment_uploaded_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "assignment_uploaded_by_profile_id": {
+          "name": "assignment_uploaded_by_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "removed_at": {
+          "name": "removed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "removed_by_profile_id": {
+          "name": "removed_by_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_by_profile_id": {
+          "name": "created_by_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_by_profile_id": {
+          "name": "updated_by_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "birth_giving_events_identity_idx": {
+          "name": "birth_giving_events_identity_idx",
+          "columns": [
+            {
+              "expression": "lower(regexp_replace(trim(normalize(\"name\", NFKC)), '[[:space:]]+', ' ', 'g'))",
+              "isExpression": true,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "lower(regexp_replace(trim(normalize(\"customer\", NFKC)), '[[:space:]]+', ' ', 'g'))",
+              "isExpression": true,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "starts_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "timestamptz_ops"
+            }
+          ],
+          "isUnique": true,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "birth_giving_events_status_starts_at_idx": {
+          "name": "birth_giving_events_status_starts_at_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "starts_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "birth_giving_events_removed_by_profile_id_fkey": {
+          "name": "birth_giving_events_removed_by_profile_id_fkey",
+          "tableFrom": "birth_giving_events",
+          "columnsFrom": [
+            "removed_by_profile_id"
+          ],
+          "tableTo": "profiles",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "set null"
+        },
+        "birth_giving_events_assignment_uploaded_by_fkey": {
+          "name": "birth_giving_events_assignment_uploaded_by_fkey",
+          "tableFrom": "birth_giving_events",
+          "columnsFrom": [
+            "assignment_uploaded_by_profile_id"
+          ],
+          "tableTo": "profiles",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "restrict"
+        },
+        "birth_giving_events_created_by_profile_id_fkey": {
+          "name": "birth_giving_events_created_by_profile_id_fkey",
+          "tableFrom": "birth_giving_events",
+          "columnsFrom": [
+            "created_by_profile_id"
+          ],
+          "tableTo": "profiles",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "restrict"
+        },
+        "birth_giving_events_updated_by_profile_id_fkey": {
+          "name": "birth_giving_events_updated_by_profile_id_fkey",
+          "tableFrom": "birth_giving_events",
+          "columnsFrom": [
+            "updated_by_profile_id"
+          ],
+          "tableTo": "profiles",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "restrict"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {
+        "Community can view published BG events, organizers view drafts": {
+          "name": "Community can view published BG events, organizers view drafts",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": [
+            "authenticated"
+          ],
+          "using": "EXISTS (\n  SELECT 1\n  FROM profiles caller_profile\n  JOIN users caller_user ON caller_user.id = caller_profile.user_id\n  WHERE caller_profile.id = current_profile_id()\n    AND caller_profile.access_removed_at IS NULL\n    AND caller_profile.beta_access_granted_at IS NOT NULL\n    AND caller_user.verified_work_email IS NOT NULL\n) AND \"birth_giving_events\".\"removed_at\" IS NULL AND (\"birth_giving_events\".\"status\" = 'published' OR current_profile_id() = ANY(\"birth_giving_events\".\"organizer_profile_ids\"))"
+        }
+      },
+      "checkConstraints": {
+        "birth_giving_events_name_check": {
+          "name": "birth_giving_events_name_check",
+          "value": "length(trim(\"birth_giving_events\".\"name\")) > 0"
+        },
+        "birth_giving_events_customer_check": {
+          "name": "birth_giving_events_customer_check",
+          "value": "length(trim(\"birth_giving_events\".\"customer\")) > 0"
+        },
+        "birth_giving_events_organizers_check": {
+          "name": "birth_giving_events_organizers_check",
+          "value": "cardinality(\"birth_giving_events\".\"organizer_profile_ids\") > 0 AND cardinality(array_remove(\"birth_giving_events\".\"organizer_profile_ids\", NULL)) = cardinality(\"birth_giving_events\".\"organizer_profile_ids\")"
+        },
+        "birth_giving_events_assignment_check": {
+          "name": "birth_giving_events_assignment_check",
+          "value": "(\n    \"birth_giving_events\".\"assignment_state\" = 'present'\n    AND \"birth_giving_events\".\"assignment_storage_path\" IS NOT NULL\n    AND length(trim(\"birth_giving_events\".\"assignment_storage_path\")) > 0\n    AND \"birth_giving_events\".\"assignment_storage_path\" LIKE 'birth-giving/assignments/' || \"birth_giving_events\".\"id\"::text || '/%'\n    AND \"birth_giving_events\".\"assignment_file_name\" IS NOT NULL\n    AND length(trim(\"birth_giving_events\".\"assignment_file_name\")) > 0\n    AND \"birth_giving_events\".\"assignment_mime_type\" IS NOT NULL\n    AND length(trim(\"birth_giving_events\".\"assignment_mime_type\")) > 0\n    AND \"birth_giving_events\".\"assignment_file_size\" > 0\n    AND \"birth_giving_events\".\"assignment_uploaded_at\" IS NOT NULL\n    AND \"birth_giving_events\".\"assignment_uploaded_by_profile_id\" IS NOT NULL\n  ) OR (\n    \"birth_giving_events\".\"assignment_state\" IN ('none', 'missing')\n    AND \"birth_giving_events\".\"assignment_storage_path\" IS NULL\n    AND \"birth_giving_events\".\"assignment_file_name\" IS NULL\n    AND \"birth_giving_events\".\"assignment_mime_type\" IS NULL\n    AND \"birth_giving_events\".\"assignment_file_size\" IS NULL\n    AND \"birth_giving_events\".\"assignment_uploaded_at\" IS NULL\n    AND \"birth_giving_events\".\"assignment_uploaded_by_profile_id\" IS NULL\n  )"
+        },
+        "birth_giving_events_removed_check": {
+          "name": "birth_giving_events_removed_check",
+          "value": "(\"birth_giving_events\".\"removed_at\" IS NULL) = (\"birth_giving_events\".\"removed_by_profile_id\" IS NULL)"
+        }
+      },
+      "isRLSEnabled": true
+    },
+    "public.birth_giving_team_members": {
+      "name": "birth_giving_team_members",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "event_id": {
+          "name": "event_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "profile_id": {
+          "name": "profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "confirmed_at": {
+          "name": "confirmed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "reflection_contribution": {
+          "name": "reflection_contribution",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reflection_learning": {
+          "name": "reflection_learning",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reflection_submitted_at": {
+          "name": "reflection_submitted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_by_profile_id": {
+          "name": "created_by_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_by_profile_id": {
+          "name": "updated_by_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "birth_giving_team_members_team_idx": {
+          "name": "birth_giving_team_members_team_idx",
+          "columns": [
+            {
+              "expression": "event_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "team_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "birth_giving_team_members_profile_idx": {
+          "name": "birth_giving_team_members_profile_idx",
+          "columns": [
+            {
+              "expression": "profile_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "birth_giving_team_members_event_team_fkey": {
+          "name": "birth_giving_team_members_event_team_fkey",
+          "tableFrom": "birth_giving_team_members",
+          "columnsFrom": [
+            "event_id",
+            "team_id"
+          ],
+          "tableTo": "birth_giving_teams",
+          "columnsTo": [
+            "event_id",
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        },
+        "birth_giving_team_members_profile_id_fkey": {
+          "name": "birth_giving_team_members_profile_id_fkey",
+          "tableFrom": "birth_giving_team_members",
+          "columnsFrom": [
+            "profile_id"
+          ],
+          "tableTo": "profiles",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        },
+        "birth_giving_team_members_created_by_profile_id_fkey": {
+          "name": "birth_giving_team_members_created_by_profile_id_fkey",
+          "tableFrom": "birth_giving_team_members",
+          "columnsFrom": [
+            "created_by_profile_id"
+          ],
+          "tableTo": "profiles",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "restrict"
+        },
+        "birth_giving_team_members_updated_by_profile_id_fkey": {
+          "name": "birth_giving_team_members_updated_by_profile_id_fkey",
+          "tableFrom": "birth_giving_team_members",
+          "columnsFrom": [
+            "updated_by_profile_id"
+          ],
+          "tableTo": "profiles",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "restrict"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "birth_giving_team_members_event_profile_key": {
+          "name": "birth_giving_team_members_event_profile_key",
+          "columns": [
+            "event_id",
+            "profile_id"
+          ],
+          "nullsNotDistinct": false
+        },
+        "birth_giving_team_members_event_team_profile_key": {
+          "name": "birth_giving_team_members_event_team_profile_key",
+          "columns": [
+            "event_id",
+            "team_id",
+            "profile_id"
+          ],
+          "nullsNotDistinct": false
+        }
+      },
+      "policies": {
+        "Community can view BG memberships for accessible events": {
+          "name": "Community can view BG memberships for accessible events",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": [
+            "authenticated"
+          ],
+          "using": "EXISTS (\n  SELECT 1\n  FROM profiles caller_profile\n  JOIN users caller_user ON caller_user.id = caller_profile.user_id\n  WHERE caller_profile.id = current_profile_id()\n    AND caller_profile.access_removed_at IS NULL\n    AND caller_profile.beta_access_granted_at IS NOT NULL\n    AND caller_user.verified_work_email IS NOT NULL\n) AND EXISTS (\n      SELECT 1 FROM birth_giving_events event\n      WHERE event.id = \"birth_giving_team_members\".\"event_id\"\n        AND event.removed_at IS NULL\n        AND (event.status = 'published' OR current_profile_id() = ANY(event.organizer_profile_ids))\n    )"
+        }
+      },
+      "checkConstraints": {
+        "birth_giving_team_members_reflection_check": {
+          "name": "birth_giving_team_members_reflection_check",
+          "value": "(\n    \"birth_giving_team_members\".\"reflection_contribution\" IS NULL\n    AND \"birth_giving_team_members\".\"reflection_learning\" IS NULL\n    AND \"birth_giving_team_members\".\"reflection_submitted_at\" IS NULL\n  ) OR (\n    \"birth_giving_team_members\".\"reflection_contribution\" IS NOT NULL\n    AND length(trim(\"birth_giving_team_members\".\"reflection_contribution\")) > 0\n    AND \"birth_giving_team_members\".\"reflection_learning\" IS NOT NULL\n    AND length(trim(\"birth_giving_team_members\".\"reflection_learning\")) > 0\n    AND \"birth_giving_team_members\".\"reflection_submitted_at\" IS NOT NULL\n  )"
+        }
+      },
+      "isRLSEnabled": true
+    },
+    "public.birth_giving_teams": {
+      "name": "birth_giving_teams",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "event_id": {
+          "name": "event_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_winner": {
+          "name": "is_winner",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "result_state": {
+          "name": "result_state",
+          "type": "birth_giving_team_result_state",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "result_files": {
+          "name": "result_files",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "cancelled_at": {
+          "name": "cancelled_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cancellation_reason": {
+          "name": "cancellation_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_by_profile_id": {
+          "name": "created_by_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_by_profile_id": {
+          "name": "updated_by_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "birth_giving_teams_event_winner_idx": {
+          "name": "birth_giving_teams_event_winner_idx",
+          "columns": [
+            {
+              "expression": "event_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "with": {},
+          "method": "btree",
+          "where": "\"birth_giving_teams\".\"is_winner\" AND \"birth_giving_teams\".\"cancelled_at\" IS NULL",
+          "concurrently": false
+        },
+        "birth_giving_teams_event_idx": {
+          "name": "birth_giving_teams_event_idx",
+          "columns": [
+            {
+              "expression": "event_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "birth_giving_teams_event_id_fkey": {
+          "name": "birth_giving_teams_event_id_fkey",
+          "tableFrom": "birth_giving_teams",
+          "columnsFrom": [
+            "event_id"
+          ],
+          "tableTo": "birth_giving_events",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        },
+        "birth_giving_teams_created_by_profile_id_fkey": {
+          "name": "birth_giving_teams_created_by_profile_id_fkey",
+          "tableFrom": "birth_giving_teams",
+          "columnsFrom": [
+            "created_by_profile_id"
+          ],
+          "tableTo": "profiles",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "restrict"
+        },
+        "birth_giving_teams_updated_by_profile_id_fkey": {
+          "name": "birth_giving_teams_updated_by_profile_id_fkey",
+          "tableFrom": "birth_giving_teams",
+          "columnsFrom": [
+            "updated_by_profile_id"
+          ],
+          "tableTo": "profiles",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "restrict"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "birth_giving_teams_event_id_id_key": {
+          "name": "birth_giving_teams_event_id_id_key",
+          "columns": [
+            "event_id",
+            "id"
+          ],
+          "nullsNotDistinct": false
+        }
+      },
+      "policies": {
+        "Community can view BG teams for accessible events": {
+          "name": "Community can view BG teams for accessible events",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": [
+            "authenticated"
+          ],
+          "using": "EXISTS (\n  SELECT 1\n  FROM profiles caller_profile\n  JOIN users caller_user ON caller_user.id = caller_profile.user_id\n  WHERE caller_profile.id = current_profile_id()\n    AND caller_profile.access_removed_at IS NULL\n    AND caller_profile.beta_access_granted_at IS NOT NULL\n    AND caller_user.verified_work_email IS NOT NULL\n) AND EXISTS (\n      SELECT 1 FROM birth_giving_events event\n      WHERE event.id = \"birth_giving_teams\".\"event_id\"\n        AND event.removed_at IS NULL\n        AND (event.status = 'published' OR current_profile_id() = ANY(event.organizer_profile_ids))\n    )"
+        }
+      },
+      "checkConstraints": {
+        "birth_giving_teams_name_check": {
+          "name": "birth_giving_teams_name_check",
+          "value": "length(trim(\"birth_giving_teams\".\"name\")) > 0"
+        },
+        "birth_giving_teams_cancellation_check": {
+          "name": "birth_giving_teams_cancellation_check",
+          "value": "(\n    \"birth_giving_teams\".\"cancelled_at\" IS NULL AND \"birth_giving_teams\".\"cancellation_reason\" IS NULL\n  ) OR (\n    \"birth_giving_teams\".\"cancelled_at\" IS NOT NULL\n    AND \"birth_giving_teams\".\"cancellation_reason\" IS NOT NULL\n    AND length(trim(\"birth_giving_teams\".\"cancellation_reason\")) > 0\n  )"
+        },
+        "birth_giving_teams_result_check": {
+          "name": "birth_giving_teams_result_check",
+          "value": "jsonb_typeof(\"birth_giving_teams\".\"result_files\") = 'array' AND (\n    (\"birth_giving_teams\".\"result_state\" = 'present' AND jsonb_array_length(\"birth_giving_teams\".\"result_files\") > 0)\n    OR (\"birth_giving_teams\".\"result_state\" IN ('pending', 'missing') AND jsonb_array_length(\"birth_giving_teams\".\"result_files\") = 0)\n  )"
+        }
+      },
+      "isRLSEnabled": true
+    },
+    "public.book_loans": {
+      "name": "book_loans",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "library_book_id": {
+          "name": "library_book_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "borrower_id": {
+          "name": "borrower_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "borrowed_at": {
+          "name": "borrowed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "due_at": {
+          "name": "due_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "returned_at": {
+          "name": "returned_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "book_loans_library_book_id_idx": {
+          "name": "book_loans_library_book_id_idx",
+          "columns": [
+            {
+              "expression": "library_book_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "uuid_ops"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "book_loans_borrower_id_idx": {
+          "name": "book_loans_borrower_id_idx",
+          "columns": [
+            {
+              "expression": "borrower_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "uuid_ops"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "book_loans_active_idx": {
+          "name": "book_loans_active_idx",
+          "columns": [
+            {
+              "expression": "library_book_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "uuid_ops"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "where": "(returned_at IS NULL)",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "book_loans_library_book_id_fkey": {
+          "name": "book_loans_library_book_id_fkey",
+          "tableFrom": "book_loans",
+          "columnsFrom": [
+            "library_book_id"
+          ],
+          "tableTo": "library_books",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "restrict"
+        },
+        "book_loans_borrower_id_fkey": {
+          "name": "book_loans_borrower_id_fkey",
+          "tableFrom": "book_loans",
+          "columnsFrom": [
+            "borrower_id"
+          ],
+          "tableTo": "profiles",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "restrict"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {
+        "Authenticated users can view loans": {
+          "name": "Authenticated users can view loans",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": [
+            "authenticated"
+          ],
+          "using": "true"
+        },
+        "Users can borrow for themselves": {
+          "name": "Users can borrow for themselves",
+          "as": "PERMISSIVE",
+          "for": "INSERT",
+          "to": [
+            "authenticated"
+          ],
+          "withCheck": "(borrower_id = current_profile_id())"
+        },
+        "Borrower can return their own loan": {
+          "name": "Borrower can return their own loan",
+          "as": "PERMISSIVE",
+          "for": "UPDATE",
+          "to": [
+            "authenticated"
+          ],
+          "using": "(borrower_id = current_profile_id())",
+          "withCheck": "(borrower_id = current_profile_id())"
+        }
+      },
+      "checkConstraints": {},
+      "isRLSEnabled": true
+    },
+    "public.book_tags": {
+      "name": "book_tags",
+      "schema": "",
+      "columns": {
+        "book_id": {
+          "name": "book_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tag_id": {
+          "name": "tag_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_by_profile_id": {
+          "name": "created_by_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_by_profile_id": {
+          "name": "updated_by_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "book_tags_tag_idx": {
+          "name": "book_tags_tag_idx",
+          "columns": [
+            {
+              "expression": "tag_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "uuid_ops"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "book_tags_book_id_fkey": {
+          "name": "book_tags_book_id_fkey",
+          "tableFrom": "book_tags",
+          "columnsFrom": [
+            "book_id"
+          ],
+          "tableTo": "books",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        },
+        "book_tags_tag_id_fkey": {
+          "name": "book_tags_tag_id_fkey",
+          "tableFrom": "book_tags",
+          "columnsFrom": [
+            "tag_id"
+          ],
+          "tableTo": "tags",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        },
+        "book_tags_created_by_profile_id_fkey": {
+          "name": "book_tags_created_by_profile_id_fkey",
+          "tableFrom": "book_tags",
+          "columnsFrom": [
+            "created_by_profile_id"
+          ],
+          "tableTo": "profiles",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "restrict"
+        },
+        "book_tags_updated_by_profile_id_fkey": {
+          "name": "book_tags_updated_by_profile_id_fkey",
+          "tableFrom": "book_tags",
+          "columnsFrom": [
+            "updated_by_profile_id"
+          ],
+          "tableTo": "profiles",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "restrict"
+        }
+      },
+      "compositePrimaryKeys": {
+        "book_tags_pkey": {
+          "name": "book_tags_pkey",
+          "columns": [
+            "book_id",
+            "tag_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {
+        "Authenticated users can view book tags": {
+          "name": "Authenticated users can view book tags",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": [
+            "authenticated"
+          ],
+          "using": "true"
+        },
+        "Authenticated users can assign book tags": {
+          "name": "Authenticated users can assign book tags",
+          "as": "PERMISSIVE",
+          "for": "INSERT",
+          "to": [
+            "authenticated"
+          ],
+          "withCheck": "(created_by_profile_id = current_profile_id())"
+        },
+        "Coaches and admins can update book tags": {
+          "name": "Coaches and admins can update book tags",
+          "as": "PERMISSIVE",
+          "for": "UPDATE",
+          "to": [
+            "authenticated"
+          ],
+          "using": "is_coach_or_admin()",
+          "withCheck": "is_coach_or_admin()"
+        },
+        "Coaches and admins can remove book tags": {
+          "name": "Coaches and admins can remove book tags",
+          "as": "PERMISSIVE",
+          "for": "DELETE",
+          "to": [
+            "authenticated"
+          ],
+          "using": "is_coach_or_admin()"
+        }
+      },
+      "checkConstraints": {},
+      "isRLSEnabled": true
+    },
+    "public.books": {
+      "name": "books",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "title_cs": {
+          "name": "title_cs",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title_en": {
+          "name": "title_en",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "author": {
+          "name": "author",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "isbn_13": {
+          "name": "isbn_13",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "google_books_cover_url": {
+          "name": "google_books_cover_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "book_points": {
+          "name": "book_points",
+          "type": "numeric(3, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "page_count": {
+          "name": "page_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "preview_link": {
+          "name": "preview_link",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source": {
+          "name": "source",
+          "type": "book_source",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'manual'"
+        },
+        "external_id": {
+          "name": "external_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "list_status": {
+          "name": "list_status",
+          "type": "book_list_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'processing'"
+        },
+        "list_status_changed_at": {
+          "name": "list_status_changed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "list_status_changed_by_profile_id": {
+          "name": "list_status_changed_by_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "list_status_reason": {
+          "name": "list_status_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "highlight_category_id": {
+          "name": "highlight_category_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_rocket_model": {
+          "name": "is_rocket_model",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_by_profile_id": {
+          "name": "created_by_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_by_profile_id": {
+          "name": "updated_by_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "books_created_by_idx": {
+          "name": "books_created_by_idx",
+          "columns": [
+            {
+              "expression": "created_by_profile_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "uuid_ops"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "books_author_trgm_idx": {
+          "name": "books_author_trgm_idx",
+          "columns": [
+            {
+              "expression": "author",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "gin_trgm_ops"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "gin",
+          "concurrently": false
+        },
+        "books_created_desc_idx": {
+          "name": "books_created_desc_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "first",
+              "opclass": "timestamptz_ops"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "books_isbn_13_idx": {
+          "name": "books_isbn_13_idx",
+          "columns": [
+            {
+              "expression": "isbn_13",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "text_ops"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "where": "(isbn_13 IS NOT NULL)",
+          "concurrently": false
+        },
+        "books_list_status_idx": {
+          "name": "books_list_status_idx",
+          "columns": [
+            {
+              "expression": "list_status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "enum_ops"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "books_title_cs_trgm_idx": {
+          "name": "books_title_cs_trgm_idx",
+          "columns": [
+            {
+              "expression": "title_cs",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "gin_trgm_ops"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "gin",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "books_created_by_profile_id_fkey": {
+          "name": "books_created_by_profile_id_fkey",
+          "tableFrom": "books",
+          "columnsFrom": [
+            "created_by_profile_id"
+          ],
+          "tableTo": "profiles",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "restrict"
+        },
+        "books_updated_by_profile_id_fkey": {
+          "name": "books_updated_by_profile_id_fkey",
+          "tableFrom": "books",
+          "columnsFrom": [
+            "updated_by_profile_id"
+          ],
+          "tableTo": "profiles",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "restrict"
+        },
+        "books_list_status_changed_by_profile_id_fkey": {
+          "name": "books_list_status_changed_by_profile_id_fkey",
+          "tableFrom": "books",
+          "columnsFrom": [
+            "list_status_changed_by_profile_id"
+          ],
+          "tableTo": "profiles",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "set null"
+        },
+        "books_highlight_category_id_fkey": {
+          "name": "books_highlight_category_id_fkey",
+          "tableFrom": "books",
+          "columnsFrom": [
+            "highlight_category_id"
+          ],
+          "tableTo": "highlight_categories",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "set null"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {
+        "Coaches and admins can delete books": {
+          "name": "Coaches and admins can delete books",
+          "as": "PERMISSIVE",
+          "for": "DELETE",
+          "to": [
+            "public"
+          ],
+          "using": "is_coach_or_admin()"
+        },
+        "Coaches and admins can update books": {
+          "name": "Coaches and admins can update books",
+          "as": "PERMISSIVE",
+          "for": "UPDATE",
+          "to": [
+            "authenticated"
+          ],
+          "using": "is_coach_or_admin()",
+          "withCheck": "is_coach_or_admin()"
+        },
+        "Authenticated users can add books": {
+          "name": "Authenticated users can add books",
+          "as": "PERMISSIVE",
+          "for": "INSERT",
+          "to": [
+            "authenticated"
+          ],
+          "withCheck": "(created_by_profile_id = current_profile_id())"
+        },
+        "Authenticated users can view all books": {
+          "name": "Authenticated users can view all books",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": [
+            "authenticated"
+          ],
+          "using": "true"
+        }
+      },
+      "checkConstraints": {
+        "books_book_points_check": {
+          "name": "books_book_points_check",
+          "value": "(book_points IS NULL) OR ((book_points >= (0)::numeric) AND (book_points <= (3)::numeric))"
+        },
+        "books_archived_points_check": {
+          "name": "books_archived_points_check",
+          "value": "(list_status <> 'archived') OR (book_points = (0)::numeric)"
+        }
+      },
+      "isRLSEnabled": true
+    },
+    "public.highlight_categories": {
+      "name": "highlight_categories",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_by_profile_id": {
+          "name": "created_by_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_by_profile_id": {
+          "name": "updated_by_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "highlight_categories_created_by_profile_id_fkey": {
+          "name": "highlight_categories_created_by_profile_id_fkey",
+          "tableFrom": "highlight_categories",
+          "columnsFrom": [
+            "created_by_profile_id"
+          ],
+          "tableTo": "profiles",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "restrict"
+        },
+        "highlight_categories_updated_by_profile_id_fkey": {
+          "name": "highlight_categories_updated_by_profile_id_fkey",
+          "tableFrom": "highlight_categories",
+          "columnsFrom": [
+            "updated_by_profile_id"
+          ],
+          "tableTo": "profiles",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "restrict"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {
+        "Authenticated users can view highlight categories": {
+          "name": "Authenticated users can view highlight categories",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": [
+            "authenticated"
+          ],
+          "using": "true"
+        },
+        "Coaches and admins can add highlight categories": {
+          "name": "Coaches and admins can add highlight categories",
+          "as": "PERMISSIVE",
+          "for": "INSERT",
+          "to": [
+            "authenticated"
+          ],
+          "withCheck": "is_coach_or_admin()"
+        },
+        "Coaches and admins can update highlight categories": {
+          "name": "Coaches and admins can update highlight categories",
+          "as": "PERMISSIVE",
+          "for": "UPDATE",
+          "to": [
+            "authenticated"
+          ],
+          "using": "is_coach_or_admin()",
+          "withCheck": "is_coach_or_admin()"
+        },
+        "Coaches and admins can delete highlight categories": {
+          "name": "Coaches and admins can delete highlight categories",
+          "as": "PERMISSIVE",
+          "for": "DELETE",
+          "to": [
+            "authenticated"
+          ],
+          "using": "is_coach_or_admin()"
+        }
+      },
+      "checkConstraints": {},
+      "isRLSEnabled": true
+    },
+    "public.library_books": {
+      "name": "library_books",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "book_id": {
+          "name": "book_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "isbn_13": {
+          "name": "isbn_13",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_by_profile_id": {
+          "name": "created_by_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_by_profile_id": {
+          "name": "updated_by_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "library_books_book_id_idx": {
+          "name": "library_books_book_id_idx",
+          "columns": [
+            {
+              "expression": "book_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "uuid_ops"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "library_books_isbn_13_idx": {
+          "name": "library_books_isbn_13_idx",
+          "columns": [
+            {
+              "expression": "isbn_13",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "text_ops"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "where": "(isbn_13 IS NOT NULL)",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "library_books_book_id_fkey": {
+          "name": "library_books_book_id_fkey",
+          "tableFrom": "library_books",
+          "columnsFrom": [
+            "book_id"
+          ],
+          "tableTo": "books",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "restrict"
+        },
+        "library_books_created_by_profile_id_fkey": {
+          "name": "library_books_created_by_profile_id_fkey",
+          "tableFrom": "library_books",
+          "columnsFrom": [
+            "created_by_profile_id"
+          ],
+          "tableTo": "profiles",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "restrict"
+        },
+        "library_books_updated_by_profile_id_fkey": {
+          "name": "library_books_updated_by_profile_id_fkey",
+          "tableFrom": "library_books",
+          "columnsFrom": [
+            "updated_by_profile_id"
+          ],
+          "tableTo": "profiles",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "restrict"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {
+        "Authenticated users can view library books": {
+          "name": "Authenticated users can view library books",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": [
+            "authenticated"
+          ],
+          "using": "true"
+        },
+        "Coaches and admins can add library books": {
+          "name": "Coaches and admins can add library books",
+          "as": "PERMISSIVE",
+          "for": "INSERT",
+          "to": [
+            "authenticated"
+          ],
+          "withCheck": "is_coach_or_admin()"
+        },
+        "Coaches and admins can update library books": {
+          "name": "Coaches and admins can update library books",
+          "as": "PERMISSIVE",
+          "for": "UPDATE",
+          "to": [
+            "authenticated"
+          ],
+          "using": "is_coach_or_admin()",
+          "withCheck": "is_coach_or_admin()"
+        },
+        "Coaches and admins can delete library books": {
+          "name": "Coaches and admins can delete library books",
+          "as": "PERMISSIVE",
+          "for": "DELETE",
+          "to": [
+            "authenticated"
+          ],
+          "using": "is_coach_or_admin()"
+        }
+      },
+      "checkConstraints": {},
+      "isRLSEnabled": true
+    },
+    "public.tags": {
+      "name": "tags",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_by_profile_id": {
+          "name": "created_by_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_by_profile_id": {
+          "name": "updated_by_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "tags_created_by_profile_id_fkey": {
+          "name": "tags_created_by_profile_id_fkey",
+          "tableFrom": "tags",
+          "columnsFrom": [
+            "created_by_profile_id"
+          ],
+          "tableTo": "profiles",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "restrict"
+        },
+        "tags_updated_by_profile_id_fkey": {
+          "name": "tags_updated_by_profile_id_fkey",
+          "tableFrom": "tags",
+          "columnsFrom": [
+            "updated_by_profile_id"
+          ],
+          "tableTo": "profiles",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "restrict"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "tags_name_key": {
+          "name": "tags_name_key",
+          "columns": [
+            "name"
+          ],
+          "nullsNotDistinct": false
+        }
+      },
+      "policies": {
+        "Authenticated users can view tags": {
+          "name": "Authenticated users can view tags",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": [
+            "authenticated"
+          ],
+          "using": "true"
+        },
+        "Coaches and admins can add tags": {
+          "name": "Coaches and admins can add tags",
+          "as": "PERMISSIVE",
+          "for": "INSERT",
+          "to": [
+            "authenticated"
+          ],
+          "withCheck": "is_coach_or_admin()"
+        },
+        "Coaches and admins can update tags": {
+          "name": "Coaches and admins can update tags",
+          "as": "PERMISSIVE",
+          "for": "UPDATE",
+          "to": [
+            "authenticated"
+          ],
+          "using": "is_coach_or_admin()",
+          "withCheck": "is_coach_or_admin()"
+        },
+        "Coaches and admins can delete tags": {
+          "name": "Coaches and admins can delete tags",
+          "as": "PERMISSIVE",
+          "for": "DELETE",
+          "to": [
+            "authenticated"
+          ],
+          "using": "is_coach_or_admin()"
+        }
+      },
+      "checkConstraints": {},
+      "isRLSEnabled": true
+    },
+    "public.content_sources": {
+      "name": "content_sources",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "kind": {
+          "name": "kind",
+          "type": "content_source_kind",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "creator": {
+          "name": "creator",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "external_url": {
+          "name": "external_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "points": {
+          "name": "points",
+          "type": "numeric(3, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "content_source_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending_review'"
+        },
+        "status_changed_at": {
+          "name": "status_changed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status_changed_by_profile_id": {
+          "name": "status_changed_by_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_by_profile_id": {
+          "name": "created_by_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_by_profile_id": {
+          "name": "updated_by_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "content_sources_created_by_idx": {
+          "name": "content_sources_created_by_idx",
+          "columns": [
+            {
+              "expression": "created_by_profile_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "uuid_ops"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "content_sources_status_idx": {
+          "name": "content_sources_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "enum_ops"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "content_sources_title_trgm_idx": {
+          "name": "content_sources_title_trgm_idx",
+          "columns": [
+            {
+              "expression": "title",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "gin_trgm_ops"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "gin",
+          "concurrently": false
+        },
+        "content_sources_creator_trgm_idx": {
+          "name": "content_sources_creator_trgm_idx",
+          "columns": [
+            {
+              "expression": "creator",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "gin_trgm_ops"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "gin",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "content_sources_created_by_profile_id_fkey": {
+          "name": "content_sources_created_by_profile_id_fkey",
+          "tableFrom": "content_sources",
+          "columnsFrom": [
+            "created_by_profile_id"
+          ],
+          "tableTo": "profiles",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "restrict"
+        },
+        "content_sources_updated_by_profile_id_fkey": {
+          "name": "content_sources_updated_by_profile_id_fkey",
+          "tableFrom": "content_sources",
+          "columnsFrom": [
+            "updated_by_profile_id"
+          ],
+          "tableTo": "profiles",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "restrict"
+        },
+        "content_sources_status_changed_by_profile_id_fkey": {
+          "name": "content_sources_status_changed_by_profile_id_fkey",
+          "tableFrom": "content_sources",
+          "columnsFrom": [
+            "status_changed_by_profile_id"
+          ],
+          "tableTo": "profiles",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "set null"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {
+        "Authenticated users can view all content sources": {
+          "name": "Authenticated users can view all content sources",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": [
+            "authenticated"
+          ],
+          "using": "true"
+        },
+        "Authenticated users can add content sources": {
+          "name": "Authenticated users can add content sources",
+          "as": "PERMISSIVE",
+          "for": "INSERT",
+          "to": [
+            "authenticated"
+          ],
+          "withCheck": "((created_by_profile_id = current_profile_id()) AND (status = 'pending_review'::content_source_status))"
+        },
+        "Coaches and admins can update content sources": {
+          "name": "Coaches and admins can update content sources",
+          "as": "PERMISSIVE",
+          "for": "UPDATE",
+          "to": [
+            "authenticated"
+          ],
+          "using": "is_coach_or_admin()",
+          "withCheck": "is_coach_or_admin()"
+        },
+        "Coaches and admins can delete content sources": {
+          "name": "Coaches and admins can delete content sources",
+          "as": "PERMISSIVE",
+          "for": "DELETE",
+          "to": [
+            "authenticated"
+          ],
+          "using": "is_coach_or_admin()"
+        }
+      },
+      "checkConstraints": {
+        "content_sources_points_check": {
+          "name": "content_sources_points_check",
+          "value": "(points IS NULL) OR ((points >= (0)::numeric) AND (points <= (3)::numeric))"
+        }
+      },
+      "isRLSEnabled": true
+    },
+    "public.customer_meetings": {
+      "name": "customer_meetings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "profile_id": {
+          "name": "profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "meeting_at": {
+          "name": "meeting_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "company": {
+          "name": "company",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "contact_person": {
+          "name": "contact_person",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "position": {
+          "name": "position",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "objective": {
+          "name": "objective",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "post_mortem": {
+          "name": "post_mortem",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "team_share": {
+          "name": "team_share",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "removed_at": {
+          "name": "removed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_by_profile_id": {
+          "name": "created_by_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_by_profile_id": {
+          "name": "updated_by_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "customer_meetings_profile_idx": {
+          "name": "customer_meetings_profile_idx",
+          "columns": [
+            {
+              "expression": "profile_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "uuid_ops"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "customer_meetings_created_desc_idx": {
+          "name": "customer_meetings_created_desc_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "first",
+              "opclass": "timestamptz_ops"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "customer_meetings_profile_id_fkey": {
+          "name": "customer_meetings_profile_id_fkey",
+          "tableFrom": "customer_meetings",
+          "columnsFrom": [
+            "profile_id"
+          ],
+          "tableTo": "profiles",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        },
+        "customer_meetings_created_by_profile_id_fkey": {
+          "name": "customer_meetings_created_by_profile_id_fkey",
+          "tableFrom": "customer_meetings",
+          "columnsFrom": [
+            "created_by_profile_id"
+          ],
+          "tableTo": "profiles",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "restrict"
+        },
+        "customer_meetings_updated_by_profile_id_fkey": {
+          "name": "customer_meetings_updated_by_profile_id_fkey",
+          "tableFrom": "customer_meetings",
+          "columnsFrom": [
+            "updated_by_profile_id"
+          ],
+          "tableTo": "profiles",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "restrict"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {
+        "Users can view their own customer meetings": {
+          "name": "Users can view their own customer meetings",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": [
+            "authenticated"
+          ],
+          "using": "(profile_id = current_profile_id())"
+        },
+        "Users can create their own customer meetings": {
+          "name": "Users can create their own customer meetings",
+          "as": "PERMISSIVE",
+          "for": "INSERT",
+          "to": [
+            "authenticated"
+          ],
+          "withCheck": "(profile_id = current_profile_id())"
+        },
+        "Users can update their own customer meetings": {
+          "name": "Users can update their own customer meetings",
+          "as": "PERMISSIVE",
+          "for": "UPDATE",
+          "to": [
+            "authenticated"
+          ],
+          "using": "(profile_id = current_profile_id())",
+          "withCheck": "(profile_id = current_profile_id())"
+        },
+        "Users can delete their own customer meetings": {
+          "name": "Users can delete their own customer meetings",
+          "as": "PERMISSIVE",
+          "for": "DELETE",
+          "to": [
+            "authenticated"
+          ],
+          "using": "(profile_id = current_profile_id())"
+        }
+      },
+      "checkConstraints": {},
+      "isRLSEnabled": true
+    },
+    "public.dashboard_layouts": {
+      "name": "dashboard_layouts",
+      "schema": "",
+      "columns": {
+        "profile_id": {
+          "name": "profile_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "widgets": {
+          "name": "widgets",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_by_profile_id": {
+          "name": "created_by_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_by_profile_id": {
+          "name": "updated_by_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "dashboard_layouts_profile_id_fkey": {
+          "name": "dashboard_layouts_profile_id_fkey",
+          "tableFrom": "dashboard_layouts",
+          "columnsFrom": [
+            "profile_id"
+          ],
+          "tableTo": "profiles",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        },
+        "dashboard_layouts_created_by_profile_id_fkey": {
+          "name": "dashboard_layouts_created_by_profile_id_fkey",
+          "tableFrom": "dashboard_layouts",
+          "columnsFrom": [
+            "created_by_profile_id"
+          ],
+          "tableTo": "profiles",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "restrict"
+        },
+        "dashboard_layouts_updated_by_profile_id_fkey": {
+          "name": "dashboard_layouts_updated_by_profile_id_fkey",
+          "tableFrom": "dashboard_layouts",
+          "columnsFrom": [
+            "updated_by_profile_id"
+          ],
+          "tableTo": "profiles",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "restrict"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {
+        "Users can delete their own dashboard layout": {
+          "name": "Users can delete their own dashboard layout",
+          "as": "PERMISSIVE",
+          "for": "DELETE",
+          "to": [
+            "public"
+          ],
+          "using": "(profile_id = current_profile_id())"
+        },
+        "Users can update their own dashboard layout": {
+          "name": "Users can update their own dashboard layout",
+          "as": "PERMISSIVE",
+          "for": "UPDATE",
+          "to": [
+            "public"
+          ],
+          "using": "(profile_id = current_profile_id())",
+          "withCheck": "(profile_id = current_profile_id())"
+        },
+        "Users can insert their own dashboard layout": {
+          "name": "Users can insert their own dashboard layout",
+          "as": "PERMISSIVE",
+          "for": "INSERT",
+          "to": [
+            "public"
+          ],
+          "withCheck": "(profile_id = current_profile_id())"
+        },
+        "Users can view their own dashboard layout": {
+          "name": "Users can view their own dashboard layout",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": [
+            "public"
+          ],
+          "using": "(profile_id = current_profile_id())"
+        }
+      },
+      "checkConstraints": {},
+      "isRLSEnabled": true
+    },
+    "public.essay_coach_reads": {
+      "name": "essay_coach_reads",
+      "schema": "",
+      "columns": {
+        "essay_id": {
+          "name": "essay_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "coach_profile_id": {
+          "name": "coach_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "read_at": {
+          "name": "read_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_by_profile_id": {
+          "name": "created_by_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_by_profile_id": {
+          "name": "updated_by_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "essay_coach_reads_coach_idx": {
+          "name": "essay_coach_reads_coach_idx",
+          "columns": [
+            {
+              "expression": "coach_profile_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "uuid_ops"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "essay_coach_reads_essay_id_fkey": {
+          "name": "essay_coach_reads_essay_id_fkey",
+          "tableFrom": "essay_coach_reads",
+          "columnsFrom": [
+            "essay_id"
+          ],
+          "tableTo": "essays",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        },
+        "essay_coach_reads_coach_profile_id_fkey": {
+          "name": "essay_coach_reads_coach_profile_id_fkey",
+          "tableFrom": "essay_coach_reads",
+          "columnsFrom": [
+            "coach_profile_id"
+          ],
+          "tableTo": "profiles",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        },
+        "essay_coach_reads_created_by_profile_id_fkey": {
+          "name": "essay_coach_reads_created_by_profile_id_fkey",
+          "tableFrom": "essay_coach_reads",
+          "columnsFrom": [
+            "created_by_profile_id"
+          ],
+          "tableTo": "profiles",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "restrict"
+        },
+        "essay_coach_reads_updated_by_profile_id_fkey": {
+          "name": "essay_coach_reads_updated_by_profile_id_fkey",
+          "tableFrom": "essay_coach_reads",
+          "columnsFrom": [
+            "updated_by_profile_id"
+          ],
+          "tableTo": "profiles",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "restrict"
+        }
+      },
+      "compositePrimaryKeys": {
+        "essay_coach_reads_pkey": {
+          "name": "essay_coach_reads_pkey",
+          "columns": [
+            "essay_id",
+            "coach_profile_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {
+        "Coaches remove own reads": {
+          "name": "Coaches remove own reads",
+          "as": "PERMISSIVE",
+          "for": "DELETE",
+          "to": [
+            "authenticated"
+          ],
+          "using": "(coach_profile_id = current_profile_id())"
+        },
+        "Coaches mark own reads within their team": {
+          "name": "Coaches mark own reads within their team",
+          "as": "PERMISSIVE",
+          "for": "INSERT",
+          "to": [
+            "authenticated"
+          ],
+          "withCheck": "((coach_profile_id = current_profile_id()) AND coach_can_review_essay(essay_id))"
+        },
+        "Coach sees own reads; author sees reads of own essays": {
+          "name": "Coach sees own reads; author sees reads of own essays",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": [
+            "authenticated"
+          ],
+          "using": "((coach_profile_id = current_profile_id()) OR (EXISTS ( SELECT 1\n   FROM essays e\n  WHERE ((e.id = essay_coach_reads.essay_id) AND (e.author_profile_id = current_profile_id())))))"
+        }
+      },
+      "checkConstraints": {},
+      "isRLSEnabled": true
+    },
+    "public.essay_comments": {
+      "name": "essay_comments",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "essay_id": {
+          "name": "essay_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "author_profile_id": {
+          "name": "author_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "parent_id": {
+          "name": "parent_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "removed_at": {
+          "name": "removed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_by_profile_id": {
+          "name": "created_by_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_by_profile_id": {
+          "name": "updated_by_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "essay_comments_author_idx": {
+          "name": "essay_comments_author_idx",
+          "columns": [
+            {
+              "expression": "author_profile_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "uuid_ops"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "essay_comments_essay_idx": {
+          "name": "essay_comments_essay_idx",
+          "columns": [
+            {
+              "expression": "essay_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "uuid_ops"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "essay_comments_essay_id_fkey": {
+          "name": "essay_comments_essay_id_fkey",
+          "tableFrom": "essay_comments",
+          "columnsFrom": [
+            "essay_id"
+          ],
+          "tableTo": "essays",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        },
+        "essay_comments_author_profile_id_fkey": {
+          "name": "essay_comments_author_profile_id_fkey",
+          "tableFrom": "essay_comments",
+          "columnsFrom": [
+            "author_profile_id"
+          ],
+          "tableTo": "profiles",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        },
+        "essay_comments_created_by_profile_id_fkey": {
+          "name": "essay_comments_created_by_profile_id_fkey",
+          "tableFrom": "essay_comments",
+          "columnsFrom": [
+            "created_by_profile_id"
+          ],
+          "tableTo": "profiles",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "restrict"
+        },
+        "essay_comments_updated_by_profile_id_fkey": {
+          "name": "essay_comments_updated_by_profile_id_fkey",
+          "tableFrom": "essay_comments",
+          "columnsFrom": [
+            "updated_by_profile_id"
+          ],
+          "tableTo": "profiles",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "restrict"
+        },
+        "essay_comments_parent_id_fkey": {
+          "name": "essay_comments_parent_id_fkey",
+          "tableFrom": "essay_comments",
+          "columnsFrom": [
+            "parent_id"
+          ],
+          "tableTo": "essay_comments",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "set null"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {
+        "Authors and admins can delete essay comments": {
+          "name": "Authors and admins can delete essay comments",
+          "as": "PERMISSIVE",
+          "for": "DELETE",
+          "to": [
+            "authenticated"
+          ],
+          "using": "((author_profile_id = current_profile_id()) OR is_admin())"
+        },
+        "Authors can update their own essay comments": {
+          "name": "Authors can update their own essay comments",
+          "as": "PERMISSIVE",
+          "for": "UPDATE",
+          "to": [
+            "authenticated"
+          ],
+          "using": "(author_profile_id = current_profile_id())",
+          "withCheck": "(author_profile_id = current_profile_id())"
+        },
+        "Authenticated users can add essay comments": {
+          "name": "Authenticated users can add essay comments",
+          "as": "PERMISSIVE",
+          "for": "INSERT",
+          "to": [
+            "authenticated"
+          ],
+          "withCheck": "(author_profile_id = current_profile_id())"
+        },
+        "Authenticated users can view essay comments": {
+          "name": "Authenticated users can view essay comments",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": [
+            "authenticated"
+          ],
+          "using": "true"
+        }
+      },
+      "checkConstraints": {
+        "essay_comments_body_check": {
+          "name": "essay_comments_body_check",
+          "value": "(char_length(body) >= 1) AND (char_length(body) <= 4000)"
+        }
+      },
+      "isRLSEnabled": true
+    },
+    "public.essay_revisions": {
+      "name": "essay_revisions",
+      "schema": "",
+      "columns": {
+        "essay_id": {
+          "name": "essay_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "revision_no": {
+          "name": "revision_no",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content_json": {
+          "name": "content_json",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "invalid_since": {
+          "name": "invalid_since",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_by_profile_id": {
+          "name": "created_by_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_by_profile_id": {
+          "name": "updated_by_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "essay_revisions_essay_id_fkey": {
+          "name": "essay_revisions_essay_id_fkey",
+          "tableFrom": "essay_revisions",
+          "columnsFrom": [
+            "essay_id"
+          ],
+          "tableTo": "essays",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        },
+        "essay_revisions_created_by_profile_id_fkey": {
+          "name": "essay_revisions_created_by_profile_id_fkey",
+          "tableFrom": "essay_revisions",
+          "columnsFrom": [
+            "created_by_profile_id"
+          ],
+          "tableTo": "profiles",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "restrict"
+        },
+        "essay_revisions_updated_by_profile_id_fkey": {
+          "name": "essay_revisions_updated_by_profile_id_fkey",
+          "tableFrom": "essay_revisions",
+          "columnsFrom": [
+            "updated_by_profile_id"
+          ],
+          "tableTo": "profiles",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "restrict"
+        }
+      },
+      "compositePrimaryKeys": {
+        "essay_revisions_pkey": {
+          "name": "essay_revisions_pkey",
+          "columns": [
+            "essay_id",
+            "revision_no"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {
+        "Authenticated users can view essay revisions": {
+          "name": "Authenticated users can view essay revisions",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": [
+            "authenticated"
+          ],
+          "using": "(EXISTS ( SELECT 1\n   FROM essays e\n  WHERE ((e.id = essay_revisions.essay_id) AND ((e.published_at IS NOT NULL) OR (e.author_profile_id = ( SELECT current_profile_id())) OR ( SELECT is_admin())))))"
+        },
+        "Authors can create essay revisions": {
+          "name": "Authors can create essay revisions",
+          "as": "PERMISSIVE",
+          "for": "INSERT",
+          "to": [
+            "authenticated"
+          ],
+          "withCheck": "(created_by_profile_id = current_profile_id())"
+        },
+        "Authors can update their newest recent essay revision": {
+          "name": "Authors can update their newest recent essay revision",
+          "as": "PERMISSIVE",
+          "for": "UPDATE",
+          "to": [
+            "authenticated"
+          ],
+          "using": "((created_by_profile_id = ( SELECT current_profile_id())) AND (created_at > (now() - '00:30:00'::interval)))",
+          "withCheck": "(created_by_profile_id = ( SELECT current_profile_id()))"
+        },
+        "Essay revisions cannot be deleted": {
+          "name": "Essay revisions cannot be deleted",
+          "as": "PERMISSIVE",
+          "for": "DELETE",
+          "to": [
+            "authenticated"
+          ],
+          "using": "false"
+        }
+      },
+      "checkConstraints": {},
+      "isRLSEnabled": true
+    },
+    "public.essay_views": {
+      "name": "essay_views",
+      "schema": "",
+      "columns": {
+        "essay_id": {
+          "name": "essay_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "viewer_profile_id": {
+          "name": "viewer_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "first_viewed_at": {
+          "name": "first_viewed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_viewed_at": {
+          "name": "last_viewed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_by_profile_id": {
+          "name": "created_by_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_by_profile_id": {
+          "name": "updated_by_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "essay_views_viewer_idx": {
+          "name": "essay_views_viewer_idx",
+          "columns": [
+            {
+              "expression": "viewer_profile_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "uuid_ops"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "essay_views_essay_id_fkey": {
+          "name": "essay_views_essay_id_fkey",
+          "tableFrom": "essay_views",
+          "columnsFrom": [
+            "essay_id"
+          ],
+          "tableTo": "essays",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        },
+        "essay_views_viewer_profile_id_fkey": {
+          "name": "essay_views_viewer_profile_id_fkey",
+          "tableFrom": "essay_views",
+          "columnsFrom": [
+            "viewer_profile_id"
+          ],
+          "tableTo": "profiles",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        },
+        "essay_views_created_by_profile_id_fkey": {
+          "name": "essay_views_created_by_profile_id_fkey",
+          "tableFrom": "essay_views",
+          "columnsFrom": [
+            "created_by_profile_id"
+          ],
+          "tableTo": "profiles",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "restrict"
+        },
+        "essay_views_updated_by_profile_id_fkey": {
+          "name": "essay_views_updated_by_profile_id_fkey",
+          "tableFrom": "essay_views",
+          "columnsFrom": [
+            "updated_by_profile_id"
+          ],
+          "tableTo": "profiles",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "restrict"
+        }
+      },
+      "compositePrimaryKeys": {
+        "essay_views_pkey": {
+          "name": "essay_views_pkey",
+          "columns": [
+            "essay_id",
+            "viewer_profile_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {
+        "No direct inserts to essay_views": {
+          "name": "No direct inserts to essay_views",
+          "as": "PERMISSIVE",
+          "for": "INSERT",
+          "to": [
+            "authenticated"
+          ],
+          "withCheck": "false"
+        },
+        "Authors see all viewers; others see own row": {
+          "name": "Authors see all viewers; others see own row",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": [
+            "authenticated"
+          ],
+          "using": "((viewer_profile_id = current_profile_id()) OR (EXISTS ( SELECT 1\n   FROM essays e\n  WHERE ((e.id = essay_views.essay_id) AND (e.author_profile_id = current_profile_id())))))"
+        }
+      },
+      "checkConstraints": {},
+      "isRLSEnabled": true
+    },
+    "public.essay_votes": {
+      "name": "essay_votes",
+      "schema": "",
+      "columns": {
+        "essay_id": {
+          "name": "essay_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "voter_profile_id": {
+          "name": "voter_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_by_profile_id": {
+          "name": "created_by_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_by_profile_id": {
+          "name": "updated_by_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "essay_votes_voter_idx": {
+          "name": "essay_votes_voter_idx",
+          "columns": [
+            {
+              "expression": "voter_profile_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "uuid_ops"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "essay_votes_essay_id_fkey": {
+          "name": "essay_votes_essay_id_fkey",
+          "tableFrom": "essay_votes",
+          "columnsFrom": [
+            "essay_id"
+          ],
+          "tableTo": "essays",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        },
+        "essay_votes_voter_profile_id_fkey": {
+          "name": "essay_votes_voter_profile_id_fkey",
+          "tableFrom": "essay_votes",
+          "columnsFrom": [
+            "voter_profile_id"
+          ],
+          "tableTo": "profiles",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        },
+        "essay_votes_created_by_profile_id_fkey": {
+          "name": "essay_votes_created_by_profile_id_fkey",
+          "tableFrom": "essay_votes",
+          "columnsFrom": [
+            "created_by_profile_id"
+          ],
+          "tableTo": "profiles",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "restrict"
+        },
+        "essay_votes_updated_by_profile_id_fkey": {
+          "name": "essay_votes_updated_by_profile_id_fkey",
+          "tableFrom": "essay_votes",
+          "columnsFrom": [
+            "updated_by_profile_id"
+          ],
+          "tableTo": "profiles",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "restrict"
+        }
+      },
+      "compositePrimaryKeys": {
+        "essay_votes_pkey": {
+          "name": "essay_votes_pkey",
+          "columns": [
+            "essay_id",
+            "voter_profile_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {
+        "Users can vote (not own essays)": {
+          "name": "Users can vote (not own essays)",
+          "as": "PERMISSIVE",
+          "for": "INSERT",
+          "to": [
+            "authenticated"
+          ],
+          "withCheck": "((voter_profile_id = current_profile_id()) AND (NOT (essay_id IN ( SELECT essays.id\n   FROM essays\n  WHERE (essays.author_profile_id = current_profile_id())))))"
+        },
+        "Authenticated users can view votes": {
+          "name": "Authenticated users can view votes",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": [
+            "authenticated"
+          ],
+          "using": "true"
+        },
+        "Users can remove own votes": {
+          "name": "Users can remove own votes",
+          "as": "PERMISSIVE",
+          "for": "DELETE",
+          "to": [
+            "authenticated"
+          ],
+          "using": "(voter_profile_id = current_profile_id())"
+        }
+      },
+      "checkConstraints": {},
+      "isRLSEnabled": true
+    },
+    "public.essays": {
+      "name": "essays",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "external_id": {
+          "name": "external_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "author_profile_id": {
+          "name": "author_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "book_id": {
+          "name": "book_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "frozen_book_points": {
+          "name": "frozen_book_points",
+          "type": "numeric(3, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "content_source_id": {
+          "name": "content_source_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "published_at": {
+          "name": "published_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pinned_at": {
+          "name": "pinned_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pinned_by_profile_id": {
+          "name": "pinned_by_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "removed_at": {
+          "name": "removed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_by_profile_id": {
+          "name": "created_by_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_by_profile_id": {
+          "name": "updated_by_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "essays_author_idx": {
+          "name": "essays_author_idx",
+          "columns": [
+            {
+              "expression": "author_profile_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "uuid_ops"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "essays_book_idx": {
+          "name": "essays_book_idx",
+          "columns": [
+            {
+              "expression": "book_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "uuid_ops"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "essays_content_source_idx": {
+          "name": "essays_content_source_idx",
+          "columns": [
+            {
+              "expression": "content_source_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "uuid_ops"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "essays_created_desc_idx": {
+          "name": "essays_created_desc_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "first",
+              "opclass": "timestamptz_ops"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "essays_author_profile_id_fkey": {
+          "name": "essays_author_profile_id_fkey",
+          "tableFrom": "essays",
+          "columnsFrom": [
+            "author_profile_id"
+          ],
+          "tableTo": "profiles",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        },
+        "essays_book_id_fkey": {
+          "name": "essays_book_id_fkey",
+          "tableFrom": "essays",
+          "columnsFrom": [
+            "book_id"
+          ],
+          "tableTo": "books",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "set null"
+        },
+        "essays_content_source_id_fkey": {
+          "name": "essays_content_source_id_fkey",
+          "tableFrom": "essays",
+          "columnsFrom": [
+            "content_source_id"
+          ],
+          "tableTo": "content_sources",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "set null"
+        },
+        "essays_pinned_by_profile_id_fkey": {
+          "name": "essays_pinned_by_profile_id_fkey",
+          "tableFrom": "essays",
+          "columnsFrom": [
+            "pinned_by_profile_id"
+          ],
+          "tableTo": "profiles",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "set null"
+        },
+        "essays_created_by_profile_id_fkey": {
+          "name": "essays_created_by_profile_id_fkey",
+          "tableFrom": "essays",
+          "columnsFrom": [
+            "created_by_profile_id"
+          ],
+          "tableTo": "profiles",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "restrict"
+        },
+        "essays_updated_by_profile_id_fkey": {
+          "name": "essays_updated_by_profile_id_fkey",
+          "tableFrom": "essays",
+          "columnsFrom": [
+            "updated_by_profile_id"
+          ],
+          "tableTo": "profiles",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "restrict"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {
+        "Authors can create their own essays": {
+          "name": "Authors can create their own essays",
+          "as": "PERMISSIVE",
+          "for": "INSERT",
+          "to": [
+            "authenticated"
+          ],
+          "withCheck": "(author_profile_id = current_profile_id())"
+        },
+        "Authenticated users can view all essays": {
+          "name": "Authenticated users can view all essays",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": [
+            "authenticated"
+          ],
+          "using": "((published_at IS NOT NULL) OR (author_profile_id = ( SELECT current_profile_id())) OR ( SELECT is_admin()))"
+        },
+        "Authors and admins can delete essays": {
+          "name": "Authors and admins can delete essays",
+          "as": "PERMISSIVE",
+          "for": "DELETE",
+          "to": [
+            "authenticated"
+          ],
+          "using": "((author_profile_id = current_profile_id()) OR is_admin())"
+        },
+        "Authors can update their own essays": {
+          "name": "Authors can update their own essays",
+          "as": "PERMISSIVE",
+          "for": "UPDATE",
+          "to": [
+            "authenticated"
+          ],
+          "using": "(author_profile_id = current_profile_id())",
+          "withCheck": "(author_profile_id = current_profile_id())"
+        }
+      },
+      "checkConstraints": {
+        "essays_source_exclusive_check": {
+          "name": "essays_source_exclusive_check",
+          "value": "NOT ((book_id IS NOT NULL) AND (content_source_id IS NOT NULL))"
+        },
+        "essays_frozen_book_points_check": {
+          "name": "essays_frozen_book_points_check",
+          "value": "(frozen_book_points IS NULL) OR ((frozen_book_points >= (0)::numeric) AND (frozen_book_points <= (3)::numeric))"
+        }
+      },
+      "isRLSEnabled": true
+    },
+    "public.feedback": {
+      "name": "feedback",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "author_profile_id": {
+          "name": "author_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "resolved_at": {
+          "name": "resolved_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_by_profile_id": {
+          "name": "created_by_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_by_profile_id": {
+          "name": "updated_by_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "feedback_active_created_idx": {
+          "name": "feedback_active_created_idx",
+          "columns": [
+            {
+              "expression": "resolved_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "timestamptz_ops"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "first",
+              "opclass": "timestamptz_ops"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "feedback_author_idx": {
+          "name": "feedback_author_idx",
+          "columns": [
+            {
+              "expression": "author_profile_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "uuid_ops"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "feedback_author_profile_id_fkey": {
+          "name": "feedback_author_profile_id_fkey",
+          "tableFrom": "feedback",
+          "columnsFrom": [
+            "author_profile_id"
+          ],
+          "tableTo": "profiles",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        },
+        "feedback_created_by_profile_id_fkey": {
+          "name": "feedback_created_by_profile_id_fkey",
+          "tableFrom": "feedback",
+          "columnsFrom": [
+            "created_by_profile_id"
+          ],
+          "tableTo": "profiles",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "restrict"
+        },
+        "feedback_updated_by_profile_id_fkey": {
+          "name": "feedback_updated_by_profile_id_fkey",
+          "tableFrom": "feedback",
+          "columnsFrom": [
+            "updated_by_profile_id"
+          ],
+          "tableTo": "profiles",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "restrict"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {
+        "Authenticated users can view feedback": {
+          "name": "Authenticated users can view feedback",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": [
+            "authenticated"
+          ],
+          "using": "true"
+        },
+        "Authenticated users can create feedback": {
+          "name": "Authenticated users can create feedback",
+          "as": "PERMISSIVE",
+          "for": "INSERT",
+          "to": [
+            "authenticated"
+          ],
+          "withCheck": "(author_profile_id = current_profile_id())"
+        },
+        "Admins can update feedback": {
+          "name": "Admins can update feedback",
+          "as": "PERMISSIVE",
+          "for": "UPDATE",
+          "to": [
+            "authenticated"
+          ],
+          "using": "is_admin()",
+          "withCheck": "is_admin()"
+        },
+        "Authors and admins can delete feedback": {
+          "name": "Authors and admins can delete feedback",
+          "as": "PERMISSIVE",
+          "for": "DELETE",
+          "to": [
+            "authenticated"
+          ],
+          "using": "((author_profile_id = current_profile_id()) OR is_admin())"
+        }
+      },
+      "checkConstraints": {
+        "feedback_body_check": {
+          "name": "feedback_body_check",
+          "value": "(char_length(body) >= 1) AND (char_length(body) <= 4000)"
+        }
+      },
+      "isRLSEnabled": true
+    },
+    "public.individual_coaching_sessions": {
+      "name": "individual_coaching_sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "profile_id": {
+          "name": "profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "session_at": {
+          "name": "session_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "coach_profile_id": {
+          "name": "coach_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "external_coach_name": {
+          "name": "external_coach_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "key_takeaways": {
+          "name": "key_takeaways",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "action_steps": {
+          "name": "action_steps",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "removed_at": {
+          "name": "removed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_by_profile_id": {
+          "name": "created_by_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_by_profile_id": {
+          "name": "updated_by_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "individual_coaching_sessions_profile_idx": {
+          "name": "individual_coaching_sessions_profile_idx",
+          "columns": [
+            {
+              "expression": "profile_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "uuid_ops"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "individual_coaching_sessions_coach_idx": {
+          "name": "individual_coaching_sessions_coach_idx",
+          "columns": [
+            {
+              "expression": "coach_profile_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "uuid_ops"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "individual_coaching_sessions_created_desc_idx": {
+          "name": "individual_coaching_sessions_created_desc_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "first",
+              "opclass": "timestamptz_ops"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "individual_coaching_sessions_profile_id_fkey": {
+          "name": "individual_coaching_sessions_profile_id_fkey",
+          "tableFrom": "individual_coaching_sessions",
+          "columnsFrom": [
+            "profile_id"
+          ],
+          "tableTo": "profiles",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        },
+        "individual_coaching_sessions_coach_profile_id_fkey": {
+          "name": "individual_coaching_sessions_coach_profile_id_fkey",
+          "tableFrom": "individual_coaching_sessions",
+          "columnsFrom": [
+            "coach_profile_id"
+          ],
+          "tableTo": "profiles",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "set null"
+        },
+        "individual_coaching_sessions_created_by_profile_id_fkey": {
+          "name": "individual_coaching_sessions_created_by_profile_id_fkey",
+          "tableFrom": "individual_coaching_sessions",
+          "columnsFrom": [
+            "created_by_profile_id"
+          ],
+          "tableTo": "profiles",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "restrict"
+        },
+        "individual_coaching_sessions_updated_by_profile_id_fkey": {
+          "name": "individual_coaching_sessions_updated_by_profile_id_fkey",
+          "tableFrom": "individual_coaching_sessions",
+          "columnsFrom": [
+            "updated_by_profile_id"
+          ],
+          "tableTo": "profiles",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "restrict"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {
+        "Users can view their own coaching sessions": {
+          "name": "Users can view their own coaching sessions",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": [
+            "authenticated"
+          ],
+          "using": "(profile_id = current_profile_id())"
+        },
+        "Users can create their own coaching sessions": {
+          "name": "Users can create their own coaching sessions",
+          "as": "PERMISSIVE",
+          "for": "INSERT",
+          "to": [
+            "authenticated"
+          ],
+          "withCheck": "(profile_id = current_profile_id())"
+        },
+        "Users can update their own coaching sessions": {
+          "name": "Users can update their own coaching sessions",
+          "as": "PERMISSIVE",
+          "for": "UPDATE",
+          "to": [
+            "authenticated"
+          ],
+          "using": "(profile_id = current_profile_id())",
+          "withCheck": "(profile_id = current_profile_id())"
+        },
+        "Users can delete their own coaching sessions": {
+          "name": "Users can delete their own coaching sessions",
+          "as": "PERMISSIVE",
+          "for": "DELETE",
+          "to": [
+            "authenticated"
+          ],
+          "using": "(profile_id = current_profile_id())"
+        }
+      },
+      "checkConstraints": {
+        "individual_coaching_sessions_coach_xor": {
+          "name": "individual_coaching_sessions_coach_xor",
+          "value": "(coach_profile_id IS NOT NULL) <> (external_coach_name IS NOT NULL)"
+        }
+      },
+      "isRLSEnabled": true
+    },
+    "public.notification_preferences": {
+      "name": "notification_preferences",
+      "schema": "",
+      "columns": {
+        "profile_id": {
+          "name": "profile_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "essay_coach_read_email": {
+          "name": "essay_coach_read_email",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "essay_comment_email": {
+          "name": "essay_comment_email",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "essay_vote_email": {
+          "name": "essay_vote_email",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "book_submitted_email": {
+          "name": "book_submitted_email",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_by_profile_id": {
+          "name": "created_by_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_by_profile_id": {
+          "name": "updated_by_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "notification_preferences_profile_id_fkey": {
+          "name": "notification_preferences_profile_id_fkey",
+          "tableFrom": "notification_preferences",
+          "columnsFrom": [
+            "profile_id"
+          ],
+          "tableTo": "profiles",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        },
+        "notification_preferences_created_by_profile_id_fkey": {
+          "name": "notification_preferences_created_by_profile_id_fkey",
+          "tableFrom": "notification_preferences",
+          "columnsFrom": [
+            "created_by_profile_id"
+          ],
+          "tableTo": "profiles",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "restrict"
+        },
+        "notification_preferences_updated_by_profile_id_fkey": {
+          "name": "notification_preferences_updated_by_profile_id_fkey",
+          "tableFrom": "notification_preferences",
+          "columnsFrom": [
+            "updated_by_profile_id"
+          ],
+          "tableTo": "profiles",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "restrict"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {
+        "Users can view their own notification preferences": {
+          "name": "Users can view their own notification preferences",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": [
+            "authenticated"
+          ],
+          "using": "(profile_id = current_profile_id())"
+        },
+        "Users can insert their own notification preferences": {
+          "name": "Users can insert their own notification preferences",
+          "as": "PERMISSIVE",
+          "for": "INSERT",
+          "to": [
+            "authenticated"
+          ],
+          "withCheck": "(profile_id = current_profile_id())"
+        },
+        "Users can update their own notification preferences": {
+          "name": "Users can update their own notification preferences",
+          "as": "PERMISSIVE",
+          "for": "UPDATE",
+          "to": [
+            "authenticated"
+          ],
+          "using": "(profile_id = current_profile_id())",
+          "withCheck": "(profile_id = current_profile_id())"
+        }
+      },
+      "checkConstraints": {},
+      "isRLSEnabled": true
+    },
+    "public.personality_tests": {
+      "name": "personality_tests",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "profile_id": {
+          "name": "profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "test_type": {
+          "name": "test_type",
+          "type": "personality_test_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "test_type_other": {
+          "name": "test_type_other",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tested_on": {
+          "name": "tested_on",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "file_path": {
+          "name": "file_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "file_name": {
+          "name": "file_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "file_size": {
+          "name": "file_size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "removed_at": {
+          "name": "removed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_by_profile_id": {
+          "name": "created_by_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_by_profile_id": {
+          "name": "updated_by_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "personality_tests_profile_tested_on_idx": {
+          "name": "personality_tests_profile_tested_on_idx",
+          "columns": [
+            {
+              "expression": "profile_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "uuid_ops"
+            },
+            {
+              "expression": "tested_on",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "date_ops"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "personality_tests_profile_id_fkey": {
+          "name": "personality_tests_profile_id_fkey",
+          "tableFrom": "personality_tests",
+          "columnsFrom": [
+            "profile_id"
+          ],
+          "tableTo": "profiles",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        },
+        "personality_tests_created_by_profile_id_fkey": {
+          "name": "personality_tests_created_by_profile_id_fkey",
+          "tableFrom": "personality_tests",
+          "columnsFrom": [
+            "created_by_profile_id"
+          ],
+          "tableTo": "profiles",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "restrict"
+        },
+        "personality_tests_updated_by_profile_id_fkey": {
+          "name": "personality_tests_updated_by_profile_id_fkey",
+          "tableFrom": "personality_tests",
+          "columnsFrom": [
+            "updated_by_profile_id"
+          ],
+          "tableTo": "profiles",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "restrict"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {
+        "Verified users can view personality tests": {
+          "name": "Verified users can view personality tests",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": [
+            "authenticated"
+          ],
+          "using": "(EXISTS (SELECT 1 FROM users WHERE (users.auth_user_id = (SELECT auth.uid()) AND users.verified_work_email IS NOT NULL)))"
+        },
+        "Users can create their own personality tests": {
+          "name": "Users can create their own personality tests",
+          "as": "PERMISSIVE",
+          "for": "INSERT",
+          "to": [
+            "authenticated"
+          ],
+          "withCheck": "(profile_id = current_profile_id())"
+        },
+        "Users can update their own personality tests": {
+          "name": "Users can update their own personality tests",
+          "as": "PERMISSIVE",
+          "for": "UPDATE",
+          "to": [
+            "authenticated"
+          ],
+          "using": "(profile_id = current_profile_id())",
+          "withCheck": "(profile_id = current_profile_id())"
+        },
+        "Users can delete their own personality tests": {
+          "name": "Users can delete their own personality tests",
+          "as": "PERMISSIVE",
+          "for": "DELETE",
+          "to": [
+            "authenticated"
+          ],
+          "using": "(profile_id = current_profile_id())"
+        }
+      },
+      "checkConstraints": {
+        "personality_tests_other_type_required": {
+          "name": "personality_tests_other_type_required",
+          "value": "(test_type <> 'other' OR (test_type_other IS NOT NULL AND length(trim(test_type_other)) > 0))"
+        }
+      },
+      "isRLSEnabled": true
+    },
+    "public.profiles": {
+      "name": "profiles",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "picture": {
+          "name": "picture",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "work_email": {
+          "name": "work_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "profile_role",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'student'"
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "phone_number": {
+          "name": "phone_number",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "personal_email": {
+          "name": "personal_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "date_of_birth": {
+          "name": "date_of_birth",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_removed_at": {
+          "name": "access_removed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_removed_by_profile_id": {
+          "name": "access_removed_by_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "beta_access_granted_at": {
+          "name": "beta_access_granted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "beta_cohort": {
+          "name": "beta_cohort",
+          "type": "beta_cohort",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'A'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_by_profile_id": {
+          "name": "created_by_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_by_profile_id": {
+          "name": "updated_by_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "profiles_team_id_idx": {
+          "name": "profiles_team_id_idx",
+          "columns": [
+            {
+              "expression": "team_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "uuid_ops"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "profiles_team_id_user_id_idx": {
+          "name": "profiles_team_id_user_id_idx",
+          "columns": [
+            {
+              "expression": "team_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "uuid_ops"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "uuid_ops"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "profiles_user_id_idx": {
+          "name": "profiles_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "uuid_ops"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "profiles_work_email_idx": {
+          "name": "profiles_work_email_idx",
+          "columns": [
+            {
+              "expression": "work_email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "text_ops"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "profiles_user_id_fkey": {
+          "name": "profiles_user_id_fkey",
+          "tableFrom": "profiles",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "tableTo": "users",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "set null"
+        },
+        "profiles_team_id_fkey": {
+          "name": "profiles_team_id_fkey",
+          "tableFrom": "profiles",
+          "columnsFrom": [
+            "team_id"
+          ],
+          "tableTo": "teams",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "set null"
+        },
+        "profiles_access_removed_by_profile_id_fkey": {
+          "name": "profiles_access_removed_by_profile_id_fkey",
+          "tableFrom": "profiles",
+          "columnsFrom": [
+            "access_removed_by_profile_id"
+          ],
+          "tableTo": "profiles",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "set null"
+        },
+        "profiles_created_by_profile_id_fkey": {
+          "name": "profiles_created_by_profile_id_fkey",
+          "tableFrom": "profiles",
+          "columnsFrom": [
+            "created_by_profile_id"
+          ],
+          "tableTo": "profiles",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "set null"
+        },
+        "profiles_updated_by_profile_id_fkey": {
+          "name": "profiles_updated_by_profile_id_fkey",
+          "tableFrom": "profiles",
+          "columnsFrom": [
+            "updated_by_profile_id"
+          ],
+          "tableTo": "profiles",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "set null"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "profiles_user_id_key": {
+          "name": "profiles_user_id_key",
+          "columns": [
+            "user_id"
+          ],
+          "nullsNotDistinct": false
+        },
+        "profiles_work_email_key": {
+          "name": "profiles_work_email_key",
+          "columns": [
+            "work_email"
+          ],
+          "nullsNotDistinct": false
+        }
+      },
+      "policies": {
+        "Verified users can view all profiles": {
+          "name": "Verified users can view all profiles",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": [
+            "authenticated"
+          ],
+          "using": "((access_removed_at IS NULL) AND (EXISTS ( SELECT 1\n   FROM users\n  WHERE ((users.auth_user_id = ( SELECT auth.uid() AS uid)) AND (users.verified_work_email IS NOT NULL)))))"
+        },
+        "Users can update their own profile picture": {
+          "name": "Users can update their own profile picture",
+          "as": "PERMISSIVE",
+          "for": "UPDATE",
+          "to": [
+            "authenticated"
+          ],
+          "using": "(user_id IN ( SELECT users.id\n   FROM users\n  WHERE (users.auth_user_id = ( SELECT auth.uid() AS uid))))",
+          "withCheck": "(user_id IN ( SELECT users.id\n   FROM users\n  WHERE (users.auth_user_id = ( SELECT auth.uid() AS uid))))"
+        }
+      },
+      "checkConstraints": {
+        "valid_czu_domain": {
+          "name": "valid_czu_domain",
+          "value": "(lower(split_part(work_email, '@'::text, 2)) = ANY (ARRAY['pef.czu.cz'::text, 'studenti.czu.cz'::text, 'rektorat.czu.cz'::text]))"
+        }
+      },
+      "isRLSEnabled": true
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "auth_user_id": {
+          "name": "auth_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "google_email": {
+          "name": "google_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "suggested_work_email": {
+          "name": "suggested_work_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "verified_work_email": {
+          "name": "verified_work_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "verified_work_email_at": {
+          "name": "verified_work_email_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_otp_sent_at": {
+          "name": "last_otp_sent_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "users_google_email_idx": {
+          "name": "users_google_email_idx",
+          "columns": [
+            {
+              "expression": "google_email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "text_ops"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "users_suggested_work_email_idx": {
+          "name": "users_suggested_work_email_idx",
+          "columns": [
+            {
+              "expression": "suggested_work_email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "text_ops"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "users_auth_user_id_fkey": {
+          "name": "users_auth_user_id_fkey",
+          "tableFrom": "users",
+          "columnsFrom": [
+            "auth_user_id"
+          ],
+          "tableTo": "users",
+          "schemaTo": "auth",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_auth_user_id_key": {
+          "name": "users_auth_user_id_key",
+          "columns": [
+            "auth_user_id"
+          ],
+          "nullsNotDistinct": false
+        },
+        "users_google_email_key": {
+          "name": "users_google_email_key",
+          "columns": [
+            "google_email"
+          ],
+          "nullsNotDistinct": false
+        }
+      },
+      "policies": {
+        "Users can update only suggested_work_email": {
+          "name": "Users can update only suggested_work_email",
+          "as": "PERMISSIVE",
+          "for": "UPDATE",
+          "to": [
+            "authenticated"
+          ],
+          "using": "(( SELECT auth.uid() AS uid) = auth_user_id)",
+          "withCheck": "(( SELECT auth.uid() AS uid) = auth_user_id)"
+        },
+        "Users can insert their own user record": {
+          "name": "Users can insert their own user record",
+          "as": "PERMISSIVE",
+          "for": "INSERT",
+          "to": [
+            "authenticated"
+          ],
+          "withCheck": "(( SELECT auth.uid() AS uid) = auth_user_id)"
+        },
+        "Users can view their own user record": {
+          "name": "Users can view their own user record",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": [
+            "authenticated"
+          ],
+          "using": "(( SELECT auth.uid() AS uid) = auth_user_id)"
+        }
+      },
+      "checkConstraints": {},
+      "isRLSEnabled": true
+    },
+    "public.recurring_schedules": {
+      "name": "recurring_schedules",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "room_id": {
+          "name": "room_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "schedule_type": {
+          "name": "schedule_type",
+          "type": "schedule_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "day_of_week": {
+          "name": "day_of_week",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "start_time": {
+          "name": "start_time",
+          "type": "time",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "end_time": {
+          "name": "end_time",
+          "type": "time",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "valid_from": {
+          "name": "valid_from",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "valid_until": {
+          "name": "valid_until",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "removed_at": {
+          "name": "removed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_by_profile_id": {
+          "name": "created_by_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_by_profile_id": {
+          "name": "updated_by_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "idx_recurring_schedules_day": {
+          "name": "idx_recurring_schedules_day",
+          "columns": [
+            {
+              "expression": "day_of_week",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "int2_ops"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "idx_recurring_schedules_room": {
+          "name": "idx_recurring_schedules_room",
+          "columns": [
+            {
+              "expression": "room_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "uuid_ops"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "idx_recurring_schedules_team": {
+          "name": "idx_recurring_schedules_team",
+          "columns": [
+            {
+              "expression": "team_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "uuid_ops"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "idx_recurring_schedules_type": {
+          "name": "idx_recurring_schedules_type",
+          "columns": [
+            {
+              "expression": "schedule_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "enum_ops"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "idx_recurring_schedules_valid": {
+          "name": "idx_recurring_schedules_valid",
+          "columns": [
+            {
+              "expression": "valid_from",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "date_ops"
+            },
+            {
+              "expression": "valid_until",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "date_ops"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "recurring_schedules_room_id_fkey": {
+          "name": "recurring_schedules_room_id_fkey",
+          "tableFrom": "recurring_schedules",
+          "columnsFrom": [
+            "room_id"
+          ],
+          "tableTo": "rooms",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        },
+        "recurring_schedules_team_id_fkey": {
+          "name": "recurring_schedules_team_id_fkey",
+          "tableFrom": "recurring_schedules",
+          "columnsFrom": [
+            "team_id"
+          ],
+          "tableTo": "teams",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        },
+        "recurring_schedules_created_by_profile_id_fkey": {
+          "name": "recurring_schedules_created_by_profile_id_fkey",
+          "tableFrom": "recurring_schedules",
+          "columnsFrom": [
+            "created_by_profile_id"
+          ],
+          "tableTo": "profiles",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "restrict"
+        },
+        "recurring_schedules_updated_by_profile_id_fkey": {
+          "name": "recurring_schedules_updated_by_profile_id_fkey",
+          "tableFrom": "recurring_schedules",
+          "columnsFrom": [
+            "updated_by_profile_id"
+          ],
+          "tableTo": "profiles",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "restrict"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {
+        "Coaches can manage recurring_schedules": {
+          "name": "Coaches can manage recurring_schedules",
+          "as": "PERMISSIVE",
+          "for": "ALL",
+          "to": [
+            "authenticated"
+          ],
+          "using": "(EXISTS ( SELECT 1\n   FROM profiles\n  WHERE ((profiles.user_id IN ( SELECT users.id\n           FROM users\n          WHERE (users.auth_user_id = ( SELECT auth.uid() AS uid)))) AND (profiles.role = ANY (ARRAY['coach'::profile_role, 'admin'::profile_role])))))",
+          "withCheck": "(EXISTS ( SELECT 1\n   FROM profiles\n  WHERE ((profiles.user_id IN ( SELECT users.id\n           FROM users\n          WHERE (users.auth_user_id = ( SELECT auth.uid() AS uid)))) AND (profiles.role = ANY (ARRAY['coach'::profile_role, 'admin'::profile_role])))))"
+        },
+        "Authenticated can read recurring_schedules": {
+          "name": "Authenticated can read recurring_schedules",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": [
+            "authenticated"
+          ],
+          "using": "true"
+        }
+      },
+      "checkConstraints": {
+        "recurring_schedules_day_of_week_check": {
+          "name": "recurring_schedules_day_of_week_check",
+          "value": "(day_of_week >= 0) AND (day_of_week <= 6)"
+        },
+        "valid_time_range": {
+          "name": "valid_time_range",
+          "value": "end_time > start_time"
+        },
+        "valid_schedule_dates": {
+          "name": "valid_schedule_dates",
+          "value": "(valid_until IS NULL) OR (valid_until >= valid_from)"
+        },
+        "recurring_schedules_team_for_ts": {
+          "name": "recurring_schedules_team_for_ts",
+          "value": "(schedule_type <> 'training_session'::schedule_type) OR (team_id IS NOT NULL)"
+        }
+      },
+      "isRLSEnabled": true
+    },
+    "public.reservations": {
+      "name": "reservations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "room_id": {
+          "name": "room_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "owner_profile_id": {
+          "name": "owner_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "person_count": {
+          "name": "person_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "start_at": {
+          "name": "start_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "end_at": {
+          "name": "end_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cancelled_at": {
+          "name": "cancelled_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cancelled_by_profile_id": {
+          "name": "cancelled_by_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_by_profile_id": {
+          "name": "created_by_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_by_profile_id": {
+          "name": "updated_by_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "idx_reservations_room_time": {
+          "name": "idx_reservations_room_time",
+          "columns": [
+            {
+              "expression": "room_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "uuid_ops"
+            },
+            {
+              "expression": "start_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "timestamptz_ops"
+            },
+            {
+              "expression": "end_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "timestamptz_ops"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "idx_reservations_start": {
+          "name": "idx_reservations_start",
+          "columns": [
+            {
+              "expression": "start_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "timestamptz_ops"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "idx_reservations_owner": {
+          "name": "idx_reservations_owner",
+          "columns": [
+            {
+              "expression": "owner_profile_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "uuid_ops"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "reservations_room_id_fkey": {
+          "name": "reservations_room_id_fkey",
+          "tableFrom": "reservations",
+          "columnsFrom": [
+            "room_id"
+          ],
+          "tableTo": "rooms",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        },
+        "reservations_owner_profile_id_fkey": {
+          "name": "reservations_owner_profile_id_fkey",
+          "tableFrom": "reservations",
+          "columnsFrom": [
+            "owner_profile_id"
+          ],
+          "tableTo": "profiles",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "set null"
+        },
+        "reservations_cancelled_by_profile_id_fkey": {
+          "name": "reservations_cancelled_by_profile_id_fkey",
+          "tableFrom": "reservations",
+          "columnsFrom": [
+            "cancelled_by_profile_id"
+          ],
+          "tableTo": "profiles",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "set null"
+        },
+        "reservations_created_by_profile_id_fkey": {
+          "name": "reservations_created_by_profile_id_fkey",
+          "tableFrom": "reservations",
+          "columnsFrom": [
+            "created_by_profile_id"
+          ],
+          "tableTo": "profiles",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "restrict"
+        },
+        "reservations_updated_by_profile_id_fkey": {
+          "name": "reservations_updated_by_profile_id_fkey",
+          "tableFrom": "reservations",
+          "columnsFrom": [
+            "updated_by_profile_id"
+          ],
+          "tableTo": "profiles",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "restrict"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {
+        "Authenticated can read reservations": {
+          "name": "Authenticated can read reservations",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": [
+            "authenticated"
+          ],
+          "using": "true"
+        },
+        "Users can delete own reservations": {
+          "name": "Users can delete own reservations",
+          "as": "PERMISSIVE",
+          "for": "DELETE",
+          "to": [
+            "authenticated"
+          ],
+          "using": "(owner_profile_id IN ( SELECT profiles.id\n   FROM profiles\n  WHERE (profiles.user_id IN ( SELECT users.id\n           FROM users\n          WHERE (users.auth_user_id = ( SELECT auth.uid() AS uid))))))"
+        },
+        "Users can update own reservations": {
+          "name": "Users can update own reservations",
+          "as": "PERMISSIVE",
+          "for": "UPDATE",
+          "to": [
+            "authenticated"
+          ],
+          "using": "(owner_profile_id IN ( SELECT profiles.id\n   FROM profiles\n  WHERE (profiles.user_id IN ( SELECT users.id\n           FROM users\n          WHERE (users.auth_user_id = ( SELECT auth.uid() AS uid))))))",
+          "withCheck": "(owner_profile_id IN ( SELECT profiles.id\n   FROM profiles\n  WHERE (profiles.user_id IN ( SELECT users.id\n           FROM users\n          WHERE (users.auth_user_id = ( SELECT auth.uid() AS uid))))))"
+        },
+        "Users can create own reservations": {
+          "name": "Users can create own reservations",
+          "as": "PERMISSIVE",
+          "for": "INSERT",
+          "to": [
+            "authenticated"
+          ],
+          "withCheck": "(owner_profile_id IN ( SELECT profiles.id\n   FROM profiles\n  WHERE (profiles.user_id IN ( SELECT users.id\n           FROM users\n          WHERE (users.auth_user_id = ( SELECT auth.uid() AS uid))))))"
+        }
+      },
+      "checkConstraints": {
+        "valid_reservation_time": {
+          "name": "valid_reservation_time",
+          "value": "end_at > start_at"
+        }
+      },
+      "isRLSEnabled": true
+    },
+    "public.rooms": {
+      "name": "rooms",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "code": {
+          "name": "code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "available_days": {
+          "name": "available_days",
+          "type": "integer[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "can_have_ts": {
+          "name": "can_have_ts",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "removed_at": {
+          "name": "removed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_by_profile_id": {
+          "name": "created_by_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_by_profile_id": {
+          "name": "updated_by_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "idx_rooms_code": {
+          "name": "idx_rooms_code",
+          "columns": [
+            {
+              "expression": "code",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "text_ops"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "rooms_created_by_profile_id_fkey": {
+          "name": "rooms_created_by_profile_id_fkey",
+          "tableFrom": "rooms",
+          "columnsFrom": [
+            "created_by_profile_id"
+          ],
+          "tableTo": "profiles",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "restrict"
+        },
+        "rooms_updated_by_profile_id_fkey": {
+          "name": "rooms_updated_by_profile_id_fkey",
+          "tableFrom": "rooms",
+          "columnsFrom": [
+            "updated_by_profile_id"
+          ],
+          "tableTo": "profiles",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "restrict"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "rooms_code_key": {
+          "name": "rooms_code_key",
+          "columns": [
+            "code"
+          ],
+          "nullsNotDistinct": false
+        }
+      },
+      "policies": {
+        "Admins can manage rooms": {
+          "name": "Admins can manage rooms",
+          "as": "PERMISSIVE",
+          "for": "ALL",
+          "to": [
+            "authenticated"
+          ],
+          "using": "(EXISTS ( SELECT 1\n   FROM profiles\n  WHERE ((profiles.user_id IN ( SELECT users.id\n           FROM users\n          WHERE (users.auth_user_id = ( SELECT auth.uid() AS uid)))) AND (profiles.role = 'admin'::profile_role))))",
+          "withCheck": "(EXISTS ( SELECT 1\n   FROM profiles\n  WHERE ((profiles.user_id IN ( SELECT users.id\n           FROM users\n          WHERE (users.auth_user_id = ( SELECT auth.uid() AS uid)))) AND (profiles.role = 'admin'::profile_role))))"
+        },
+        "Authenticated can read rooms": {
+          "name": "Authenticated can read rooms",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": [
+            "authenticated"
+          ],
+          "using": "true"
+        }
+      },
+      "checkConstraints": {},
+      "isRLSEnabled": true
+    },
+    "public.schedule_breaks": {
+      "name": "schedule_breaks",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "start_date": {
+          "name": "start_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "end_date": {
+          "name": "end_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_by_profile_id": {
+          "name": "created_by_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_by_profile_id": {
+          "name": "updated_by_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "idx_schedule_breaks_dates": {
+          "name": "idx_schedule_breaks_dates",
+          "columns": [
+            {
+              "expression": "start_date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "date_ops"
+            },
+            {
+              "expression": "end_date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "date_ops"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "schedule_breaks_created_by_profile_id_fkey": {
+          "name": "schedule_breaks_created_by_profile_id_fkey",
+          "tableFrom": "schedule_breaks",
+          "columnsFrom": [
+            "created_by_profile_id"
+          ],
+          "tableTo": "profiles",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "restrict"
+        },
+        "schedule_breaks_updated_by_profile_id_fkey": {
+          "name": "schedule_breaks_updated_by_profile_id_fkey",
+          "tableFrom": "schedule_breaks",
+          "columnsFrom": [
+            "updated_by_profile_id"
+          ],
+          "tableTo": "profiles",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "restrict"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {
+        "Coaches can manage schedule_breaks": {
+          "name": "Coaches can manage schedule_breaks",
+          "as": "PERMISSIVE",
+          "for": "ALL",
+          "to": [
+            "authenticated"
+          ],
+          "using": "(EXISTS ( SELECT 1\n   FROM profiles\n  WHERE ((profiles.user_id IN ( SELECT users.id\n           FROM users\n          WHERE (users.auth_user_id = ( SELECT auth.uid() AS uid)))) AND (profiles.role = ANY (ARRAY['coach'::profile_role, 'admin'::profile_role])))))",
+          "withCheck": "(EXISTS ( SELECT 1\n   FROM profiles\n  WHERE ((profiles.user_id IN ( SELECT users.id\n           FROM users\n          WHERE (users.auth_user_id = ( SELECT auth.uid() AS uid)))) AND (profiles.role = ANY (ARRAY['coach'::profile_role, 'admin'::profile_role])))))"
+        },
+        "Authenticated can read schedule_breaks": {
+          "name": "Authenticated can read schedule_breaks",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": [
+            "authenticated"
+          ],
+          "using": "true"
+        }
+      },
+      "checkConstraints": {
+        "valid_break_date_range": {
+          "name": "valid_break_date_range",
+          "value": "end_date >= start_date"
+        }
+      },
+      "isRLSEnabled": true
+    },
+    "public.team_activities": {
+      "name": "team_activities",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "occurred_at": {
+          "name": "occurred_at",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "activity_type": {
+          "name": "activity_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "participants": {
+          "name": "participants",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reflection": {
+          "name": "reflection",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "image_path": {
+          "name": "image_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "removed_at": {
+          "name": "removed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_by_profile_id": {
+          "name": "created_by_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_by_profile_id": {
+          "name": "updated_by_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "team_activities_team_occurred_at_idx": {
+          "name": "team_activities_team_occurred_at_idx",
+          "columns": [
+            {
+              "expression": "team_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "uuid_ops"
+            },
+            {
+              "expression": "occurred_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "date_ops"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "team_activities_team_id_fkey": {
+          "name": "team_activities_team_id_fkey",
+          "tableFrom": "team_activities",
+          "columnsFrom": [
+            "team_id"
+          ],
+          "tableTo": "teams",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        },
+        "team_activities_created_by_profile_id_fkey": {
+          "name": "team_activities_created_by_profile_id_fkey",
+          "tableFrom": "team_activities",
+          "columnsFrom": [
+            "created_by_profile_id"
+          ],
+          "tableTo": "profiles",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "restrict"
+        },
+        "team_activities_updated_by_profile_id_fkey": {
+          "name": "team_activities_updated_by_profile_id_fkey",
+          "tableFrom": "team_activities",
+          "columnsFrom": [
+            "updated_by_profile_id"
+          ],
+          "tableTo": "profiles",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "restrict"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {
+        "Team members can view activities": {
+          "name": "Team members can view activities",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": [
+            "authenticated"
+          ],
+          "using": "team_id IN (SELECT team_id FROM profiles WHERE id = current_profile_id() AND access_removed_at IS NULL)"
+        },
+        "Team members can create activities": {
+          "name": "Team members can create activities",
+          "as": "PERMISSIVE",
+          "for": "INSERT",
+          "to": [
+            "authenticated"
+          ],
+          "withCheck": "team_id IN (SELECT team_id FROM profiles WHERE id = current_profile_id() AND access_removed_at IS NULL)"
+        },
+        "Team members can update activities": {
+          "name": "Team members can update activities",
+          "as": "PERMISSIVE",
+          "for": "UPDATE",
+          "to": [
+            "authenticated"
+          ],
+          "using": "team_id IN (SELECT team_id FROM profiles WHERE id = current_profile_id() AND access_removed_at IS NULL)",
+          "withCheck": "team_id IN (SELECT team_id FROM profiles WHERE id = current_profile_id() AND access_removed_at IS NULL)"
+        },
+        "Team members can delete activities": {
+          "name": "Team members can delete activities",
+          "as": "PERMISSIVE",
+          "for": "DELETE",
+          "to": [
+            "authenticated"
+          ],
+          "using": "team_id IN (SELECT team_id FROM profiles WHERE id = current_profile_id() AND access_removed_at IS NULL)"
+        }
+      },
+      "checkConstraints": {},
+      "isRLSEnabled": true
+    },
+    "public.team_activity_attendees": {
+      "name": "team_activity_attendees",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "activity_id": {
+          "name": "activity_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "profile_id": {
+          "name": "profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "attendance_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'present'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_by_profile_id": {
+          "name": "created_by_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_by_profile_id": {
+          "name": "updated_by_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "team_activity_attendees_activity_idx": {
+          "name": "team_activity_attendees_activity_idx",
+          "columns": [
+            {
+              "expression": "activity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "uuid_ops"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "team_activity_attendees_profile_idx": {
+          "name": "team_activity_attendees_profile_idx",
+          "columns": [
+            {
+              "expression": "profile_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "uuid_ops"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "team_activity_attendees_activity_id_fkey": {
+          "name": "team_activity_attendees_activity_id_fkey",
+          "tableFrom": "team_activity_attendees",
+          "columnsFrom": [
+            "activity_id"
+          ],
+          "tableTo": "team_activities",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        },
+        "team_activity_attendees_profile_id_fkey": {
+          "name": "team_activity_attendees_profile_id_fkey",
+          "tableFrom": "team_activity_attendees",
+          "columnsFrom": [
+            "profile_id"
+          ],
+          "tableTo": "profiles",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        },
+        "team_activity_attendees_created_by_profile_id_fkey": {
+          "name": "team_activity_attendees_created_by_profile_id_fkey",
+          "tableFrom": "team_activity_attendees",
+          "columnsFrom": [
+            "created_by_profile_id"
+          ],
+          "tableTo": "profiles",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "restrict"
+        },
+        "team_activity_attendees_updated_by_profile_id_fkey": {
+          "name": "team_activity_attendees_updated_by_profile_id_fkey",
+          "tableFrom": "team_activity_attendees",
+          "columnsFrom": [
+            "updated_by_profile_id"
+          ],
+          "tableTo": "profiles",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "restrict"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "team_activity_attendees_activity_profile_key": {
+          "name": "team_activity_attendees_activity_profile_key",
+          "columns": [
+            "activity_id",
+            "profile_id"
+          ],
+          "nullsNotDistinct": false
+        }
+      },
+      "policies": {
+        "Team members can view activity attendees": {
+          "name": "Team members can view activity attendees",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": [
+            "authenticated"
+          ],
+          "using": "activity_id IN (SELECT id FROM team_activities WHERE team_id IN (SELECT team_id FROM profiles WHERE id = current_profile_id() AND access_removed_at IS NULL))"
+        },
+        "Team members can create activity attendees": {
+          "name": "Team members can create activity attendees",
+          "as": "PERMISSIVE",
+          "for": "INSERT",
+          "to": [
+            "authenticated"
+          ],
+          "withCheck": "activity_id IN (SELECT id FROM team_activities WHERE team_id IN (SELECT team_id FROM profiles WHERE id = current_profile_id() AND access_removed_at IS NULL))"
+        },
+        "Team members can update activity attendees": {
+          "name": "Team members can update activity attendees",
+          "as": "PERMISSIVE",
+          "for": "UPDATE",
+          "to": [
+            "authenticated"
+          ],
+          "using": "activity_id IN (SELECT id FROM team_activities WHERE team_id IN (SELECT team_id FROM profiles WHERE id = current_profile_id() AND access_removed_at IS NULL))",
+          "withCheck": "activity_id IN (SELECT id FROM team_activities WHERE team_id IN (SELECT team_id FROM profiles WHERE id = current_profile_id() AND access_removed_at IS NULL))"
+        },
+        "Team members can delete activity attendees": {
+          "name": "Team members can delete activity attendees",
+          "as": "PERMISSIVE",
+          "for": "DELETE",
+          "to": [
+            "authenticated"
+          ],
+          "using": "activity_id IN (SELECT id FROM team_activities WHERE team_id IN (SELECT team_id FROM profiles WHERE id = current_profile_id() AND access_removed_at IS NULL))"
+        }
+      },
+      "checkConstraints": {},
+      "isRLSEnabled": true
+    },
+    "public.team_annual_reflection_entries": {
+      "name": "team_annual_reflection_entries",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "annual_reflection_id": {
+          "name": "annual_reflection_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "topic": {
+          "name": "topic",
+          "type": "annual_reflection_topic",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "what_went_well": {
+          "name": "what_went_well",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "what_didnt_go_well": {
+          "name": "what_didnt_go_well",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "what_next_time": {
+          "name": "what_next_time",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_by_profile_id": {
+          "name": "updated_by_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "team_annual_reflection_entries_reflection_topic_idx": {
+          "name": "team_annual_reflection_entries_reflection_topic_idx",
+          "columns": [
+            {
+              "expression": "annual_reflection_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "uuid_ops"
+            },
+            {
+              "expression": "topic",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "enum_ops"
+            }
+          ],
+          "isUnique": true,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "team_annual_reflection_entries_reflection_idx": {
+          "name": "team_annual_reflection_entries_reflection_idx",
+          "columns": [
+            {
+              "expression": "annual_reflection_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "uuid_ops"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "team_annual_reflection_entries_annual_reflection_id_fkey": {
+          "name": "team_annual_reflection_entries_annual_reflection_id_fkey",
+          "tableFrom": "team_annual_reflection_entries",
+          "columnsFrom": [
+            "annual_reflection_id"
+          ],
+          "tableTo": "team_annual_reflections",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        },
+        "team_annual_reflection_entries_updated_by_profile_id_fkey": {
+          "name": "team_annual_reflection_entries_updated_by_profile_id_fkey",
+          "tableFrom": "team_annual_reflection_entries",
+          "columnsFrom": [
+            "updated_by_profile_id"
+          ],
+          "tableTo": "profiles",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "set null"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {
+        "Team members can view annual reflection entries": {
+          "name": "Team members can view annual reflection entries",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": [
+            "authenticated"
+          ],
+          "using": "annual_reflection_id IN (SELECT id FROM team_annual_reflections WHERE team_id IN (SELECT team_id FROM profiles WHERE id = current_profile_id() AND access_removed_at IS NULL))"
+        },
+        "Team members can create annual reflection entries": {
+          "name": "Team members can create annual reflection entries",
+          "as": "PERMISSIVE",
+          "for": "INSERT",
+          "to": [
+            "authenticated"
+          ],
+          "withCheck": "annual_reflection_id IN (SELECT id FROM team_annual_reflections WHERE team_id IN (SELECT team_id FROM profiles WHERE id = current_profile_id() AND access_removed_at IS NULL))"
+        },
+        "Team members can update annual reflection entries": {
+          "name": "Team members can update annual reflection entries",
+          "as": "PERMISSIVE",
+          "for": "UPDATE",
+          "to": [
+            "authenticated"
+          ],
+          "using": "annual_reflection_id IN (SELECT id FROM team_annual_reflections WHERE team_id IN (SELECT team_id FROM profiles WHERE id = current_profile_id() AND access_removed_at IS NULL))",
+          "withCheck": "annual_reflection_id IN (SELECT id FROM team_annual_reflections WHERE team_id IN (SELECT team_id FROM profiles WHERE id = current_profile_id() AND access_removed_at IS NULL))"
+        },
+        "Team members can delete annual reflection entries": {
+          "name": "Team members can delete annual reflection entries",
+          "as": "PERMISSIVE",
+          "for": "DELETE",
+          "to": [
+            "authenticated"
+          ],
+          "using": "annual_reflection_id IN (SELECT id FROM team_annual_reflections WHERE team_id IN (SELECT team_id FROM profiles WHERE id = current_profile_id() AND access_removed_at IS NULL))"
+        }
+      },
+      "checkConstraints": {},
+      "isRLSEnabled": true
+    },
+    "public.team_annual_reflections": {
+      "name": "team_annual_reflections",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reflection_month": {
+          "name": "reflection_month",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "removed_at": {
+          "name": "removed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_by_profile_id": {
+          "name": "created_by_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_by_profile_id": {
+          "name": "updated_by_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "team_annual_reflections_team_month_idx": {
+          "name": "team_annual_reflections_team_month_idx",
+          "columns": [
+            {
+              "expression": "team_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "uuid_ops"
+            },
+            {
+              "expression": "reflection_month",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "date_ops"
+            }
+          ],
+          "isUnique": true,
+          "with": {},
+          "method": "btree",
+          "where": "(removed_at IS NULL)",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "team_annual_reflections_team_id_fkey": {
+          "name": "team_annual_reflections_team_id_fkey",
+          "tableFrom": "team_annual_reflections",
+          "columnsFrom": [
+            "team_id"
+          ],
+          "tableTo": "teams",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        },
+        "team_annual_reflections_created_by_profile_id_fkey": {
+          "name": "team_annual_reflections_created_by_profile_id_fkey",
+          "tableFrom": "team_annual_reflections",
+          "columnsFrom": [
+            "created_by_profile_id"
+          ],
+          "tableTo": "profiles",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "restrict"
+        },
+        "team_annual_reflections_updated_by_profile_id_fkey": {
+          "name": "team_annual_reflections_updated_by_profile_id_fkey",
+          "tableFrom": "team_annual_reflections",
+          "columnsFrom": [
+            "updated_by_profile_id"
+          ],
+          "tableTo": "profiles",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "restrict"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {
+        "Team members can view annual reflections": {
+          "name": "Team members can view annual reflections",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": [
+            "authenticated"
+          ],
+          "using": "team_id IN (SELECT team_id FROM profiles WHERE id = current_profile_id() AND access_removed_at IS NULL)"
+        },
+        "Team members can create annual reflections": {
+          "name": "Team members can create annual reflections",
+          "as": "PERMISSIVE",
+          "for": "INSERT",
+          "to": [
+            "authenticated"
+          ],
+          "withCheck": "team_id IN (SELECT team_id FROM profiles WHERE id = current_profile_id() AND access_removed_at IS NULL)"
+        },
+        "Team members can update annual reflections": {
+          "name": "Team members can update annual reflections",
+          "as": "PERMISSIVE",
+          "for": "UPDATE",
+          "to": [
+            "authenticated"
+          ],
+          "using": "team_id IN (SELECT team_id FROM profiles WHERE id = current_profile_id() AND access_removed_at IS NULL)",
+          "withCheck": "team_id IN (SELECT team_id FROM profiles WHERE id = current_profile_id() AND access_removed_at IS NULL)"
+        },
+        "Team members can delete annual reflections": {
+          "name": "Team members can delete annual reflections",
+          "as": "PERMISSIVE",
+          "for": "DELETE",
+          "to": [
+            "authenticated"
+          ],
+          "using": "team_id IN (SELECT team_id FROM profiles WHERE id = current_profile_id() AND access_removed_at IS NULL)"
+        }
+      },
+      "checkConstraints": {
+        "team_annual_reflections_month_check": {
+          "name": "team_annual_reflections_month_check",
+          "value": "EXTRACT(MONTH FROM reflection_month) = 5"
+        }
+      },
+      "isRLSEnabled": true
+    },
+    "public.team_document_versions": {
+      "name": "team_document_versions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "document_id": {
+          "name": "document_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "version_no": {
+          "name": "version_no",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "file_path": {
+          "name": "file_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "file_name": {
+          "name": "file_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "file_size": {
+          "name": "file_size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "effective_from": {
+          "name": "effective_from",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "change_note": {
+          "name": "change_note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_by_profile_id": {
+          "name": "created_by_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "team_document_versions_document_version_idx": {
+          "name": "team_document_versions_document_version_idx",
+          "columns": [
+            {
+              "expression": "document_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "uuid_ops"
+            },
+            {
+              "expression": "version_no",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "int4_ops"
+            }
+          ],
+          "isUnique": true,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "team_document_versions_document_id_fkey": {
+          "name": "team_document_versions_document_id_fkey",
+          "tableFrom": "team_document_versions",
+          "columnsFrom": [
+            "document_id"
+          ],
+          "tableTo": "team_documents",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        },
+        "team_document_versions_created_by_profile_id_fkey": {
+          "name": "team_document_versions_created_by_profile_id_fkey",
+          "tableFrom": "team_document_versions",
+          "columnsFrom": [
+            "created_by_profile_id"
+          ],
+          "tableTo": "profiles",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "restrict"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {
+        "Team members can view document versions": {
+          "name": "Team members can view document versions",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": [
+            "authenticated"
+          ],
+          "using": "document_id IN (\n\t\t\tSELECT team_documents.id\n\t\t\tFROM team_documents\n\t\t\tWHERE team_documents.team_id IN (\n\t\t\t\tSELECT team_id FROM profiles WHERE id = current_profile_id() AND access_removed_at IS NULL\n\t\t\t)\n\t\t)"
+        },
+        "Team members can create document versions": {
+          "name": "Team members can create document versions",
+          "as": "PERMISSIVE",
+          "for": "INSERT",
+          "to": [
+            "authenticated"
+          ],
+          "withCheck": "created_by_profile_id = current_profile_id() AND document_id IN (\n\t\t\tSELECT team_documents.id\n\t\t\tFROM team_documents\n\t\t\tWHERE team_documents.removed_at IS NULL\n\t\t\t\tAND team_documents.team_id IN (\n\t\t\t\t\tSELECT team_id FROM profiles WHERE id = current_profile_id() AND access_removed_at IS NULL\n\t\t\t\t)\n\t\t)"
+        }
+      },
+      "checkConstraints": {
+        "team_document_versions_version_positive": {
+          "name": "team_document_versions_version_positive",
+          "value": "version_no > 0"
+        },
+        "team_document_versions_file_size_positive": {
+          "name": "team_document_versions_file_size_positive",
+          "value": "file_size > 0"
+        }
+      },
+      "isRLSEnabled": true
+    },
+    "public.team_documents": {
+      "name": "team_documents",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "doc_type": {
+          "name": "doc_type",
+          "type": "team_document_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "removed_at": {
+          "name": "removed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_by_profile_id": {
+          "name": "created_by_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_by_profile_id": {
+          "name": "updated_by_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "team_documents_featured_team_type_idx": {
+          "name": "team_documents_featured_team_type_idx",
+          "columns": [
+            {
+              "expression": "team_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "uuid_ops"
+            },
+            {
+              "expression": "doc_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "enum_ops"
+            }
+          ],
+          "isUnique": true,
+          "with": {},
+          "method": "btree",
+          "where": "doc_type IN ('team_contract', 'financial_policy') AND removed_at IS NULL",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "team_documents_team_id_fkey": {
+          "name": "team_documents_team_id_fkey",
+          "tableFrom": "team_documents",
+          "columnsFrom": [
+            "team_id"
+          ],
+          "tableTo": "teams",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        },
+        "team_documents_created_by_profile_id_fkey": {
+          "name": "team_documents_created_by_profile_id_fkey",
+          "tableFrom": "team_documents",
+          "columnsFrom": [
+            "created_by_profile_id"
+          ],
+          "tableTo": "profiles",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "restrict"
+        },
+        "team_documents_updated_by_profile_id_fkey": {
+          "name": "team_documents_updated_by_profile_id_fkey",
+          "tableFrom": "team_documents",
+          "columnsFrom": [
+            "updated_by_profile_id"
+          ],
+          "tableTo": "profiles",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "restrict"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {
+        "Team members can view documents": {
+          "name": "Team members can view documents",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": [
+            "authenticated"
+          ],
+          "using": "team_id IN (SELECT team_id FROM profiles WHERE id = current_profile_id() AND access_removed_at IS NULL)"
+        },
+        "Team members can create documents": {
+          "name": "Team members can create documents",
+          "as": "PERMISSIVE",
+          "for": "INSERT",
+          "to": [
+            "authenticated"
+          ],
+          "withCheck": "team_id IN (SELECT team_id FROM profiles WHERE id = current_profile_id() AND access_removed_at IS NULL) AND created_by_profile_id = current_profile_id() AND updated_by_profile_id = current_profile_id()"
+        },
+        "Team members can update custom documents": {
+          "name": "Team members can update custom documents",
+          "as": "PERMISSIVE",
+          "for": "UPDATE",
+          "to": [
+            "authenticated"
+          ],
+          "using": "doc_type = 'other' AND team_id IN (SELECT team_id FROM profiles WHERE id = current_profile_id() AND access_removed_at IS NULL)",
+          "withCheck": "doc_type = 'other' AND team_id IN (SELECT team_id FROM profiles WHERE id = current_profile_id() AND access_removed_at IS NULL) AND updated_by_profile_id = current_profile_id()"
+        }
+      },
+      "checkConstraints": {
+        "team_documents_title_matches_type": {
+          "name": "team_documents_title_matches_type",
+          "value": "(\n\t\t(doc_type = 'other' AND title IS NOT NULL AND length(trim(title)) > 0)\n\t\tOR (doc_type <> 'other' AND title IS NULL)\n\t)"
+        }
+      },
+      "isRLSEnabled": true
+    },
+    "public.team_reflection_action_steps": {
+      "name": "team_reflection_action_steps",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "team_reflection_id": {
+          "name": "team_reflection_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "assignee_profile_id": {
+          "name": "assignee_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "custom_assignee": {
+          "name": "custom_assignee",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "order_index": {
+          "name": "order_index",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "removed_at": {
+          "name": "removed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_by_profile_id": {
+          "name": "created_by_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "team_reflection_action_steps_reflection_idx": {
+          "name": "team_reflection_action_steps_reflection_idx",
+          "columns": [
+            {
+              "expression": "team_reflection_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "uuid_ops"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "team_reflection_action_steps_team_reflection_id_fkey": {
+          "name": "team_reflection_action_steps_team_reflection_id_fkey",
+          "tableFrom": "team_reflection_action_steps",
+          "columnsFrom": [
+            "team_reflection_id"
+          ],
+          "tableTo": "team_reflections",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        },
+        "team_reflection_action_steps_assignee_profile_id_fkey": {
+          "name": "team_reflection_action_steps_assignee_profile_id_fkey",
+          "tableFrom": "team_reflection_action_steps",
+          "columnsFrom": [
+            "assignee_profile_id"
+          ],
+          "tableTo": "profiles",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "set null"
+        },
+        "team_reflection_action_steps_created_by_profile_id_fkey": {
+          "name": "team_reflection_action_steps_created_by_profile_id_fkey",
+          "tableFrom": "team_reflection_action_steps",
+          "columnsFrom": [
+            "created_by_profile_id"
+          ],
+          "tableTo": "profiles",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "set null"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {
+        "Team members can view action steps": {
+          "name": "Team members can view action steps",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": [
+            "authenticated"
+          ],
+          "using": "team_reflection_id IN (SELECT id FROM team_reflections WHERE team_id IN (SELECT team_id FROM profiles WHERE id = current_profile_id() AND access_removed_at IS NULL))"
+        },
+        "Team members can create action steps": {
+          "name": "Team members can create action steps",
+          "as": "PERMISSIVE",
+          "for": "INSERT",
+          "to": [
+            "authenticated"
+          ],
+          "withCheck": "team_reflection_id IN (SELECT id FROM team_reflections WHERE team_id IN (SELECT team_id FROM profiles WHERE id = current_profile_id() AND access_removed_at IS NULL))"
+        },
+        "Team members can update action steps": {
+          "name": "Team members can update action steps",
+          "as": "PERMISSIVE",
+          "for": "UPDATE",
+          "to": [
+            "authenticated"
+          ],
+          "using": "team_reflection_id IN (SELECT id FROM team_reflections WHERE team_id IN (SELECT team_id FROM profiles WHERE id = current_profile_id() AND access_removed_at IS NULL))",
+          "withCheck": "team_reflection_id IN (SELECT id FROM team_reflections WHERE team_id IN (SELECT team_id FROM profiles WHERE id = current_profile_id() AND access_removed_at IS NULL))"
+        },
+        "Team members can delete action steps": {
+          "name": "Team members can delete action steps",
+          "as": "PERMISSIVE",
+          "for": "DELETE",
+          "to": [
+            "authenticated"
+          ],
+          "using": "team_reflection_id IN (SELECT id FROM team_reflections WHERE team_id IN (SELECT team_id FROM profiles WHERE id = current_profile_id() AND access_removed_at IS NULL))"
+        }
+      },
+      "checkConstraints": {},
+      "isRLSEnabled": true
+    },
+    "public.team_reflections": {
+      "name": "team_reflections",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "month": {
+          "name": "month",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "what_went_well": {
+          "name": "what_went_well",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "what_didnt_go_well": {
+          "name": "what_didnt_go_well",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "what_we_do_differently": {
+          "name": "what_we_do_differently",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "planned_action_steps": {
+          "name": "planned_action_steps",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "responsible_person": {
+          "name": "responsible_person",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "removed_at": {
+          "name": "removed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_by_profile_id": {
+          "name": "created_by_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_by_profile_id": {
+          "name": "updated_by_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "team_reflections_team_month_idx": {
+          "name": "team_reflections_team_month_idx",
+          "columns": [
+            {
+              "expression": "team_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "uuid_ops"
+            },
+            {
+              "expression": "month",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "date_ops"
+            }
+          ],
+          "isUnique": true,
+          "with": {},
+          "method": "btree",
+          "where": "(removed_at IS NULL)",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "team_reflections_team_id_fkey": {
+          "name": "team_reflections_team_id_fkey",
+          "tableFrom": "team_reflections",
+          "columnsFrom": [
+            "team_id"
+          ],
+          "tableTo": "teams",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        },
+        "team_reflections_created_by_profile_id_fkey": {
+          "name": "team_reflections_created_by_profile_id_fkey",
+          "tableFrom": "team_reflections",
+          "columnsFrom": [
+            "created_by_profile_id"
+          ],
+          "tableTo": "profiles",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "restrict"
+        },
+        "team_reflections_updated_by_profile_id_fkey": {
+          "name": "team_reflections_updated_by_profile_id_fkey",
+          "tableFrom": "team_reflections",
+          "columnsFrom": [
+            "updated_by_profile_id"
+          ],
+          "tableTo": "profiles",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "restrict"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {
+        "Team members can view reflections": {
+          "name": "Team members can view reflections",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": [
+            "authenticated"
+          ],
+          "using": "team_id IN (SELECT team_id FROM profiles WHERE id = current_profile_id() AND access_removed_at IS NULL)"
+        },
+        "Team members can create reflections": {
+          "name": "Team members can create reflections",
+          "as": "PERMISSIVE",
+          "for": "INSERT",
+          "to": [
+            "authenticated"
+          ],
+          "withCheck": "team_id IN (SELECT team_id FROM profiles WHERE id = current_profile_id() AND access_removed_at IS NULL)"
+        },
+        "Team members can update reflections": {
+          "name": "Team members can update reflections",
+          "as": "PERMISSIVE",
+          "for": "UPDATE",
+          "to": [
+            "authenticated"
+          ],
+          "using": "team_id IN (SELECT team_id FROM profiles WHERE id = current_profile_id() AND access_removed_at IS NULL)",
+          "withCheck": "team_id IN (SELECT team_id FROM profiles WHERE id = current_profile_id() AND access_removed_at IS NULL)"
+        },
+        "Team members can delete reflections": {
+          "name": "Team members can delete reflections",
+          "as": "PERMISSIVE",
+          "for": "DELETE",
+          "to": [
+            "authenticated"
+          ],
+          "using": "team_id IN (SELECT team_id FROM profiles WHERE id = current_profile_id() AND access_removed_at IS NULL)"
+        }
+      },
+      "checkConstraints": {},
+      "isRLSEnabled": true
+    },
+    "public.teams": {
+      "name": "teams",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "picture": {
+          "name": "picture",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "color": {
+          "name": "color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "onboardingYear": {
+          "name": "onboardingYear",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "removed_at": {
+          "name": "removed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_by_profile_id": {
+          "name": "created_by_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_by_profile_id": {
+          "name": "updated_by_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {
+        "Authenticated users can read teams": {
+          "name": "Authenticated users can read teams",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": [
+            "authenticated"
+          ],
+          "using": "true"
+        }
+      },
+      "checkConstraints": {},
+      "isRLSEnabled": true
+    },
+    "public.tools_techniques": {
+      "name": "tools_techniques",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "profile_id": {
+          "name": "profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tool_type": {
+          "name": "tool_type",
+          "type": "tool_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reflection": {
+          "name": "reflection",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "removed_at": {
+          "name": "removed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_by_profile_id": {
+          "name": "created_by_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_by_profile_id": {
+          "name": "updated_by_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "tools_techniques_profile_idx": {
+          "name": "tools_techniques_profile_idx",
+          "columns": [
+            {
+              "expression": "profile_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "uuid_ops"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "tools_techniques_profile_id_fkey": {
+          "name": "tools_techniques_profile_id_fkey",
+          "tableFrom": "tools_techniques",
+          "columnsFrom": [
+            "profile_id"
+          ],
+          "tableTo": "profiles",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        },
+        "tools_techniques_created_by_profile_id_fkey": {
+          "name": "tools_techniques_created_by_profile_id_fkey",
+          "tableFrom": "tools_techniques",
+          "columnsFrom": [
+            "created_by_profile_id"
+          ],
+          "tableTo": "profiles",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "restrict"
+        },
+        "tools_techniques_updated_by_profile_id_fkey": {
+          "name": "tools_techniques_updated_by_profile_id_fkey",
+          "tableFrom": "tools_techniques",
+          "columnsFrom": [
+            "updated_by_profile_id"
+          ],
+          "tableTo": "profiles",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "restrict"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {
+        "Users can view their own tools and techniques": {
+          "name": "Users can view their own tools and techniques",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": [
+            "authenticated"
+          ],
+          "using": "(profile_id = current_profile_id())"
+        },
+        "Users can create their own tools and techniques": {
+          "name": "Users can create their own tools and techniques",
+          "as": "PERMISSIVE",
+          "for": "INSERT",
+          "to": [
+            "authenticated"
+          ],
+          "withCheck": "(profile_id = current_profile_id())"
+        },
+        "Users can update their own tools and techniques": {
+          "name": "Users can update their own tools and techniques",
+          "as": "PERMISSIVE",
+          "for": "UPDATE",
+          "to": [
+            "authenticated"
+          ],
+          "using": "(profile_id = current_profile_id())",
+          "withCheck": "(profile_id = current_profile_id())"
+        },
+        "Users can delete their own tools and techniques": {
+          "name": "Users can delete their own tools and techniques",
+          "as": "PERMISSIVE",
+          "for": "DELETE",
+          "to": [
+            "authenticated"
+          ],
+          "using": "(profile_id = current_profile_id())"
+        }
+      },
+      "checkConstraints": {},
+      "isRLSEnabled": true
+    }
+  },
+  "enums": {
+    "public.birth_giving_assignment_state": {
+      "name": "birth_giving_assignment_state",
+      "schema": "public",
+      "values": [
+        "present",
+        "missing",
+        "none"
+      ]
+    },
+    "public.birth_giving_duration": {
+      "name": "birth_giving_duration",
+      "schema": "public",
+      "values": [
+        "8h",
+        "24h"
+      ]
+    },
+    "public.birth_giving_event_status": {
+      "name": "birth_giving_event_status",
+      "schema": "public",
+      "values": [
+        "draft",
+        "published"
+      ]
+    },
+    "public.birth_giving_team_result_state": {
+      "name": "birth_giving_team_result_state",
+      "schema": "public",
+      "values": [
+        "pending",
+        "present",
+        "missing"
+      ]
+    },
+    "public.book_list_status": {
+      "name": "book_list_status",
+      "schema": "public",
+      "values": [
+        "processing",
+        "shortlist",
+        "longlist",
+        "archived"
+      ]
+    },
+    "public.book_source": {
+      "name": "book_source",
+      "schema": "public",
+      "values": [
+        "manual",
+        "google_books",
+        "open_library"
+      ]
+    },
+    "public.content_source_kind": {
+      "name": "content_source_kind",
+      "schema": "public",
+      "values": [
+        "podcast",
+        "conference",
+        "program",
+        "other"
+      ]
+    },
+    "public.content_source_status": {
+      "name": "content_source_status",
+      "schema": "public",
+      "values": [
+        "pending_review",
+        "approved",
+        "archived"
+      ]
+    },
+    "public.personality_test_type": {
+      "name": "personality_test_type",
+      "schema": "public",
+      "values": [
+        "gallup",
+        "mbti",
+        "disc",
+        "big_five",
+        "enneagram",
+        "belbin",
+        "other"
+      ]
+    },
+    "public.beta_cohort": {
+      "name": "beta_cohort",
+      "schema": "public",
+      "values": [
+        "A",
+        "B"
+      ]
+    },
+    "public.profile_role": {
+      "name": "profile_role",
+      "schema": "public",
+      "values": [
+        "student",
+        "mentor",
+        "coach",
+        "admin"
+      ]
+    },
+    "public.schedule_type": {
+      "name": "schedule_type",
+      "schema": "public",
+      "values": [
+        "training_session",
+        "houston_calling"
+      ]
+    },
+    "public.attendance_status": {
+      "name": "attendance_status",
+      "schema": "public",
+      "values": [
+        "present",
+        "absent",
+        "excused",
+        "late"
+      ]
+    },
+    "public.annual_reflection_topic": {
+      "name": "annual_reflection_topic",
+      "schema": "public",
+      "values": [
+        "predmety_zkousky_vyucujici",
+        "metodika_a_metriky",
+        "kouci_a_mentori",
+        "tymy_a_tymove_spolecnosti",
+        "individualni_prinos",
+        "komunita",
+        "komunitni_role",
+        "komunitni_akce",
+        "komunitni_a_cross_projekty",
+        "zacleneni_tucnaku",
+        "dalsi"
+      ]
+    },
+    "public.team_document_type": {
+      "name": "team_document_type",
+      "schema": "public",
+      "values": [
+        "team_contract",
+        "financial_policy",
+        "other"
+      ]
+    },
+    "public.tool_type": {
+      "name": "tool_type",
+      "schema": "public",
+      "values": [
+        "model",
+        "technique",
+        "tool"
+      ]
+    }
+  },
+  "schemas": {},
+  "views": {
+    "public.books_with_essay_count": {
+      "name": "books_with_essay_count",
+      "schema": "public",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "title_cs": {
+          "name": "title_cs",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "title_en": {
+          "name": "title_en",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "author": {
+          "name": "author",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "isbn_13": {
+          "name": "isbn_13",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "google_books_cover_url": {
+          "name": "google_books_cover_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "book_points": {
+          "name": "book_points",
+          "type": "numeric(3, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "page_count": {
+          "name": "page_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "preview_link": {
+          "name": "preview_link",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source": {
+          "name": "source",
+          "type": "book_source",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "external_id": {
+          "name": "external_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "list_status": {
+          "name": "list_status",
+          "type": "book_list_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "list_status_changed_at": {
+          "name": "list_status_changed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "list_status_changed_by_profile_id": {
+          "name": "list_status_changed_by_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "list_status_reason": {
+          "name": "list_status_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "highlight_category_id": {
+          "name": "highlight_category_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_rocket_model": {
+          "name": "is_rocket_model",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by_profile_id": {
+          "name": "created_by_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_by_profile_id": {
+          "name": "updated_by_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "essay_count": {
+          "name": "essay_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "definition": "SELECT b.id, b.title_cs, b.title_en, b.author, b.isbn_13, b.description, b.google_books_cover_url, b.book_points, b.page_count, b.preview_link, b.source, b.external_id, b.list_status, b.list_status_changed_at, b.list_status_changed_by_profile_id, b.list_status_reason, b.highlight_category_id, b.is_rocket_model, b.created_at, b.updated_at, b.created_by_profile_id, b.updated_by_profile_id, COALESCE(ec.essay_count, 0) AS essay_count FROM books b LEFT JOIN ( SELECT essays.book_id, count(*)::integer AS essay_count FROM essays WHERE essays.book_id IS NOT NULL AND essays.published_at IS NOT NULL AND essays.removed_at IS NULL GROUP BY essays.book_id) ec ON ec.book_id = b.id",
+      "materialized": false,
+      "isExisting": false
+    }
+  },
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/supabase/migrations/meta/20260902200442_snapshot.json
+++ b/supabase/migrations/meta/20260902200442_snapshot.json
@@ -1,0 +1,7622 @@
+{
+  "id": "5ef433e8-889b-4ca1-9942-c6b73c58867c",
+  "prevId": "ce87fa55-fca5-4861-b9e2-c2abd60cfc42",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.birth_giving_events": {
+      "name": "birth_giving_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "customer": {
+          "name": "customer",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "starts_at": {
+          "name": "starts_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "duration": {
+          "name": "duration",
+          "type": "birth_giving_duration",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "birth_giving_event_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'draft'"
+        },
+        "organizer_profile_ids": {
+          "name": "organizer_profile_ids",
+          "type": "uuid[]",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "assignment_state": {
+          "name": "assignment_state",
+          "type": "birth_giving_assignment_state",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'none'"
+        },
+        "assignment_storage_path": {
+          "name": "assignment_storage_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "assignment_file_name": {
+          "name": "assignment_file_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "assignment_mime_type": {
+          "name": "assignment_mime_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "assignment_file_size": {
+          "name": "assignment_file_size",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "assignment_uploaded_at": {
+          "name": "assignment_uploaded_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "assignment_uploaded_by_profile_id": {
+          "name": "assignment_uploaded_by_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "removed_at": {
+          "name": "removed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "removed_by_profile_id": {
+          "name": "removed_by_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_by_profile_id": {
+          "name": "created_by_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_by_profile_id": {
+          "name": "updated_by_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "birth_giving_events_identity_idx": {
+          "name": "birth_giving_events_identity_idx",
+          "columns": [
+            {
+              "expression": "lower(regexp_replace(trim(normalize(\"name\", NFKC)), '[[:space:]]+', ' ', 'g'))",
+              "isExpression": true,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "lower(regexp_replace(trim(normalize(\"customer\", NFKC)), '[[:space:]]+', ' ', 'g'))",
+              "isExpression": true,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "starts_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "timestamptz_ops"
+            }
+          ],
+          "isUnique": true,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "birth_giving_events_status_starts_at_idx": {
+          "name": "birth_giving_events_status_starts_at_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "starts_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "birth_giving_events_removed_by_profile_id_fkey": {
+          "name": "birth_giving_events_removed_by_profile_id_fkey",
+          "tableFrom": "birth_giving_events",
+          "columnsFrom": [
+            "removed_by_profile_id"
+          ],
+          "tableTo": "profiles",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "set null"
+        },
+        "birth_giving_events_assignment_uploaded_by_fkey": {
+          "name": "birth_giving_events_assignment_uploaded_by_fkey",
+          "tableFrom": "birth_giving_events",
+          "columnsFrom": [
+            "assignment_uploaded_by_profile_id"
+          ],
+          "tableTo": "profiles",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "restrict"
+        },
+        "birth_giving_events_created_by_profile_id_fkey": {
+          "name": "birth_giving_events_created_by_profile_id_fkey",
+          "tableFrom": "birth_giving_events",
+          "columnsFrom": [
+            "created_by_profile_id"
+          ],
+          "tableTo": "profiles",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "restrict"
+        },
+        "birth_giving_events_updated_by_profile_id_fkey": {
+          "name": "birth_giving_events_updated_by_profile_id_fkey",
+          "tableFrom": "birth_giving_events",
+          "columnsFrom": [
+            "updated_by_profile_id"
+          ],
+          "tableTo": "profiles",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "restrict"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {
+        "Community can view published BG events, organizers view drafts": {
+          "name": "Community can view published BG events, organizers view drafts",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": [
+            "authenticated"
+          ],
+          "using": "EXISTS (\n  SELECT 1\n  FROM profiles caller_profile\n  JOIN users caller_user ON caller_user.id = caller_profile.user_id\n  WHERE caller_profile.id = current_profile_id()\n    AND caller_profile.access_removed_at IS NULL\n    AND caller_profile.beta_access_granted_at IS NOT NULL\n    AND caller_user.verified_work_email IS NOT NULL\n) AND \"birth_giving_events\".\"removed_at\" IS NULL AND (\"birth_giving_events\".\"status\" = 'published' OR current_profile_id() = ANY(\"birth_giving_events\".\"organizer_profile_ids\"))"
+        }
+      },
+      "checkConstraints": {
+        "birth_giving_events_name_check": {
+          "name": "birth_giving_events_name_check",
+          "value": "length(trim(\"birth_giving_events\".\"name\")) > 0"
+        },
+        "birth_giving_events_customer_check": {
+          "name": "birth_giving_events_customer_check",
+          "value": "length(trim(\"birth_giving_events\".\"customer\")) > 0"
+        },
+        "birth_giving_events_organizers_check": {
+          "name": "birth_giving_events_organizers_check",
+          "value": "cardinality(\"birth_giving_events\".\"organizer_profile_ids\") > 0 AND cardinality(array_remove(\"birth_giving_events\".\"organizer_profile_ids\", NULL)) = cardinality(\"birth_giving_events\".\"organizer_profile_ids\")"
+        },
+        "birth_giving_events_assignment_check": {
+          "name": "birth_giving_events_assignment_check",
+          "value": "(\n    \"birth_giving_events\".\"assignment_state\" = 'present'\n    AND \"birth_giving_events\".\"assignment_storage_path\" IS NOT NULL\n    AND length(trim(\"birth_giving_events\".\"assignment_storage_path\")) > 0\n    AND \"birth_giving_events\".\"assignment_storage_path\" LIKE 'birth-giving/assignments/' || \"birth_giving_events\".\"id\"::text || '/%'\n    AND \"birth_giving_events\".\"assignment_file_name\" IS NOT NULL\n    AND length(trim(\"birth_giving_events\".\"assignment_file_name\")) > 0\n    AND \"birth_giving_events\".\"assignment_mime_type\" IS NOT NULL\n    AND length(trim(\"birth_giving_events\".\"assignment_mime_type\")) > 0\n    AND \"birth_giving_events\".\"assignment_file_size\" > 0\n    AND \"birth_giving_events\".\"assignment_uploaded_at\" IS NOT NULL\n    AND \"birth_giving_events\".\"assignment_uploaded_by_profile_id\" IS NOT NULL\n  ) OR (\n    \"birth_giving_events\".\"assignment_state\" IN ('none', 'missing')\n    AND \"birth_giving_events\".\"assignment_storage_path\" IS NULL\n    AND \"birth_giving_events\".\"assignment_file_name\" IS NULL\n    AND \"birth_giving_events\".\"assignment_mime_type\" IS NULL\n    AND \"birth_giving_events\".\"assignment_file_size\" IS NULL\n    AND \"birth_giving_events\".\"assignment_uploaded_at\" IS NULL\n    AND \"birth_giving_events\".\"assignment_uploaded_by_profile_id\" IS NULL\n  )"
+        },
+        "birth_giving_events_removed_check": {
+          "name": "birth_giving_events_removed_check",
+          "value": "(\"birth_giving_events\".\"removed_at\" IS NULL) = (\"birth_giving_events\".\"removed_by_profile_id\" IS NULL)"
+        }
+      },
+      "isRLSEnabled": true
+    },
+    "public.birth_giving_team_members": {
+      "name": "birth_giving_team_members",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "event_id": {
+          "name": "event_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "profile_id": {
+          "name": "profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "confirmed_at": {
+          "name": "confirmed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "reflection_contribution": {
+          "name": "reflection_contribution",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reflection_learning": {
+          "name": "reflection_learning",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reflection_submitted_at": {
+          "name": "reflection_submitted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_by_profile_id": {
+          "name": "created_by_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_by_profile_id": {
+          "name": "updated_by_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "birth_giving_team_members_team_idx": {
+          "name": "birth_giving_team_members_team_idx",
+          "columns": [
+            {
+              "expression": "event_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "team_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "birth_giving_team_members_profile_idx": {
+          "name": "birth_giving_team_members_profile_idx",
+          "columns": [
+            {
+              "expression": "profile_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "birth_giving_team_members_event_team_fkey": {
+          "name": "birth_giving_team_members_event_team_fkey",
+          "tableFrom": "birth_giving_team_members",
+          "columnsFrom": [
+            "event_id",
+            "team_id"
+          ],
+          "tableTo": "birth_giving_teams",
+          "columnsTo": [
+            "event_id",
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        },
+        "birth_giving_team_members_profile_id_fkey": {
+          "name": "birth_giving_team_members_profile_id_fkey",
+          "tableFrom": "birth_giving_team_members",
+          "columnsFrom": [
+            "profile_id"
+          ],
+          "tableTo": "profiles",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        },
+        "birth_giving_team_members_created_by_profile_id_fkey": {
+          "name": "birth_giving_team_members_created_by_profile_id_fkey",
+          "tableFrom": "birth_giving_team_members",
+          "columnsFrom": [
+            "created_by_profile_id"
+          ],
+          "tableTo": "profiles",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "restrict"
+        },
+        "birth_giving_team_members_updated_by_profile_id_fkey": {
+          "name": "birth_giving_team_members_updated_by_profile_id_fkey",
+          "tableFrom": "birth_giving_team_members",
+          "columnsFrom": [
+            "updated_by_profile_id"
+          ],
+          "tableTo": "profiles",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "restrict"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "birth_giving_team_members_event_profile_key": {
+          "name": "birth_giving_team_members_event_profile_key",
+          "columns": [
+            "event_id",
+            "profile_id"
+          ],
+          "nullsNotDistinct": false
+        },
+        "birth_giving_team_members_event_team_profile_key": {
+          "name": "birth_giving_team_members_event_team_profile_key",
+          "columns": [
+            "event_id",
+            "team_id",
+            "profile_id"
+          ],
+          "nullsNotDistinct": false
+        }
+      },
+      "policies": {
+        "Community can view BG memberships for accessible events": {
+          "name": "Community can view BG memberships for accessible events",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": [
+            "authenticated"
+          ],
+          "using": "EXISTS (\n  SELECT 1\n  FROM profiles caller_profile\n  JOIN users caller_user ON caller_user.id = caller_profile.user_id\n  WHERE caller_profile.id = current_profile_id()\n    AND caller_profile.access_removed_at IS NULL\n    AND caller_profile.beta_access_granted_at IS NOT NULL\n    AND caller_user.verified_work_email IS NOT NULL\n) AND EXISTS (\n      SELECT 1 FROM birth_giving_events event\n      WHERE event.id = \"birth_giving_team_members\".\"event_id\"\n        AND event.removed_at IS NULL\n        AND (event.status = 'published' OR current_profile_id() = ANY(event.organizer_profile_ids))\n    )"
+        }
+      },
+      "checkConstraints": {
+        "birth_giving_team_members_reflection_check": {
+          "name": "birth_giving_team_members_reflection_check",
+          "value": "(\n    \"birth_giving_team_members\".\"reflection_contribution\" IS NULL\n    AND \"birth_giving_team_members\".\"reflection_learning\" IS NULL\n    AND \"birth_giving_team_members\".\"reflection_submitted_at\" IS NULL\n  ) OR (\n    \"birth_giving_team_members\".\"reflection_contribution\" IS NOT NULL\n    AND length(trim(\"birth_giving_team_members\".\"reflection_contribution\")) > 0\n    AND \"birth_giving_team_members\".\"reflection_learning\" IS NOT NULL\n    AND length(trim(\"birth_giving_team_members\".\"reflection_learning\")) > 0\n    AND \"birth_giving_team_members\".\"reflection_submitted_at\" IS NOT NULL\n  )"
+        }
+      },
+      "isRLSEnabled": true
+    },
+    "public.birth_giving_teams": {
+      "name": "birth_giving_teams",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "event_id": {
+          "name": "event_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_winner": {
+          "name": "is_winner",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "result_state": {
+          "name": "result_state",
+          "type": "birth_giving_team_result_state",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "result_files": {
+          "name": "result_files",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "cancelled_at": {
+          "name": "cancelled_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cancellation_reason": {
+          "name": "cancellation_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_by_profile_id": {
+          "name": "created_by_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_by_profile_id": {
+          "name": "updated_by_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "birth_giving_teams_event_winner_idx": {
+          "name": "birth_giving_teams_event_winner_idx",
+          "columns": [
+            {
+              "expression": "event_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "with": {},
+          "method": "btree",
+          "where": "\"birth_giving_teams\".\"is_winner\" AND \"birth_giving_teams\".\"cancelled_at\" IS NULL",
+          "concurrently": false
+        },
+        "birth_giving_teams_event_idx": {
+          "name": "birth_giving_teams_event_idx",
+          "columns": [
+            {
+              "expression": "event_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "birth_giving_teams_event_id_fkey": {
+          "name": "birth_giving_teams_event_id_fkey",
+          "tableFrom": "birth_giving_teams",
+          "columnsFrom": [
+            "event_id"
+          ],
+          "tableTo": "birth_giving_events",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        },
+        "birth_giving_teams_created_by_profile_id_fkey": {
+          "name": "birth_giving_teams_created_by_profile_id_fkey",
+          "tableFrom": "birth_giving_teams",
+          "columnsFrom": [
+            "created_by_profile_id"
+          ],
+          "tableTo": "profiles",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "restrict"
+        },
+        "birth_giving_teams_updated_by_profile_id_fkey": {
+          "name": "birth_giving_teams_updated_by_profile_id_fkey",
+          "tableFrom": "birth_giving_teams",
+          "columnsFrom": [
+            "updated_by_profile_id"
+          ],
+          "tableTo": "profiles",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "restrict"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "birth_giving_teams_event_id_id_key": {
+          "name": "birth_giving_teams_event_id_id_key",
+          "columns": [
+            "event_id",
+            "id"
+          ],
+          "nullsNotDistinct": false
+        }
+      },
+      "policies": {
+        "Community can view BG teams for accessible events": {
+          "name": "Community can view BG teams for accessible events",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": [
+            "authenticated"
+          ],
+          "using": "EXISTS (\n  SELECT 1\n  FROM profiles caller_profile\n  JOIN users caller_user ON caller_user.id = caller_profile.user_id\n  WHERE caller_profile.id = current_profile_id()\n    AND caller_profile.access_removed_at IS NULL\n    AND caller_profile.beta_access_granted_at IS NOT NULL\n    AND caller_user.verified_work_email IS NOT NULL\n) AND EXISTS (\n      SELECT 1 FROM birth_giving_events event\n      WHERE event.id = \"birth_giving_teams\".\"event_id\"\n        AND event.removed_at IS NULL\n        AND (event.status = 'published' OR current_profile_id() = ANY(event.organizer_profile_ids))\n    )"
+        }
+      },
+      "checkConstraints": {
+        "birth_giving_teams_name_check": {
+          "name": "birth_giving_teams_name_check",
+          "value": "length(trim(\"birth_giving_teams\".\"name\")) > 0"
+        },
+        "birth_giving_teams_cancellation_check": {
+          "name": "birth_giving_teams_cancellation_check",
+          "value": "(\n    \"birth_giving_teams\".\"cancelled_at\" IS NULL AND \"birth_giving_teams\".\"cancellation_reason\" IS NULL\n  ) OR (\n    \"birth_giving_teams\".\"cancelled_at\" IS NOT NULL\n    AND \"birth_giving_teams\".\"cancellation_reason\" IS NOT NULL\n    AND length(trim(\"birth_giving_teams\".\"cancellation_reason\")) > 0\n  )"
+        },
+        "birth_giving_teams_result_check": {
+          "name": "birth_giving_teams_result_check",
+          "value": "jsonb_typeof(\"birth_giving_teams\".\"result_files\") = 'array' AND (\n    (\"birth_giving_teams\".\"result_state\" = 'present' AND jsonb_array_length(\"birth_giving_teams\".\"result_files\") > 0)\n    OR (\"birth_giving_teams\".\"result_state\" IN ('pending', 'missing') AND jsonb_array_length(\"birth_giving_teams\".\"result_files\") = 0)\n  )"
+        }
+      },
+      "isRLSEnabled": true
+    },
+    "public.book_loans": {
+      "name": "book_loans",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "library_book_id": {
+          "name": "library_book_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "borrower_id": {
+          "name": "borrower_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "borrowed_at": {
+          "name": "borrowed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "due_at": {
+          "name": "due_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "returned_at": {
+          "name": "returned_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "book_loans_library_book_id_idx": {
+          "name": "book_loans_library_book_id_idx",
+          "columns": [
+            {
+              "expression": "library_book_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "uuid_ops"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "book_loans_borrower_id_idx": {
+          "name": "book_loans_borrower_id_idx",
+          "columns": [
+            {
+              "expression": "borrower_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "uuid_ops"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "book_loans_active_idx": {
+          "name": "book_loans_active_idx",
+          "columns": [
+            {
+              "expression": "library_book_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "uuid_ops"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "where": "(returned_at IS NULL)",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "book_loans_library_book_id_fkey": {
+          "name": "book_loans_library_book_id_fkey",
+          "tableFrom": "book_loans",
+          "columnsFrom": [
+            "library_book_id"
+          ],
+          "tableTo": "library_books",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "restrict"
+        },
+        "book_loans_borrower_id_fkey": {
+          "name": "book_loans_borrower_id_fkey",
+          "tableFrom": "book_loans",
+          "columnsFrom": [
+            "borrower_id"
+          ],
+          "tableTo": "profiles",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "restrict"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {
+        "Authenticated users can view loans": {
+          "name": "Authenticated users can view loans",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": [
+            "authenticated"
+          ],
+          "using": "true"
+        },
+        "Users can borrow for themselves": {
+          "name": "Users can borrow for themselves",
+          "as": "PERMISSIVE",
+          "for": "INSERT",
+          "to": [
+            "authenticated"
+          ],
+          "withCheck": "(borrower_id = current_profile_id())"
+        },
+        "Borrower can return their own loan": {
+          "name": "Borrower can return their own loan",
+          "as": "PERMISSIVE",
+          "for": "UPDATE",
+          "to": [
+            "authenticated"
+          ],
+          "using": "(borrower_id = current_profile_id())",
+          "withCheck": "(borrower_id = current_profile_id())"
+        }
+      },
+      "checkConstraints": {},
+      "isRLSEnabled": true
+    },
+    "public.book_tags": {
+      "name": "book_tags",
+      "schema": "",
+      "columns": {
+        "book_id": {
+          "name": "book_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tag_id": {
+          "name": "tag_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_by_profile_id": {
+          "name": "created_by_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_by_profile_id": {
+          "name": "updated_by_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "book_tags_tag_idx": {
+          "name": "book_tags_tag_idx",
+          "columns": [
+            {
+              "expression": "tag_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "uuid_ops"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "book_tags_book_id_fkey": {
+          "name": "book_tags_book_id_fkey",
+          "tableFrom": "book_tags",
+          "columnsFrom": [
+            "book_id"
+          ],
+          "tableTo": "books",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        },
+        "book_tags_tag_id_fkey": {
+          "name": "book_tags_tag_id_fkey",
+          "tableFrom": "book_tags",
+          "columnsFrom": [
+            "tag_id"
+          ],
+          "tableTo": "tags",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        },
+        "book_tags_created_by_profile_id_fkey": {
+          "name": "book_tags_created_by_profile_id_fkey",
+          "tableFrom": "book_tags",
+          "columnsFrom": [
+            "created_by_profile_id"
+          ],
+          "tableTo": "profiles",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "restrict"
+        },
+        "book_tags_updated_by_profile_id_fkey": {
+          "name": "book_tags_updated_by_profile_id_fkey",
+          "tableFrom": "book_tags",
+          "columnsFrom": [
+            "updated_by_profile_id"
+          ],
+          "tableTo": "profiles",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "restrict"
+        }
+      },
+      "compositePrimaryKeys": {
+        "book_tags_pkey": {
+          "name": "book_tags_pkey",
+          "columns": [
+            "book_id",
+            "tag_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {
+        "Authenticated users can view book tags": {
+          "name": "Authenticated users can view book tags",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": [
+            "authenticated"
+          ],
+          "using": "true"
+        },
+        "Authenticated users can assign book tags": {
+          "name": "Authenticated users can assign book tags",
+          "as": "PERMISSIVE",
+          "for": "INSERT",
+          "to": [
+            "authenticated"
+          ],
+          "withCheck": "(created_by_profile_id = current_profile_id())"
+        },
+        "Coaches and admins can update book tags": {
+          "name": "Coaches and admins can update book tags",
+          "as": "PERMISSIVE",
+          "for": "UPDATE",
+          "to": [
+            "authenticated"
+          ],
+          "using": "is_coach_or_admin()",
+          "withCheck": "is_coach_or_admin()"
+        },
+        "Coaches and admins can remove book tags": {
+          "name": "Coaches and admins can remove book tags",
+          "as": "PERMISSIVE",
+          "for": "DELETE",
+          "to": [
+            "authenticated"
+          ],
+          "using": "is_coach_or_admin()"
+        }
+      },
+      "checkConstraints": {},
+      "isRLSEnabled": true
+    },
+    "public.books": {
+      "name": "books",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "title_cs": {
+          "name": "title_cs",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title_en": {
+          "name": "title_en",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "author": {
+          "name": "author",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "isbn_13": {
+          "name": "isbn_13",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "google_books_cover_url": {
+          "name": "google_books_cover_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "book_points": {
+          "name": "book_points",
+          "type": "numeric(3, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "page_count": {
+          "name": "page_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "preview_link": {
+          "name": "preview_link",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source": {
+          "name": "source",
+          "type": "book_source",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'manual'"
+        },
+        "external_id": {
+          "name": "external_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "list_status": {
+          "name": "list_status",
+          "type": "book_list_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'processing'"
+        },
+        "list_status_changed_at": {
+          "name": "list_status_changed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "list_status_changed_by_profile_id": {
+          "name": "list_status_changed_by_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "list_status_reason": {
+          "name": "list_status_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "highlight_category_id": {
+          "name": "highlight_category_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_rocket_model": {
+          "name": "is_rocket_model",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_by_profile_id": {
+          "name": "created_by_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_by_profile_id": {
+          "name": "updated_by_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "books_created_by_idx": {
+          "name": "books_created_by_idx",
+          "columns": [
+            {
+              "expression": "created_by_profile_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "uuid_ops"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "books_author_trgm_idx": {
+          "name": "books_author_trgm_idx",
+          "columns": [
+            {
+              "expression": "author",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "gin_trgm_ops"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "gin",
+          "concurrently": false
+        },
+        "books_created_desc_idx": {
+          "name": "books_created_desc_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "first",
+              "opclass": "timestamptz_ops"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "books_isbn_13_idx": {
+          "name": "books_isbn_13_idx",
+          "columns": [
+            {
+              "expression": "isbn_13",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "text_ops"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "where": "(isbn_13 IS NOT NULL)",
+          "concurrently": false
+        },
+        "books_list_status_idx": {
+          "name": "books_list_status_idx",
+          "columns": [
+            {
+              "expression": "list_status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "enum_ops"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "books_title_cs_trgm_idx": {
+          "name": "books_title_cs_trgm_idx",
+          "columns": [
+            {
+              "expression": "title_cs",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "gin_trgm_ops"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "gin",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "books_created_by_profile_id_fkey": {
+          "name": "books_created_by_profile_id_fkey",
+          "tableFrom": "books",
+          "columnsFrom": [
+            "created_by_profile_id"
+          ],
+          "tableTo": "profiles",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "restrict"
+        },
+        "books_updated_by_profile_id_fkey": {
+          "name": "books_updated_by_profile_id_fkey",
+          "tableFrom": "books",
+          "columnsFrom": [
+            "updated_by_profile_id"
+          ],
+          "tableTo": "profiles",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "restrict"
+        },
+        "books_list_status_changed_by_profile_id_fkey": {
+          "name": "books_list_status_changed_by_profile_id_fkey",
+          "tableFrom": "books",
+          "columnsFrom": [
+            "list_status_changed_by_profile_id"
+          ],
+          "tableTo": "profiles",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "set null"
+        },
+        "books_highlight_category_id_fkey": {
+          "name": "books_highlight_category_id_fkey",
+          "tableFrom": "books",
+          "columnsFrom": [
+            "highlight_category_id"
+          ],
+          "tableTo": "highlight_categories",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "set null"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {
+        "Coaches and admins can delete books": {
+          "name": "Coaches and admins can delete books",
+          "as": "PERMISSIVE",
+          "for": "DELETE",
+          "to": [
+            "public"
+          ],
+          "using": "is_coach_or_admin()"
+        },
+        "Coaches and admins can update books": {
+          "name": "Coaches and admins can update books",
+          "as": "PERMISSIVE",
+          "for": "UPDATE",
+          "to": [
+            "authenticated"
+          ],
+          "using": "is_coach_or_admin()",
+          "withCheck": "is_coach_or_admin()"
+        },
+        "Authenticated users can add books": {
+          "name": "Authenticated users can add books",
+          "as": "PERMISSIVE",
+          "for": "INSERT",
+          "to": [
+            "authenticated"
+          ],
+          "withCheck": "(created_by_profile_id = current_profile_id())"
+        },
+        "Authenticated users can view all books": {
+          "name": "Authenticated users can view all books",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": [
+            "authenticated"
+          ],
+          "using": "true"
+        }
+      },
+      "checkConstraints": {
+        "books_book_points_check": {
+          "name": "books_book_points_check",
+          "value": "(book_points IS NULL) OR ((book_points >= (0)::numeric) AND (book_points <= (3)::numeric))"
+        },
+        "books_archived_points_check": {
+          "name": "books_archived_points_check",
+          "value": "(list_status <> 'archived') OR (book_points = (0)::numeric)"
+        }
+      },
+      "isRLSEnabled": true
+    },
+    "public.highlight_categories": {
+      "name": "highlight_categories",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_by_profile_id": {
+          "name": "created_by_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_by_profile_id": {
+          "name": "updated_by_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "highlight_categories_created_by_profile_id_fkey": {
+          "name": "highlight_categories_created_by_profile_id_fkey",
+          "tableFrom": "highlight_categories",
+          "columnsFrom": [
+            "created_by_profile_id"
+          ],
+          "tableTo": "profiles",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "restrict"
+        },
+        "highlight_categories_updated_by_profile_id_fkey": {
+          "name": "highlight_categories_updated_by_profile_id_fkey",
+          "tableFrom": "highlight_categories",
+          "columnsFrom": [
+            "updated_by_profile_id"
+          ],
+          "tableTo": "profiles",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "restrict"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {
+        "Authenticated users can view highlight categories": {
+          "name": "Authenticated users can view highlight categories",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": [
+            "authenticated"
+          ],
+          "using": "true"
+        },
+        "Coaches and admins can add highlight categories": {
+          "name": "Coaches and admins can add highlight categories",
+          "as": "PERMISSIVE",
+          "for": "INSERT",
+          "to": [
+            "authenticated"
+          ],
+          "withCheck": "is_coach_or_admin()"
+        },
+        "Coaches and admins can update highlight categories": {
+          "name": "Coaches and admins can update highlight categories",
+          "as": "PERMISSIVE",
+          "for": "UPDATE",
+          "to": [
+            "authenticated"
+          ],
+          "using": "is_coach_or_admin()",
+          "withCheck": "is_coach_or_admin()"
+        },
+        "Coaches and admins can delete highlight categories": {
+          "name": "Coaches and admins can delete highlight categories",
+          "as": "PERMISSIVE",
+          "for": "DELETE",
+          "to": [
+            "authenticated"
+          ],
+          "using": "is_coach_or_admin()"
+        }
+      },
+      "checkConstraints": {},
+      "isRLSEnabled": true
+    },
+    "public.library_books": {
+      "name": "library_books",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "book_id": {
+          "name": "book_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "isbn_13": {
+          "name": "isbn_13",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_by_profile_id": {
+          "name": "created_by_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_by_profile_id": {
+          "name": "updated_by_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "library_books_book_id_idx": {
+          "name": "library_books_book_id_idx",
+          "columns": [
+            {
+              "expression": "book_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "uuid_ops"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "library_books_isbn_13_idx": {
+          "name": "library_books_isbn_13_idx",
+          "columns": [
+            {
+              "expression": "isbn_13",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "text_ops"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "where": "(isbn_13 IS NOT NULL)",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "library_books_book_id_fkey": {
+          "name": "library_books_book_id_fkey",
+          "tableFrom": "library_books",
+          "columnsFrom": [
+            "book_id"
+          ],
+          "tableTo": "books",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "restrict"
+        },
+        "library_books_created_by_profile_id_fkey": {
+          "name": "library_books_created_by_profile_id_fkey",
+          "tableFrom": "library_books",
+          "columnsFrom": [
+            "created_by_profile_id"
+          ],
+          "tableTo": "profiles",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "restrict"
+        },
+        "library_books_updated_by_profile_id_fkey": {
+          "name": "library_books_updated_by_profile_id_fkey",
+          "tableFrom": "library_books",
+          "columnsFrom": [
+            "updated_by_profile_id"
+          ],
+          "tableTo": "profiles",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "restrict"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {
+        "Authenticated users can view library books": {
+          "name": "Authenticated users can view library books",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": [
+            "authenticated"
+          ],
+          "using": "true"
+        },
+        "Coaches and admins can add library books": {
+          "name": "Coaches and admins can add library books",
+          "as": "PERMISSIVE",
+          "for": "INSERT",
+          "to": [
+            "authenticated"
+          ],
+          "withCheck": "is_coach_or_admin()"
+        },
+        "Coaches and admins can update library books": {
+          "name": "Coaches and admins can update library books",
+          "as": "PERMISSIVE",
+          "for": "UPDATE",
+          "to": [
+            "authenticated"
+          ],
+          "using": "is_coach_or_admin()",
+          "withCheck": "is_coach_or_admin()"
+        },
+        "Coaches and admins can delete library books": {
+          "name": "Coaches and admins can delete library books",
+          "as": "PERMISSIVE",
+          "for": "DELETE",
+          "to": [
+            "authenticated"
+          ],
+          "using": "is_coach_or_admin()"
+        }
+      },
+      "checkConstraints": {},
+      "isRLSEnabled": true
+    },
+    "public.tags": {
+      "name": "tags",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_by_profile_id": {
+          "name": "created_by_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_by_profile_id": {
+          "name": "updated_by_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "tags_created_by_profile_id_fkey": {
+          "name": "tags_created_by_profile_id_fkey",
+          "tableFrom": "tags",
+          "columnsFrom": [
+            "created_by_profile_id"
+          ],
+          "tableTo": "profiles",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "restrict"
+        },
+        "tags_updated_by_profile_id_fkey": {
+          "name": "tags_updated_by_profile_id_fkey",
+          "tableFrom": "tags",
+          "columnsFrom": [
+            "updated_by_profile_id"
+          ],
+          "tableTo": "profiles",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "restrict"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "tags_name_key": {
+          "name": "tags_name_key",
+          "columns": [
+            "name"
+          ],
+          "nullsNotDistinct": false
+        }
+      },
+      "policies": {
+        "Authenticated users can view tags": {
+          "name": "Authenticated users can view tags",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": [
+            "authenticated"
+          ],
+          "using": "true"
+        },
+        "Coaches and admins can add tags": {
+          "name": "Coaches and admins can add tags",
+          "as": "PERMISSIVE",
+          "for": "INSERT",
+          "to": [
+            "authenticated"
+          ],
+          "withCheck": "is_coach_or_admin()"
+        },
+        "Coaches and admins can update tags": {
+          "name": "Coaches and admins can update tags",
+          "as": "PERMISSIVE",
+          "for": "UPDATE",
+          "to": [
+            "authenticated"
+          ],
+          "using": "is_coach_or_admin()",
+          "withCheck": "is_coach_or_admin()"
+        },
+        "Coaches and admins can delete tags": {
+          "name": "Coaches and admins can delete tags",
+          "as": "PERMISSIVE",
+          "for": "DELETE",
+          "to": [
+            "authenticated"
+          ],
+          "using": "is_coach_or_admin()"
+        }
+      },
+      "checkConstraints": {},
+      "isRLSEnabled": true
+    },
+    "public.content_sources": {
+      "name": "content_sources",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "kind": {
+          "name": "kind",
+          "type": "content_source_kind",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "creator": {
+          "name": "creator",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "external_url": {
+          "name": "external_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "points": {
+          "name": "points",
+          "type": "numeric(3, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "content_source_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending_review'"
+        },
+        "status_changed_at": {
+          "name": "status_changed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status_changed_by_profile_id": {
+          "name": "status_changed_by_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_by_profile_id": {
+          "name": "created_by_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_by_profile_id": {
+          "name": "updated_by_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "content_sources_created_by_idx": {
+          "name": "content_sources_created_by_idx",
+          "columns": [
+            {
+              "expression": "created_by_profile_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "uuid_ops"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "content_sources_status_idx": {
+          "name": "content_sources_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "enum_ops"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "content_sources_title_trgm_idx": {
+          "name": "content_sources_title_trgm_idx",
+          "columns": [
+            {
+              "expression": "title",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "gin_trgm_ops"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "gin",
+          "concurrently": false
+        },
+        "content_sources_creator_trgm_idx": {
+          "name": "content_sources_creator_trgm_idx",
+          "columns": [
+            {
+              "expression": "creator",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "gin_trgm_ops"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "gin",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "content_sources_created_by_profile_id_fkey": {
+          "name": "content_sources_created_by_profile_id_fkey",
+          "tableFrom": "content_sources",
+          "columnsFrom": [
+            "created_by_profile_id"
+          ],
+          "tableTo": "profiles",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "restrict"
+        },
+        "content_sources_updated_by_profile_id_fkey": {
+          "name": "content_sources_updated_by_profile_id_fkey",
+          "tableFrom": "content_sources",
+          "columnsFrom": [
+            "updated_by_profile_id"
+          ],
+          "tableTo": "profiles",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "restrict"
+        },
+        "content_sources_status_changed_by_profile_id_fkey": {
+          "name": "content_sources_status_changed_by_profile_id_fkey",
+          "tableFrom": "content_sources",
+          "columnsFrom": [
+            "status_changed_by_profile_id"
+          ],
+          "tableTo": "profiles",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "set null"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {
+        "Authenticated users can view all content sources": {
+          "name": "Authenticated users can view all content sources",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": [
+            "authenticated"
+          ],
+          "using": "true"
+        },
+        "Authenticated users can add content sources": {
+          "name": "Authenticated users can add content sources",
+          "as": "PERMISSIVE",
+          "for": "INSERT",
+          "to": [
+            "authenticated"
+          ],
+          "withCheck": "((created_by_profile_id = current_profile_id()) AND (status = 'pending_review'::content_source_status))"
+        },
+        "Coaches and admins can update content sources": {
+          "name": "Coaches and admins can update content sources",
+          "as": "PERMISSIVE",
+          "for": "UPDATE",
+          "to": [
+            "authenticated"
+          ],
+          "using": "is_coach_or_admin()",
+          "withCheck": "is_coach_or_admin()"
+        },
+        "Coaches and admins can delete content sources": {
+          "name": "Coaches and admins can delete content sources",
+          "as": "PERMISSIVE",
+          "for": "DELETE",
+          "to": [
+            "authenticated"
+          ],
+          "using": "is_coach_or_admin()"
+        }
+      },
+      "checkConstraints": {
+        "content_sources_points_check": {
+          "name": "content_sources_points_check",
+          "value": "(points IS NULL) OR ((points >= (0)::numeric) AND (points <= (3)::numeric))"
+        }
+      },
+      "isRLSEnabled": true
+    },
+    "public.customer_meetings": {
+      "name": "customer_meetings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "profile_id": {
+          "name": "profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "meeting_at": {
+          "name": "meeting_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "company": {
+          "name": "company",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "contact_person": {
+          "name": "contact_person",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "position": {
+          "name": "position",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "objective": {
+          "name": "objective",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "post_mortem": {
+          "name": "post_mortem",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "team_share": {
+          "name": "team_share",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "removed_at": {
+          "name": "removed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_by_profile_id": {
+          "name": "created_by_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_by_profile_id": {
+          "name": "updated_by_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "customer_meetings_profile_idx": {
+          "name": "customer_meetings_profile_idx",
+          "columns": [
+            {
+              "expression": "profile_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "uuid_ops"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "customer_meetings_created_desc_idx": {
+          "name": "customer_meetings_created_desc_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "first",
+              "opclass": "timestamptz_ops"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "customer_meetings_profile_id_fkey": {
+          "name": "customer_meetings_profile_id_fkey",
+          "tableFrom": "customer_meetings",
+          "columnsFrom": [
+            "profile_id"
+          ],
+          "tableTo": "profiles",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        },
+        "customer_meetings_created_by_profile_id_fkey": {
+          "name": "customer_meetings_created_by_profile_id_fkey",
+          "tableFrom": "customer_meetings",
+          "columnsFrom": [
+            "created_by_profile_id"
+          ],
+          "tableTo": "profiles",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "restrict"
+        },
+        "customer_meetings_updated_by_profile_id_fkey": {
+          "name": "customer_meetings_updated_by_profile_id_fkey",
+          "tableFrom": "customer_meetings",
+          "columnsFrom": [
+            "updated_by_profile_id"
+          ],
+          "tableTo": "profiles",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "restrict"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {
+        "Users can view their own customer meetings": {
+          "name": "Users can view their own customer meetings",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": [
+            "authenticated"
+          ],
+          "using": "(profile_id = current_profile_id())"
+        },
+        "Users can create their own customer meetings": {
+          "name": "Users can create their own customer meetings",
+          "as": "PERMISSIVE",
+          "for": "INSERT",
+          "to": [
+            "authenticated"
+          ],
+          "withCheck": "(profile_id = current_profile_id())"
+        },
+        "Users can update their own customer meetings": {
+          "name": "Users can update their own customer meetings",
+          "as": "PERMISSIVE",
+          "for": "UPDATE",
+          "to": [
+            "authenticated"
+          ],
+          "using": "(profile_id = current_profile_id())",
+          "withCheck": "(profile_id = current_profile_id())"
+        },
+        "Users can delete their own customer meetings": {
+          "name": "Users can delete their own customer meetings",
+          "as": "PERMISSIVE",
+          "for": "DELETE",
+          "to": [
+            "authenticated"
+          ],
+          "using": "(profile_id = current_profile_id())"
+        }
+      },
+      "checkConstraints": {},
+      "isRLSEnabled": true
+    },
+    "public.dashboard_layouts": {
+      "name": "dashboard_layouts",
+      "schema": "",
+      "columns": {
+        "profile_id": {
+          "name": "profile_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "widgets": {
+          "name": "widgets",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_by_profile_id": {
+          "name": "created_by_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_by_profile_id": {
+          "name": "updated_by_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "dashboard_layouts_profile_id_fkey": {
+          "name": "dashboard_layouts_profile_id_fkey",
+          "tableFrom": "dashboard_layouts",
+          "columnsFrom": [
+            "profile_id"
+          ],
+          "tableTo": "profiles",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        },
+        "dashboard_layouts_created_by_profile_id_fkey": {
+          "name": "dashboard_layouts_created_by_profile_id_fkey",
+          "tableFrom": "dashboard_layouts",
+          "columnsFrom": [
+            "created_by_profile_id"
+          ],
+          "tableTo": "profiles",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "restrict"
+        },
+        "dashboard_layouts_updated_by_profile_id_fkey": {
+          "name": "dashboard_layouts_updated_by_profile_id_fkey",
+          "tableFrom": "dashboard_layouts",
+          "columnsFrom": [
+            "updated_by_profile_id"
+          ],
+          "tableTo": "profiles",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "restrict"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {
+        "Users can delete their own dashboard layout": {
+          "name": "Users can delete their own dashboard layout",
+          "as": "PERMISSIVE",
+          "for": "DELETE",
+          "to": [
+            "public"
+          ],
+          "using": "(profile_id = current_profile_id())"
+        },
+        "Users can update their own dashboard layout": {
+          "name": "Users can update their own dashboard layout",
+          "as": "PERMISSIVE",
+          "for": "UPDATE",
+          "to": [
+            "public"
+          ],
+          "using": "(profile_id = current_profile_id())",
+          "withCheck": "(profile_id = current_profile_id())"
+        },
+        "Users can insert their own dashboard layout": {
+          "name": "Users can insert their own dashboard layout",
+          "as": "PERMISSIVE",
+          "for": "INSERT",
+          "to": [
+            "public"
+          ],
+          "withCheck": "(profile_id = current_profile_id())"
+        },
+        "Users can view their own dashboard layout": {
+          "name": "Users can view their own dashboard layout",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": [
+            "public"
+          ],
+          "using": "(profile_id = current_profile_id())"
+        }
+      },
+      "checkConstraints": {},
+      "isRLSEnabled": true
+    },
+    "public.essay_coach_reads": {
+      "name": "essay_coach_reads",
+      "schema": "",
+      "columns": {
+        "essay_id": {
+          "name": "essay_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "coach_profile_id": {
+          "name": "coach_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "read_at": {
+          "name": "read_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_by_profile_id": {
+          "name": "created_by_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_by_profile_id": {
+          "name": "updated_by_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "essay_coach_reads_coach_idx": {
+          "name": "essay_coach_reads_coach_idx",
+          "columns": [
+            {
+              "expression": "coach_profile_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "uuid_ops"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "essay_coach_reads_essay_id_fkey": {
+          "name": "essay_coach_reads_essay_id_fkey",
+          "tableFrom": "essay_coach_reads",
+          "columnsFrom": [
+            "essay_id"
+          ],
+          "tableTo": "essays",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        },
+        "essay_coach_reads_coach_profile_id_fkey": {
+          "name": "essay_coach_reads_coach_profile_id_fkey",
+          "tableFrom": "essay_coach_reads",
+          "columnsFrom": [
+            "coach_profile_id"
+          ],
+          "tableTo": "profiles",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        },
+        "essay_coach_reads_created_by_profile_id_fkey": {
+          "name": "essay_coach_reads_created_by_profile_id_fkey",
+          "tableFrom": "essay_coach_reads",
+          "columnsFrom": [
+            "created_by_profile_id"
+          ],
+          "tableTo": "profiles",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "restrict"
+        },
+        "essay_coach_reads_updated_by_profile_id_fkey": {
+          "name": "essay_coach_reads_updated_by_profile_id_fkey",
+          "tableFrom": "essay_coach_reads",
+          "columnsFrom": [
+            "updated_by_profile_id"
+          ],
+          "tableTo": "profiles",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "restrict"
+        }
+      },
+      "compositePrimaryKeys": {
+        "essay_coach_reads_pkey": {
+          "name": "essay_coach_reads_pkey",
+          "columns": [
+            "essay_id",
+            "coach_profile_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {
+        "Coaches remove own reads": {
+          "name": "Coaches remove own reads",
+          "as": "PERMISSIVE",
+          "for": "DELETE",
+          "to": [
+            "authenticated"
+          ],
+          "using": "(coach_profile_id = current_profile_id())"
+        },
+        "Coaches mark own reads within their team": {
+          "name": "Coaches mark own reads within their team",
+          "as": "PERMISSIVE",
+          "for": "INSERT",
+          "to": [
+            "authenticated"
+          ],
+          "withCheck": "((coach_profile_id = current_profile_id()) AND coach_can_review_essay(essay_id))"
+        },
+        "Coach sees own reads; author sees reads of own essays": {
+          "name": "Coach sees own reads; author sees reads of own essays",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": [
+            "authenticated"
+          ],
+          "using": "((coach_profile_id = current_profile_id()) OR (EXISTS ( SELECT 1\n   FROM essays e\n  WHERE ((e.id = essay_coach_reads.essay_id) AND (e.author_profile_id = current_profile_id())))))"
+        }
+      },
+      "checkConstraints": {},
+      "isRLSEnabled": true
+    },
+    "public.essay_comments": {
+      "name": "essay_comments",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "essay_id": {
+          "name": "essay_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "author_profile_id": {
+          "name": "author_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "parent_id": {
+          "name": "parent_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "removed_at": {
+          "name": "removed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_by_profile_id": {
+          "name": "created_by_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_by_profile_id": {
+          "name": "updated_by_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "essay_comments_author_idx": {
+          "name": "essay_comments_author_idx",
+          "columns": [
+            {
+              "expression": "author_profile_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "uuid_ops"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "essay_comments_essay_idx": {
+          "name": "essay_comments_essay_idx",
+          "columns": [
+            {
+              "expression": "essay_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "uuid_ops"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "essay_comments_essay_id_fkey": {
+          "name": "essay_comments_essay_id_fkey",
+          "tableFrom": "essay_comments",
+          "columnsFrom": [
+            "essay_id"
+          ],
+          "tableTo": "essays",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        },
+        "essay_comments_author_profile_id_fkey": {
+          "name": "essay_comments_author_profile_id_fkey",
+          "tableFrom": "essay_comments",
+          "columnsFrom": [
+            "author_profile_id"
+          ],
+          "tableTo": "profiles",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        },
+        "essay_comments_created_by_profile_id_fkey": {
+          "name": "essay_comments_created_by_profile_id_fkey",
+          "tableFrom": "essay_comments",
+          "columnsFrom": [
+            "created_by_profile_id"
+          ],
+          "tableTo": "profiles",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "restrict"
+        },
+        "essay_comments_updated_by_profile_id_fkey": {
+          "name": "essay_comments_updated_by_profile_id_fkey",
+          "tableFrom": "essay_comments",
+          "columnsFrom": [
+            "updated_by_profile_id"
+          ],
+          "tableTo": "profiles",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "restrict"
+        },
+        "essay_comments_parent_id_fkey": {
+          "name": "essay_comments_parent_id_fkey",
+          "tableFrom": "essay_comments",
+          "columnsFrom": [
+            "parent_id"
+          ],
+          "tableTo": "essay_comments",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "set null"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {
+        "Authors and admins can delete essay comments": {
+          "name": "Authors and admins can delete essay comments",
+          "as": "PERMISSIVE",
+          "for": "DELETE",
+          "to": [
+            "authenticated"
+          ],
+          "using": "((author_profile_id = current_profile_id()) OR is_admin())"
+        },
+        "Authors can update their own essay comments": {
+          "name": "Authors can update their own essay comments",
+          "as": "PERMISSIVE",
+          "for": "UPDATE",
+          "to": [
+            "authenticated"
+          ],
+          "using": "(author_profile_id = current_profile_id())",
+          "withCheck": "(author_profile_id = current_profile_id())"
+        },
+        "Authenticated users can add essay comments": {
+          "name": "Authenticated users can add essay comments",
+          "as": "PERMISSIVE",
+          "for": "INSERT",
+          "to": [
+            "authenticated"
+          ],
+          "withCheck": "(author_profile_id = current_profile_id())"
+        },
+        "Authenticated users can view essay comments": {
+          "name": "Authenticated users can view essay comments",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": [
+            "authenticated"
+          ],
+          "using": "true"
+        }
+      },
+      "checkConstraints": {
+        "essay_comments_body_check": {
+          "name": "essay_comments_body_check",
+          "value": "(char_length(body) >= 1) AND (char_length(body) <= 4000)"
+        }
+      },
+      "isRLSEnabled": true
+    },
+    "public.essay_revisions": {
+      "name": "essay_revisions",
+      "schema": "",
+      "columns": {
+        "essay_id": {
+          "name": "essay_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "revision_no": {
+          "name": "revision_no",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content_json": {
+          "name": "content_json",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "invalid_since": {
+          "name": "invalid_since",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_by_profile_id": {
+          "name": "created_by_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_by_profile_id": {
+          "name": "updated_by_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "essay_revisions_essay_id_fkey": {
+          "name": "essay_revisions_essay_id_fkey",
+          "tableFrom": "essay_revisions",
+          "columnsFrom": [
+            "essay_id"
+          ],
+          "tableTo": "essays",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        },
+        "essay_revisions_created_by_profile_id_fkey": {
+          "name": "essay_revisions_created_by_profile_id_fkey",
+          "tableFrom": "essay_revisions",
+          "columnsFrom": [
+            "created_by_profile_id"
+          ],
+          "tableTo": "profiles",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "restrict"
+        },
+        "essay_revisions_updated_by_profile_id_fkey": {
+          "name": "essay_revisions_updated_by_profile_id_fkey",
+          "tableFrom": "essay_revisions",
+          "columnsFrom": [
+            "updated_by_profile_id"
+          ],
+          "tableTo": "profiles",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "restrict"
+        }
+      },
+      "compositePrimaryKeys": {
+        "essay_revisions_pkey": {
+          "name": "essay_revisions_pkey",
+          "columns": [
+            "essay_id",
+            "revision_no"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {
+        "Authenticated users can view essay revisions": {
+          "name": "Authenticated users can view essay revisions",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": [
+            "authenticated"
+          ],
+          "using": "(EXISTS ( SELECT 1\n   FROM essays e\n  WHERE ((e.id = essay_revisions.essay_id) AND ((e.published_at IS NOT NULL) OR (e.author_profile_id = ( SELECT current_profile_id())) OR ( SELECT is_admin())))))"
+        },
+        "Authors can create essay revisions": {
+          "name": "Authors can create essay revisions",
+          "as": "PERMISSIVE",
+          "for": "INSERT",
+          "to": [
+            "authenticated"
+          ],
+          "withCheck": "(created_by_profile_id = current_profile_id())"
+        },
+        "Authors can update their newest recent essay revision": {
+          "name": "Authors can update their newest recent essay revision",
+          "as": "PERMISSIVE",
+          "for": "UPDATE",
+          "to": [
+            "authenticated"
+          ],
+          "using": "((created_by_profile_id = ( SELECT current_profile_id())) AND (created_at > (now() - '00:30:00'::interval)))",
+          "withCheck": "(created_by_profile_id = ( SELECT current_profile_id()))"
+        },
+        "Essay revisions cannot be deleted": {
+          "name": "Essay revisions cannot be deleted",
+          "as": "PERMISSIVE",
+          "for": "DELETE",
+          "to": [
+            "authenticated"
+          ],
+          "using": "false"
+        }
+      },
+      "checkConstraints": {},
+      "isRLSEnabled": true
+    },
+    "public.essay_views": {
+      "name": "essay_views",
+      "schema": "",
+      "columns": {
+        "essay_id": {
+          "name": "essay_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "viewer_profile_id": {
+          "name": "viewer_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "first_viewed_at": {
+          "name": "first_viewed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_viewed_at": {
+          "name": "last_viewed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_by_profile_id": {
+          "name": "created_by_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_by_profile_id": {
+          "name": "updated_by_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "essay_views_viewer_idx": {
+          "name": "essay_views_viewer_idx",
+          "columns": [
+            {
+              "expression": "viewer_profile_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "uuid_ops"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "essay_views_essay_id_fkey": {
+          "name": "essay_views_essay_id_fkey",
+          "tableFrom": "essay_views",
+          "columnsFrom": [
+            "essay_id"
+          ],
+          "tableTo": "essays",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        },
+        "essay_views_viewer_profile_id_fkey": {
+          "name": "essay_views_viewer_profile_id_fkey",
+          "tableFrom": "essay_views",
+          "columnsFrom": [
+            "viewer_profile_id"
+          ],
+          "tableTo": "profiles",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        },
+        "essay_views_created_by_profile_id_fkey": {
+          "name": "essay_views_created_by_profile_id_fkey",
+          "tableFrom": "essay_views",
+          "columnsFrom": [
+            "created_by_profile_id"
+          ],
+          "tableTo": "profiles",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "restrict"
+        },
+        "essay_views_updated_by_profile_id_fkey": {
+          "name": "essay_views_updated_by_profile_id_fkey",
+          "tableFrom": "essay_views",
+          "columnsFrom": [
+            "updated_by_profile_id"
+          ],
+          "tableTo": "profiles",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "restrict"
+        }
+      },
+      "compositePrimaryKeys": {
+        "essay_views_pkey": {
+          "name": "essay_views_pkey",
+          "columns": [
+            "essay_id",
+            "viewer_profile_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {
+        "No direct inserts to essay_views": {
+          "name": "No direct inserts to essay_views",
+          "as": "PERMISSIVE",
+          "for": "INSERT",
+          "to": [
+            "authenticated"
+          ],
+          "withCheck": "false"
+        },
+        "Authors see all viewers; others see own row": {
+          "name": "Authors see all viewers; others see own row",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": [
+            "authenticated"
+          ],
+          "using": "((viewer_profile_id = current_profile_id()) OR (EXISTS ( SELECT 1\n   FROM essays e\n  WHERE ((e.id = essay_views.essay_id) AND (e.author_profile_id = current_profile_id())))))"
+        }
+      },
+      "checkConstraints": {},
+      "isRLSEnabled": true
+    },
+    "public.essay_votes": {
+      "name": "essay_votes",
+      "schema": "",
+      "columns": {
+        "essay_id": {
+          "name": "essay_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "voter_profile_id": {
+          "name": "voter_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_by_profile_id": {
+          "name": "created_by_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_by_profile_id": {
+          "name": "updated_by_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "essay_votes_voter_idx": {
+          "name": "essay_votes_voter_idx",
+          "columns": [
+            {
+              "expression": "voter_profile_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "uuid_ops"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "essay_votes_essay_id_fkey": {
+          "name": "essay_votes_essay_id_fkey",
+          "tableFrom": "essay_votes",
+          "columnsFrom": [
+            "essay_id"
+          ],
+          "tableTo": "essays",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        },
+        "essay_votes_voter_profile_id_fkey": {
+          "name": "essay_votes_voter_profile_id_fkey",
+          "tableFrom": "essay_votes",
+          "columnsFrom": [
+            "voter_profile_id"
+          ],
+          "tableTo": "profiles",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        },
+        "essay_votes_created_by_profile_id_fkey": {
+          "name": "essay_votes_created_by_profile_id_fkey",
+          "tableFrom": "essay_votes",
+          "columnsFrom": [
+            "created_by_profile_id"
+          ],
+          "tableTo": "profiles",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "restrict"
+        },
+        "essay_votes_updated_by_profile_id_fkey": {
+          "name": "essay_votes_updated_by_profile_id_fkey",
+          "tableFrom": "essay_votes",
+          "columnsFrom": [
+            "updated_by_profile_id"
+          ],
+          "tableTo": "profiles",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "restrict"
+        }
+      },
+      "compositePrimaryKeys": {
+        "essay_votes_pkey": {
+          "name": "essay_votes_pkey",
+          "columns": [
+            "essay_id",
+            "voter_profile_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {
+        "Users can vote (not own essays)": {
+          "name": "Users can vote (not own essays)",
+          "as": "PERMISSIVE",
+          "for": "INSERT",
+          "to": [
+            "authenticated"
+          ],
+          "withCheck": "((voter_profile_id = current_profile_id()) AND (NOT (essay_id IN ( SELECT essays.id\n   FROM essays\n  WHERE (essays.author_profile_id = current_profile_id())))))"
+        },
+        "Authenticated users can view votes": {
+          "name": "Authenticated users can view votes",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": [
+            "authenticated"
+          ],
+          "using": "true"
+        },
+        "Users can remove own votes": {
+          "name": "Users can remove own votes",
+          "as": "PERMISSIVE",
+          "for": "DELETE",
+          "to": [
+            "authenticated"
+          ],
+          "using": "(voter_profile_id = current_profile_id())"
+        }
+      },
+      "checkConstraints": {},
+      "isRLSEnabled": true
+    },
+    "public.essays": {
+      "name": "essays",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "external_id": {
+          "name": "external_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "author_profile_id": {
+          "name": "author_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "book_id": {
+          "name": "book_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "frozen_book_points": {
+          "name": "frozen_book_points",
+          "type": "numeric(3, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "content_source_id": {
+          "name": "content_source_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "published_at": {
+          "name": "published_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pinned_at": {
+          "name": "pinned_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pinned_by_profile_id": {
+          "name": "pinned_by_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "removed_at": {
+          "name": "removed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_by_profile_id": {
+          "name": "created_by_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_by_profile_id": {
+          "name": "updated_by_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "essays_author_idx": {
+          "name": "essays_author_idx",
+          "columns": [
+            {
+              "expression": "author_profile_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "uuid_ops"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "essays_book_idx": {
+          "name": "essays_book_idx",
+          "columns": [
+            {
+              "expression": "book_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "uuid_ops"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "essays_content_source_idx": {
+          "name": "essays_content_source_idx",
+          "columns": [
+            {
+              "expression": "content_source_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "uuid_ops"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "essays_created_desc_idx": {
+          "name": "essays_created_desc_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "first",
+              "opclass": "timestamptz_ops"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "essays_author_profile_id_fkey": {
+          "name": "essays_author_profile_id_fkey",
+          "tableFrom": "essays",
+          "columnsFrom": [
+            "author_profile_id"
+          ],
+          "tableTo": "profiles",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        },
+        "essays_book_id_fkey": {
+          "name": "essays_book_id_fkey",
+          "tableFrom": "essays",
+          "columnsFrom": [
+            "book_id"
+          ],
+          "tableTo": "books",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "set null"
+        },
+        "essays_content_source_id_fkey": {
+          "name": "essays_content_source_id_fkey",
+          "tableFrom": "essays",
+          "columnsFrom": [
+            "content_source_id"
+          ],
+          "tableTo": "content_sources",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "set null"
+        },
+        "essays_pinned_by_profile_id_fkey": {
+          "name": "essays_pinned_by_profile_id_fkey",
+          "tableFrom": "essays",
+          "columnsFrom": [
+            "pinned_by_profile_id"
+          ],
+          "tableTo": "profiles",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "set null"
+        },
+        "essays_created_by_profile_id_fkey": {
+          "name": "essays_created_by_profile_id_fkey",
+          "tableFrom": "essays",
+          "columnsFrom": [
+            "created_by_profile_id"
+          ],
+          "tableTo": "profiles",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "restrict"
+        },
+        "essays_updated_by_profile_id_fkey": {
+          "name": "essays_updated_by_profile_id_fkey",
+          "tableFrom": "essays",
+          "columnsFrom": [
+            "updated_by_profile_id"
+          ],
+          "tableTo": "profiles",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "restrict"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {
+        "Authors can create their own essays": {
+          "name": "Authors can create their own essays",
+          "as": "PERMISSIVE",
+          "for": "INSERT",
+          "to": [
+            "authenticated"
+          ],
+          "withCheck": "(author_profile_id = current_profile_id())"
+        },
+        "Authenticated users can view all essays": {
+          "name": "Authenticated users can view all essays",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": [
+            "authenticated"
+          ],
+          "using": "((published_at IS NOT NULL) OR (author_profile_id = ( SELECT current_profile_id())) OR ( SELECT is_admin()))"
+        },
+        "Authors and admins can delete essays": {
+          "name": "Authors and admins can delete essays",
+          "as": "PERMISSIVE",
+          "for": "DELETE",
+          "to": [
+            "authenticated"
+          ],
+          "using": "((author_profile_id = current_profile_id()) OR is_admin())"
+        },
+        "Authors can update their own essays": {
+          "name": "Authors can update their own essays",
+          "as": "PERMISSIVE",
+          "for": "UPDATE",
+          "to": [
+            "authenticated"
+          ],
+          "using": "(author_profile_id = current_profile_id())",
+          "withCheck": "(author_profile_id = current_profile_id())"
+        }
+      },
+      "checkConstraints": {
+        "essays_source_exclusive_check": {
+          "name": "essays_source_exclusive_check",
+          "value": "NOT ((book_id IS NOT NULL) AND (content_source_id IS NOT NULL))"
+        },
+        "essays_frozen_book_points_check": {
+          "name": "essays_frozen_book_points_check",
+          "value": "(frozen_book_points IS NULL) OR ((frozen_book_points >= (0)::numeric) AND (frozen_book_points <= (3)::numeric))"
+        }
+      },
+      "isRLSEnabled": true
+    },
+    "public.feedback": {
+      "name": "feedback",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "author_profile_id": {
+          "name": "author_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "resolved_at": {
+          "name": "resolved_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_by_profile_id": {
+          "name": "created_by_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_by_profile_id": {
+          "name": "updated_by_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "feedback_active_created_idx": {
+          "name": "feedback_active_created_idx",
+          "columns": [
+            {
+              "expression": "resolved_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "timestamptz_ops"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "first",
+              "opclass": "timestamptz_ops"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "feedback_author_idx": {
+          "name": "feedback_author_idx",
+          "columns": [
+            {
+              "expression": "author_profile_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "uuid_ops"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "feedback_author_profile_id_fkey": {
+          "name": "feedback_author_profile_id_fkey",
+          "tableFrom": "feedback",
+          "columnsFrom": [
+            "author_profile_id"
+          ],
+          "tableTo": "profiles",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        },
+        "feedback_created_by_profile_id_fkey": {
+          "name": "feedback_created_by_profile_id_fkey",
+          "tableFrom": "feedback",
+          "columnsFrom": [
+            "created_by_profile_id"
+          ],
+          "tableTo": "profiles",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "restrict"
+        },
+        "feedback_updated_by_profile_id_fkey": {
+          "name": "feedback_updated_by_profile_id_fkey",
+          "tableFrom": "feedback",
+          "columnsFrom": [
+            "updated_by_profile_id"
+          ],
+          "tableTo": "profiles",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "restrict"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {
+        "Authenticated users can view feedback": {
+          "name": "Authenticated users can view feedback",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": [
+            "authenticated"
+          ],
+          "using": "true"
+        },
+        "Authenticated users can create feedback": {
+          "name": "Authenticated users can create feedback",
+          "as": "PERMISSIVE",
+          "for": "INSERT",
+          "to": [
+            "authenticated"
+          ],
+          "withCheck": "(author_profile_id = current_profile_id())"
+        },
+        "Admins can update feedback": {
+          "name": "Admins can update feedback",
+          "as": "PERMISSIVE",
+          "for": "UPDATE",
+          "to": [
+            "authenticated"
+          ],
+          "using": "is_admin()",
+          "withCheck": "is_admin()"
+        },
+        "Authors and admins can delete feedback": {
+          "name": "Authors and admins can delete feedback",
+          "as": "PERMISSIVE",
+          "for": "DELETE",
+          "to": [
+            "authenticated"
+          ],
+          "using": "((author_profile_id = current_profile_id()) OR is_admin())"
+        }
+      },
+      "checkConstraints": {
+        "feedback_body_check": {
+          "name": "feedback_body_check",
+          "value": "(char_length(body) >= 1) AND (char_length(body) <= 4000)"
+        }
+      },
+      "isRLSEnabled": true
+    },
+    "public.individual_coaching_sessions": {
+      "name": "individual_coaching_sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "profile_id": {
+          "name": "profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "session_at": {
+          "name": "session_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "coach_profile_id": {
+          "name": "coach_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "external_coach_name": {
+          "name": "external_coach_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "key_takeaways": {
+          "name": "key_takeaways",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "action_steps": {
+          "name": "action_steps",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "removed_at": {
+          "name": "removed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_by_profile_id": {
+          "name": "created_by_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_by_profile_id": {
+          "name": "updated_by_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "individual_coaching_sessions_profile_idx": {
+          "name": "individual_coaching_sessions_profile_idx",
+          "columns": [
+            {
+              "expression": "profile_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "uuid_ops"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "individual_coaching_sessions_coach_idx": {
+          "name": "individual_coaching_sessions_coach_idx",
+          "columns": [
+            {
+              "expression": "coach_profile_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "uuid_ops"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "individual_coaching_sessions_created_desc_idx": {
+          "name": "individual_coaching_sessions_created_desc_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "first",
+              "opclass": "timestamptz_ops"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "individual_coaching_sessions_profile_id_fkey": {
+          "name": "individual_coaching_sessions_profile_id_fkey",
+          "tableFrom": "individual_coaching_sessions",
+          "columnsFrom": [
+            "profile_id"
+          ],
+          "tableTo": "profiles",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        },
+        "individual_coaching_sessions_coach_profile_id_fkey": {
+          "name": "individual_coaching_sessions_coach_profile_id_fkey",
+          "tableFrom": "individual_coaching_sessions",
+          "columnsFrom": [
+            "coach_profile_id"
+          ],
+          "tableTo": "profiles",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "set null"
+        },
+        "individual_coaching_sessions_created_by_profile_id_fkey": {
+          "name": "individual_coaching_sessions_created_by_profile_id_fkey",
+          "tableFrom": "individual_coaching_sessions",
+          "columnsFrom": [
+            "created_by_profile_id"
+          ],
+          "tableTo": "profiles",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "restrict"
+        },
+        "individual_coaching_sessions_updated_by_profile_id_fkey": {
+          "name": "individual_coaching_sessions_updated_by_profile_id_fkey",
+          "tableFrom": "individual_coaching_sessions",
+          "columnsFrom": [
+            "updated_by_profile_id"
+          ],
+          "tableTo": "profiles",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "restrict"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {
+        "Users can view their own coaching sessions": {
+          "name": "Users can view their own coaching sessions",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": [
+            "authenticated"
+          ],
+          "using": "(profile_id = current_profile_id())"
+        },
+        "Users can create their own coaching sessions": {
+          "name": "Users can create their own coaching sessions",
+          "as": "PERMISSIVE",
+          "for": "INSERT",
+          "to": [
+            "authenticated"
+          ],
+          "withCheck": "(profile_id = current_profile_id())"
+        },
+        "Users can update their own coaching sessions": {
+          "name": "Users can update their own coaching sessions",
+          "as": "PERMISSIVE",
+          "for": "UPDATE",
+          "to": [
+            "authenticated"
+          ],
+          "using": "(profile_id = current_profile_id())",
+          "withCheck": "(profile_id = current_profile_id())"
+        },
+        "Users can delete their own coaching sessions": {
+          "name": "Users can delete their own coaching sessions",
+          "as": "PERMISSIVE",
+          "for": "DELETE",
+          "to": [
+            "authenticated"
+          ],
+          "using": "(profile_id = current_profile_id())"
+        }
+      },
+      "checkConstraints": {
+        "individual_coaching_sessions_coach_xor": {
+          "name": "individual_coaching_sessions_coach_xor",
+          "value": "(coach_profile_id IS NOT NULL) <> (external_coach_name IS NOT NULL)"
+        }
+      },
+      "isRLSEnabled": true
+    },
+    "public.notification_preferences": {
+      "name": "notification_preferences",
+      "schema": "",
+      "columns": {
+        "profile_id": {
+          "name": "profile_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "essay_coach_read_email": {
+          "name": "essay_coach_read_email",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "essay_comment_email": {
+          "name": "essay_comment_email",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "essay_vote_email": {
+          "name": "essay_vote_email",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "book_submitted_email": {
+          "name": "book_submitted_email",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_by_profile_id": {
+          "name": "created_by_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_by_profile_id": {
+          "name": "updated_by_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "notification_preferences_profile_id_fkey": {
+          "name": "notification_preferences_profile_id_fkey",
+          "tableFrom": "notification_preferences",
+          "columnsFrom": [
+            "profile_id"
+          ],
+          "tableTo": "profiles",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        },
+        "notification_preferences_created_by_profile_id_fkey": {
+          "name": "notification_preferences_created_by_profile_id_fkey",
+          "tableFrom": "notification_preferences",
+          "columnsFrom": [
+            "created_by_profile_id"
+          ],
+          "tableTo": "profiles",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "restrict"
+        },
+        "notification_preferences_updated_by_profile_id_fkey": {
+          "name": "notification_preferences_updated_by_profile_id_fkey",
+          "tableFrom": "notification_preferences",
+          "columnsFrom": [
+            "updated_by_profile_id"
+          ],
+          "tableTo": "profiles",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "restrict"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {
+        "Users can view their own notification preferences": {
+          "name": "Users can view their own notification preferences",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": [
+            "authenticated"
+          ],
+          "using": "(profile_id = current_profile_id())"
+        },
+        "Users can insert their own notification preferences": {
+          "name": "Users can insert their own notification preferences",
+          "as": "PERMISSIVE",
+          "for": "INSERT",
+          "to": [
+            "authenticated"
+          ],
+          "withCheck": "(profile_id = current_profile_id())"
+        },
+        "Users can update their own notification preferences": {
+          "name": "Users can update their own notification preferences",
+          "as": "PERMISSIVE",
+          "for": "UPDATE",
+          "to": [
+            "authenticated"
+          ],
+          "using": "(profile_id = current_profile_id())",
+          "withCheck": "(profile_id = current_profile_id())"
+        }
+      },
+      "checkConstraints": {},
+      "isRLSEnabled": true
+    },
+    "public.personality_tests": {
+      "name": "personality_tests",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "profile_id": {
+          "name": "profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "test_type": {
+          "name": "test_type",
+          "type": "personality_test_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "test_type_other": {
+          "name": "test_type_other",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tested_on": {
+          "name": "tested_on",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "file_path": {
+          "name": "file_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "file_name": {
+          "name": "file_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "file_size": {
+          "name": "file_size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "removed_at": {
+          "name": "removed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_by_profile_id": {
+          "name": "created_by_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_by_profile_id": {
+          "name": "updated_by_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "personality_tests_profile_tested_on_idx": {
+          "name": "personality_tests_profile_tested_on_idx",
+          "columns": [
+            {
+              "expression": "profile_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "uuid_ops"
+            },
+            {
+              "expression": "tested_on",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "date_ops"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "personality_tests_profile_id_fkey": {
+          "name": "personality_tests_profile_id_fkey",
+          "tableFrom": "personality_tests",
+          "columnsFrom": [
+            "profile_id"
+          ],
+          "tableTo": "profiles",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        },
+        "personality_tests_created_by_profile_id_fkey": {
+          "name": "personality_tests_created_by_profile_id_fkey",
+          "tableFrom": "personality_tests",
+          "columnsFrom": [
+            "created_by_profile_id"
+          ],
+          "tableTo": "profiles",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "restrict"
+        },
+        "personality_tests_updated_by_profile_id_fkey": {
+          "name": "personality_tests_updated_by_profile_id_fkey",
+          "tableFrom": "personality_tests",
+          "columnsFrom": [
+            "updated_by_profile_id"
+          ],
+          "tableTo": "profiles",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "restrict"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {
+        "Verified users can view personality tests": {
+          "name": "Verified users can view personality tests",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": [
+            "authenticated"
+          ],
+          "using": "(EXISTS (SELECT 1 FROM users WHERE (users.auth_user_id = (SELECT auth.uid()) AND users.verified_work_email IS NOT NULL)))"
+        },
+        "Users can create their own personality tests": {
+          "name": "Users can create their own personality tests",
+          "as": "PERMISSIVE",
+          "for": "INSERT",
+          "to": [
+            "authenticated"
+          ],
+          "withCheck": "(profile_id = current_profile_id())"
+        },
+        "Users can update their own personality tests": {
+          "name": "Users can update their own personality tests",
+          "as": "PERMISSIVE",
+          "for": "UPDATE",
+          "to": [
+            "authenticated"
+          ],
+          "using": "(profile_id = current_profile_id())",
+          "withCheck": "(profile_id = current_profile_id())"
+        },
+        "Users can delete their own personality tests": {
+          "name": "Users can delete their own personality tests",
+          "as": "PERMISSIVE",
+          "for": "DELETE",
+          "to": [
+            "authenticated"
+          ],
+          "using": "(profile_id = current_profile_id())"
+        }
+      },
+      "checkConstraints": {
+        "personality_tests_other_type_required": {
+          "name": "personality_tests_other_type_required",
+          "value": "(test_type <> 'other' OR (test_type_other IS NOT NULL AND length(trim(test_type_other)) > 0))"
+        }
+      },
+      "isRLSEnabled": true
+    },
+    "public.profiles": {
+      "name": "profiles",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "picture": {
+          "name": "picture",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "work_email": {
+          "name": "work_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "profile_role",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'student'"
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "phone_number": {
+          "name": "phone_number",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "personal_email": {
+          "name": "personal_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "date_of_birth": {
+          "name": "date_of_birth",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_removed_at": {
+          "name": "access_removed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_removed_by_profile_id": {
+          "name": "access_removed_by_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "beta_access_granted_at": {
+          "name": "beta_access_granted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "beta_cohort": {
+          "name": "beta_cohort",
+          "type": "beta_cohort",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'A'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_by_profile_id": {
+          "name": "created_by_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_by_profile_id": {
+          "name": "updated_by_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "profiles_team_id_idx": {
+          "name": "profiles_team_id_idx",
+          "columns": [
+            {
+              "expression": "team_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "uuid_ops"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "profiles_team_id_user_id_idx": {
+          "name": "profiles_team_id_user_id_idx",
+          "columns": [
+            {
+              "expression": "team_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "uuid_ops"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "uuid_ops"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "profiles_user_id_idx": {
+          "name": "profiles_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "uuid_ops"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "profiles_work_email_idx": {
+          "name": "profiles_work_email_idx",
+          "columns": [
+            {
+              "expression": "work_email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "text_ops"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "profiles_user_id_fkey": {
+          "name": "profiles_user_id_fkey",
+          "tableFrom": "profiles",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "tableTo": "users",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "set null"
+        },
+        "profiles_team_id_fkey": {
+          "name": "profiles_team_id_fkey",
+          "tableFrom": "profiles",
+          "columnsFrom": [
+            "team_id"
+          ],
+          "tableTo": "teams",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "set null"
+        },
+        "profiles_access_removed_by_profile_id_fkey": {
+          "name": "profiles_access_removed_by_profile_id_fkey",
+          "tableFrom": "profiles",
+          "columnsFrom": [
+            "access_removed_by_profile_id"
+          ],
+          "tableTo": "profiles",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "set null"
+        },
+        "profiles_created_by_profile_id_fkey": {
+          "name": "profiles_created_by_profile_id_fkey",
+          "tableFrom": "profiles",
+          "columnsFrom": [
+            "created_by_profile_id"
+          ],
+          "tableTo": "profiles",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "set null"
+        },
+        "profiles_updated_by_profile_id_fkey": {
+          "name": "profiles_updated_by_profile_id_fkey",
+          "tableFrom": "profiles",
+          "columnsFrom": [
+            "updated_by_profile_id"
+          ],
+          "tableTo": "profiles",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "set null"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "profiles_user_id_key": {
+          "name": "profiles_user_id_key",
+          "columns": [
+            "user_id"
+          ],
+          "nullsNotDistinct": false
+        },
+        "profiles_work_email_key": {
+          "name": "profiles_work_email_key",
+          "columns": [
+            "work_email"
+          ],
+          "nullsNotDistinct": false
+        }
+      },
+      "policies": {
+        "Verified users can view all profiles": {
+          "name": "Verified users can view all profiles",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": [
+            "authenticated"
+          ],
+          "using": "((access_removed_at IS NULL) AND (EXISTS ( SELECT 1\n   FROM users\n  WHERE ((users.auth_user_id = ( SELECT auth.uid() AS uid)) AND (users.verified_work_email IS NOT NULL)))))"
+        },
+        "Users can update their own profile picture": {
+          "name": "Users can update their own profile picture",
+          "as": "PERMISSIVE",
+          "for": "UPDATE",
+          "to": [
+            "authenticated"
+          ],
+          "using": "(user_id IN ( SELECT users.id\n   FROM users\n  WHERE (users.auth_user_id = ( SELECT auth.uid() AS uid))))",
+          "withCheck": "(user_id IN ( SELECT users.id\n   FROM users\n  WHERE (users.auth_user_id = ( SELECT auth.uid() AS uid))))"
+        }
+      },
+      "checkConstraints": {
+        "valid_czu_domain": {
+          "name": "valid_czu_domain",
+          "value": "(lower(split_part(work_email, '@'::text, 2)) = ANY (ARRAY['pef.czu.cz'::text, 'studenti.czu.cz'::text, 'rektorat.czu.cz'::text]))"
+        }
+      },
+      "isRLSEnabled": true
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "auth_user_id": {
+          "name": "auth_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "google_email": {
+          "name": "google_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "suggested_work_email": {
+          "name": "suggested_work_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "verified_work_email": {
+          "name": "verified_work_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "verified_work_email_at": {
+          "name": "verified_work_email_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_otp_sent_at": {
+          "name": "last_otp_sent_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "users_google_email_idx": {
+          "name": "users_google_email_idx",
+          "columns": [
+            {
+              "expression": "google_email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "text_ops"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "users_suggested_work_email_idx": {
+          "name": "users_suggested_work_email_idx",
+          "columns": [
+            {
+              "expression": "suggested_work_email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "text_ops"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "users_auth_user_id_fkey": {
+          "name": "users_auth_user_id_fkey",
+          "tableFrom": "users",
+          "columnsFrom": [
+            "auth_user_id"
+          ],
+          "tableTo": "users",
+          "schemaTo": "auth",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_auth_user_id_key": {
+          "name": "users_auth_user_id_key",
+          "columns": [
+            "auth_user_id"
+          ],
+          "nullsNotDistinct": false
+        },
+        "users_google_email_key": {
+          "name": "users_google_email_key",
+          "columns": [
+            "google_email"
+          ],
+          "nullsNotDistinct": false
+        }
+      },
+      "policies": {
+        "Users can update only suggested_work_email": {
+          "name": "Users can update only suggested_work_email",
+          "as": "PERMISSIVE",
+          "for": "UPDATE",
+          "to": [
+            "authenticated"
+          ],
+          "using": "(( SELECT auth.uid() AS uid) = auth_user_id)",
+          "withCheck": "(( SELECT auth.uid() AS uid) = auth_user_id)"
+        },
+        "Users can insert their own user record": {
+          "name": "Users can insert their own user record",
+          "as": "PERMISSIVE",
+          "for": "INSERT",
+          "to": [
+            "authenticated"
+          ],
+          "withCheck": "(( SELECT auth.uid() AS uid) = auth_user_id)"
+        },
+        "Users can view their own user record": {
+          "name": "Users can view their own user record",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": [
+            "authenticated"
+          ],
+          "using": "(( SELECT auth.uid() AS uid) = auth_user_id)"
+        }
+      },
+      "checkConstraints": {},
+      "isRLSEnabled": true
+    },
+    "public.recurring_schedules": {
+      "name": "recurring_schedules",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "room_id": {
+          "name": "room_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "schedule_type": {
+          "name": "schedule_type",
+          "type": "schedule_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "day_of_week": {
+          "name": "day_of_week",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "start_time": {
+          "name": "start_time",
+          "type": "time",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "end_time": {
+          "name": "end_time",
+          "type": "time",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "valid_from": {
+          "name": "valid_from",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "valid_until": {
+          "name": "valid_until",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "removed_at": {
+          "name": "removed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_by_profile_id": {
+          "name": "created_by_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_by_profile_id": {
+          "name": "updated_by_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "idx_recurring_schedules_day": {
+          "name": "idx_recurring_schedules_day",
+          "columns": [
+            {
+              "expression": "day_of_week",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "int2_ops"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "idx_recurring_schedules_room": {
+          "name": "idx_recurring_schedules_room",
+          "columns": [
+            {
+              "expression": "room_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "uuid_ops"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "idx_recurring_schedules_team": {
+          "name": "idx_recurring_schedules_team",
+          "columns": [
+            {
+              "expression": "team_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "uuid_ops"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "idx_recurring_schedules_type": {
+          "name": "idx_recurring_schedules_type",
+          "columns": [
+            {
+              "expression": "schedule_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "enum_ops"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "idx_recurring_schedules_valid": {
+          "name": "idx_recurring_schedules_valid",
+          "columns": [
+            {
+              "expression": "valid_from",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "date_ops"
+            },
+            {
+              "expression": "valid_until",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "date_ops"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "recurring_schedules_room_id_fkey": {
+          "name": "recurring_schedules_room_id_fkey",
+          "tableFrom": "recurring_schedules",
+          "columnsFrom": [
+            "room_id"
+          ],
+          "tableTo": "rooms",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        },
+        "recurring_schedules_team_id_fkey": {
+          "name": "recurring_schedules_team_id_fkey",
+          "tableFrom": "recurring_schedules",
+          "columnsFrom": [
+            "team_id"
+          ],
+          "tableTo": "teams",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        },
+        "recurring_schedules_created_by_profile_id_fkey": {
+          "name": "recurring_schedules_created_by_profile_id_fkey",
+          "tableFrom": "recurring_schedules",
+          "columnsFrom": [
+            "created_by_profile_id"
+          ],
+          "tableTo": "profiles",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "restrict"
+        },
+        "recurring_schedules_updated_by_profile_id_fkey": {
+          "name": "recurring_schedules_updated_by_profile_id_fkey",
+          "tableFrom": "recurring_schedules",
+          "columnsFrom": [
+            "updated_by_profile_id"
+          ],
+          "tableTo": "profiles",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "restrict"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {
+        "Coaches can manage recurring_schedules": {
+          "name": "Coaches can manage recurring_schedules",
+          "as": "PERMISSIVE",
+          "for": "ALL",
+          "to": [
+            "authenticated"
+          ],
+          "using": "(EXISTS ( SELECT 1\n   FROM profiles\n  WHERE ((profiles.user_id IN ( SELECT users.id\n           FROM users\n          WHERE (users.auth_user_id = ( SELECT auth.uid() AS uid)))) AND (profiles.role = ANY (ARRAY['coach'::profile_role, 'admin'::profile_role])))))",
+          "withCheck": "(EXISTS ( SELECT 1\n   FROM profiles\n  WHERE ((profiles.user_id IN ( SELECT users.id\n           FROM users\n          WHERE (users.auth_user_id = ( SELECT auth.uid() AS uid)))) AND (profiles.role = ANY (ARRAY['coach'::profile_role, 'admin'::profile_role])))))"
+        },
+        "Authenticated can read recurring_schedules": {
+          "name": "Authenticated can read recurring_schedules",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": [
+            "authenticated"
+          ],
+          "using": "true"
+        }
+      },
+      "checkConstraints": {
+        "recurring_schedules_day_of_week_check": {
+          "name": "recurring_schedules_day_of_week_check",
+          "value": "(day_of_week >= 0) AND (day_of_week <= 6)"
+        },
+        "valid_time_range": {
+          "name": "valid_time_range",
+          "value": "end_time > start_time"
+        },
+        "valid_schedule_dates": {
+          "name": "valid_schedule_dates",
+          "value": "(valid_until IS NULL) OR (valid_until >= valid_from)"
+        },
+        "recurring_schedules_team_for_ts": {
+          "name": "recurring_schedules_team_for_ts",
+          "value": "(schedule_type <> 'training_session'::schedule_type) OR (team_id IS NOT NULL)"
+        }
+      },
+      "isRLSEnabled": true
+    },
+    "public.reservations": {
+      "name": "reservations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "room_id": {
+          "name": "room_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "owner_profile_id": {
+          "name": "owner_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "person_count": {
+          "name": "person_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "start_at": {
+          "name": "start_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "end_at": {
+          "name": "end_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cancelled_at": {
+          "name": "cancelled_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cancelled_by_profile_id": {
+          "name": "cancelled_by_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_by_profile_id": {
+          "name": "created_by_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_by_profile_id": {
+          "name": "updated_by_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "idx_reservations_room_time": {
+          "name": "idx_reservations_room_time",
+          "columns": [
+            {
+              "expression": "room_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "uuid_ops"
+            },
+            {
+              "expression": "start_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "timestamptz_ops"
+            },
+            {
+              "expression": "end_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "timestamptz_ops"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "idx_reservations_start": {
+          "name": "idx_reservations_start",
+          "columns": [
+            {
+              "expression": "start_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "timestamptz_ops"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "idx_reservations_owner": {
+          "name": "idx_reservations_owner",
+          "columns": [
+            {
+              "expression": "owner_profile_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "uuid_ops"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "reservations_room_id_fkey": {
+          "name": "reservations_room_id_fkey",
+          "tableFrom": "reservations",
+          "columnsFrom": [
+            "room_id"
+          ],
+          "tableTo": "rooms",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        },
+        "reservations_owner_profile_id_fkey": {
+          "name": "reservations_owner_profile_id_fkey",
+          "tableFrom": "reservations",
+          "columnsFrom": [
+            "owner_profile_id"
+          ],
+          "tableTo": "profiles",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "set null"
+        },
+        "reservations_cancelled_by_profile_id_fkey": {
+          "name": "reservations_cancelled_by_profile_id_fkey",
+          "tableFrom": "reservations",
+          "columnsFrom": [
+            "cancelled_by_profile_id"
+          ],
+          "tableTo": "profiles",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "set null"
+        },
+        "reservations_created_by_profile_id_fkey": {
+          "name": "reservations_created_by_profile_id_fkey",
+          "tableFrom": "reservations",
+          "columnsFrom": [
+            "created_by_profile_id"
+          ],
+          "tableTo": "profiles",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "restrict"
+        },
+        "reservations_updated_by_profile_id_fkey": {
+          "name": "reservations_updated_by_profile_id_fkey",
+          "tableFrom": "reservations",
+          "columnsFrom": [
+            "updated_by_profile_id"
+          ],
+          "tableTo": "profiles",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "restrict"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {
+        "Authenticated can read reservations": {
+          "name": "Authenticated can read reservations",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": [
+            "authenticated"
+          ],
+          "using": "true"
+        },
+        "Users can delete own reservations": {
+          "name": "Users can delete own reservations",
+          "as": "PERMISSIVE",
+          "for": "DELETE",
+          "to": [
+            "authenticated"
+          ],
+          "using": "(owner_profile_id IN ( SELECT profiles.id\n   FROM profiles\n  WHERE (profiles.user_id IN ( SELECT users.id\n           FROM users\n          WHERE (users.auth_user_id = ( SELECT auth.uid() AS uid))))))"
+        },
+        "Users can update own reservations": {
+          "name": "Users can update own reservations",
+          "as": "PERMISSIVE",
+          "for": "UPDATE",
+          "to": [
+            "authenticated"
+          ],
+          "using": "(owner_profile_id IN ( SELECT profiles.id\n   FROM profiles\n  WHERE (profiles.user_id IN ( SELECT users.id\n           FROM users\n          WHERE (users.auth_user_id = ( SELECT auth.uid() AS uid))))))",
+          "withCheck": "(owner_profile_id IN ( SELECT profiles.id\n   FROM profiles\n  WHERE (profiles.user_id IN ( SELECT users.id\n           FROM users\n          WHERE (users.auth_user_id = ( SELECT auth.uid() AS uid))))))"
+        },
+        "Users can create own reservations": {
+          "name": "Users can create own reservations",
+          "as": "PERMISSIVE",
+          "for": "INSERT",
+          "to": [
+            "authenticated"
+          ],
+          "withCheck": "(owner_profile_id IN ( SELECT profiles.id\n   FROM profiles\n  WHERE (profiles.user_id IN ( SELECT users.id\n           FROM users\n          WHERE (users.auth_user_id = ( SELECT auth.uid() AS uid))))))"
+        }
+      },
+      "checkConstraints": {
+        "valid_reservation_time": {
+          "name": "valid_reservation_time",
+          "value": "end_at > start_at"
+        }
+      },
+      "isRLSEnabled": true
+    },
+    "public.rooms": {
+      "name": "rooms",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "code": {
+          "name": "code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "available_days": {
+          "name": "available_days",
+          "type": "integer[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "can_have_ts": {
+          "name": "can_have_ts",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "removed_at": {
+          "name": "removed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_by_profile_id": {
+          "name": "created_by_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_by_profile_id": {
+          "name": "updated_by_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "idx_rooms_code": {
+          "name": "idx_rooms_code",
+          "columns": [
+            {
+              "expression": "code",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "text_ops"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "rooms_created_by_profile_id_fkey": {
+          "name": "rooms_created_by_profile_id_fkey",
+          "tableFrom": "rooms",
+          "columnsFrom": [
+            "created_by_profile_id"
+          ],
+          "tableTo": "profiles",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "restrict"
+        },
+        "rooms_updated_by_profile_id_fkey": {
+          "name": "rooms_updated_by_profile_id_fkey",
+          "tableFrom": "rooms",
+          "columnsFrom": [
+            "updated_by_profile_id"
+          ],
+          "tableTo": "profiles",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "restrict"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "rooms_code_key": {
+          "name": "rooms_code_key",
+          "columns": [
+            "code"
+          ],
+          "nullsNotDistinct": false
+        }
+      },
+      "policies": {
+        "Admins can manage rooms": {
+          "name": "Admins can manage rooms",
+          "as": "PERMISSIVE",
+          "for": "ALL",
+          "to": [
+            "authenticated"
+          ],
+          "using": "(EXISTS ( SELECT 1\n   FROM profiles\n  WHERE ((profiles.user_id IN ( SELECT users.id\n           FROM users\n          WHERE (users.auth_user_id = ( SELECT auth.uid() AS uid)))) AND (profiles.role = 'admin'::profile_role))))",
+          "withCheck": "(EXISTS ( SELECT 1\n   FROM profiles\n  WHERE ((profiles.user_id IN ( SELECT users.id\n           FROM users\n          WHERE (users.auth_user_id = ( SELECT auth.uid() AS uid)))) AND (profiles.role = 'admin'::profile_role))))"
+        },
+        "Authenticated can read rooms": {
+          "name": "Authenticated can read rooms",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": [
+            "authenticated"
+          ],
+          "using": "true"
+        }
+      },
+      "checkConstraints": {},
+      "isRLSEnabled": true
+    },
+    "public.schedule_breaks": {
+      "name": "schedule_breaks",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "start_date": {
+          "name": "start_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "end_date": {
+          "name": "end_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_by_profile_id": {
+          "name": "created_by_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_by_profile_id": {
+          "name": "updated_by_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "idx_schedule_breaks_dates": {
+          "name": "idx_schedule_breaks_dates",
+          "columns": [
+            {
+              "expression": "start_date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "date_ops"
+            },
+            {
+              "expression": "end_date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "date_ops"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "schedule_breaks_created_by_profile_id_fkey": {
+          "name": "schedule_breaks_created_by_profile_id_fkey",
+          "tableFrom": "schedule_breaks",
+          "columnsFrom": [
+            "created_by_profile_id"
+          ],
+          "tableTo": "profiles",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "restrict"
+        },
+        "schedule_breaks_updated_by_profile_id_fkey": {
+          "name": "schedule_breaks_updated_by_profile_id_fkey",
+          "tableFrom": "schedule_breaks",
+          "columnsFrom": [
+            "updated_by_profile_id"
+          ],
+          "tableTo": "profiles",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "restrict"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {
+        "Coaches can manage schedule_breaks": {
+          "name": "Coaches can manage schedule_breaks",
+          "as": "PERMISSIVE",
+          "for": "ALL",
+          "to": [
+            "authenticated"
+          ],
+          "using": "(EXISTS ( SELECT 1\n   FROM profiles\n  WHERE ((profiles.user_id IN ( SELECT users.id\n           FROM users\n          WHERE (users.auth_user_id = ( SELECT auth.uid() AS uid)))) AND (profiles.role = ANY (ARRAY['coach'::profile_role, 'admin'::profile_role])))))",
+          "withCheck": "(EXISTS ( SELECT 1\n   FROM profiles\n  WHERE ((profiles.user_id IN ( SELECT users.id\n           FROM users\n          WHERE (users.auth_user_id = ( SELECT auth.uid() AS uid)))) AND (profiles.role = ANY (ARRAY['coach'::profile_role, 'admin'::profile_role])))))"
+        },
+        "Authenticated can read schedule_breaks": {
+          "name": "Authenticated can read schedule_breaks",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": [
+            "authenticated"
+          ],
+          "using": "true"
+        }
+      },
+      "checkConstraints": {
+        "valid_break_date_range": {
+          "name": "valid_break_date_range",
+          "value": "end_date >= start_date"
+        }
+      },
+      "isRLSEnabled": true
+    },
+    "public.team_activities": {
+      "name": "team_activities",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "occurred_at": {
+          "name": "occurred_at",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "activity_type": {
+          "name": "activity_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "participants": {
+          "name": "participants",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reflection": {
+          "name": "reflection",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "image_path": {
+          "name": "image_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "removed_at": {
+          "name": "removed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_by_profile_id": {
+          "name": "created_by_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_by_profile_id": {
+          "name": "updated_by_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "team_activities_team_occurred_at_idx": {
+          "name": "team_activities_team_occurred_at_idx",
+          "columns": [
+            {
+              "expression": "team_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "uuid_ops"
+            },
+            {
+              "expression": "occurred_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "date_ops"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "team_activities_team_id_fkey": {
+          "name": "team_activities_team_id_fkey",
+          "tableFrom": "team_activities",
+          "columnsFrom": [
+            "team_id"
+          ],
+          "tableTo": "teams",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        },
+        "team_activities_created_by_profile_id_fkey": {
+          "name": "team_activities_created_by_profile_id_fkey",
+          "tableFrom": "team_activities",
+          "columnsFrom": [
+            "created_by_profile_id"
+          ],
+          "tableTo": "profiles",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "restrict"
+        },
+        "team_activities_updated_by_profile_id_fkey": {
+          "name": "team_activities_updated_by_profile_id_fkey",
+          "tableFrom": "team_activities",
+          "columnsFrom": [
+            "updated_by_profile_id"
+          ],
+          "tableTo": "profiles",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "restrict"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {
+        "Team members can view activities": {
+          "name": "Team members can view activities",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": [
+            "authenticated"
+          ],
+          "using": "team_id IN (SELECT team_id FROM profiles WHERE id = current_profile_id() AND access_removed_at IS NULL)"
+        },
+        "Team members can create activities": {
+          "name": "Team members can create activities",
+          "as": "PERMISSIVE",
+          "for": "INSERT",
+          "to": [
+            "authenticated"
+          ],
+          "withCheck": "team_id IN (SELECT team_id FROM profiles WHERE id = current_profile_id() AND access_removed_at IS NULL)"
+        },
+        "Team members can update activities": {
+          "name": "Team members can update activities",
+          "as": "PERMISSIVE",
+          "for": "UPDATE",
+          "to": [
+            "authenticated"
+          ],
+          "using": "team_id IN (SELECT team_id FROM profiles WHERE id = current_profile_id() AND access_removed_at IS NULL)",
+          "withCheck": "team_id IN (SELECT team_id FROM profiles WHERE id = current_profile_id() AND access_removed_at IS NULL)"
+        },
+        "Team members can delete activities": {
+          "name": "Team members can delete activities",
+          "as": "PERMISSIVE",
+          "for": "DELETE",
+          "to": [
+            "authenticated"
+          ],
+          "using": "team_id IN (SELECT team_id FROM profiles WHERE id = current_profile_id() AND access_removed_at IS NULL)"
+        }
+      },
+      "checkConstraints": {},
+      "isRLSEnabled": true
+    },
+    "public.team_activity_attendees": {
+      "name": "team_activity_attendees",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "activity_id": {
+          "name": "activity_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "profile_id": {
+          "name": "profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "attendance_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'present'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_by_profile_id": {
+          "name": "created_by_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_by_profile_id": {
+          "name": "updated_by_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "team_activity_attendees_activity_idx": {
+          "name": "team_activity_attendees_activity_idx",
+          "columns": [
+            {
+              "expression": "activity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "uuid_ops"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "team_activity_attendees_profile_idx": {
+          "name": "team_activity_attendees_profile_idx",
+          "columns": [
+            {
+              "expression": "profile_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "uuid_ops"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "team_activity_attendees_activity_id_fkey": {
+          "name": "team_activity_attendees_activity_id_fkey",
+          "tableFrom": "team_activity_attendees",
+          "columnsFrom": [
+            "activity_id"
+          ],
+          "tableTo": "team_activities",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        },
+        "team_activity_attendees_profile_id_fkey": {
+          "name": "team_activity_attendees_profile_id_fkey",
+          "tableFrom": "team_activity_attendees",
+          "columnsFrom": [
+            "profile_id"
+          ],
+          "tableTo": "profiles",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        },
+        "team_activity_attendees_created_by_profile_id_fkey": {
+          "name": "team_activity_attendees_created_by_profile_id_fkey",
+          "tableFrom": "team_activity_attendees",
+          "columnsFrom": [
+            "created_by_profile_id"
+          ],
+          "tableTo": "profiles",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "restrict"
+        },
+        "team_activity_attendees_updated_by_profile_id_fkey": {
+          "name": "team_activity_attendees_updated_by_profile_id_fkey",
+          "tableFrom": "team_activity_attendees",
+          "columnsFrom": [
+            "updated_by_profile_id"
+          ],
+          "tableTo": "profiles",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "restrict"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "team_activity_attendees_activity_profile_key": {
+          "name": "team_activity_attendees_activity_profile_key",
+          "columns": [
+            "activity_id",
+            "profile_id"
+          ],
+          "nullsNotDistinct": false
+        }
+      },
+      "policies": {
+        "Team members can view activity attendees": {
+          "name": "Team members can view activity attendees",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": [
+            "authenticated"
+          ],
+          "using": "activity_id IN (SELECT id FROM team_activities WHERE team_id IN (SELECT team_id FROM profiles WHERE id = current_profile_id() AND access_removed_at IS NULL))"
+        },
+        "Team members can create activity attendees": {
+          "name": "Team members can create activity attendees",
+          "as": "PERMISSIVE",
+          "for": "INSERT",
+          "to": [
+            "authenticated"
+          ],
+          "withCheck": "activity_id IN (SELECT id FROM team_activities WHERE team_id IN (SELECT team_id FROM profiles WHERE id = current_profile_id() AND access_removed_at IS NULL))"
+        },
+        "Team members can update activity attendees": {
+          "name": "Team members can update activity attendees",
+          "as": "PERMISSIVE",
+          "for": "UPDATE",
+          "to": [
+            "authenticated"
+          ],
+          "using": "activity_id IN (SELECT id FROM team_activities WHERE team_id IN (SELECT team_id FROM profiles WHERE id = current_profile_id() AND access_removed_at IS NULL))",
+          "withCheck": "activity_id IN (SELECT id FROM team_activities WHERE team_id IN (SELECT team_id FROM profiles WHERE id = current_profile_id() AND access_removed_at IS NULL))"
+        },
+        "Team members can delete activity attendees": {
+          "name": "Team members can delete activity attendees",
+          "as": "PERMISSIVE",
+          "for": "DELETE",
+          "to": [
+            "authenticated"
+          ],
+          "using": "activity_id IN (SELECT id FROM team_activities WHERE team_id IN (SELECT team_id FROM profiles WHERE id = current_profile_id() AND access_removed_at IS NULL))"
+        }
+      },
+      "checkConstraints": {},
+      "isRLSEnabled": true
+    },
+    "public.team_annual_reflection_entries": {
+      "name": "team_annual_reflection_entries",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "annual_reflection_id": {
+          "name": "annual_reflection_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "topic": {
+          "name": "topic",
+          "type": "annual_reflection_topic",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "what_went_well": {
+          "name": "what_went_well",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "what_didnt_go_well": {
+          "name": "what_didnt_go_well",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "what_next_time": {
+          "name": "what_next_time",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_by_profile_id": {
+          "name": "updated_by_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "team_annual_reflection_entries_reflection_topic_idx": {
+          "name": "team_annual_reflection_entries_reflection_topic_idx",
+          "columns": [
+            {
+              "expression": "annual_reflection_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "uuid_ops"
+            },
+            {
+              "expression": "topic",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "enum_ops"
+            }
+          ],
+          "isUnique": true,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "team_annual_reflection_entries_reflection_idx": {
+          "name": "team_annual_reflection_entries_reflection_idx",
+          "columns": [
+            {
+              "expression": "annual_reflection_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "uuid_ops"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "team_annual_reflection_entries_annual_reflection_id_fkey": {
+          "name": "team_annual_reflection_entries_annual_reflection_id_fkey",
+          "tableFrom": "team_annual_reflection_entries",
+          "columnsFrom": [
+            "annual_reflection_id"
+          ],
+          "tableTo": "team_annual_reflections",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        },
+        "team_annual_reflection_entries_updated_by_profile_id_fkey": {
+          "name": "team_annual_reflection_entries_updated_by_profile_id_fkey",
+          "tableFrom": "team_annual_reflection_entries",
+          "columnsFrom": [
+            "updated_by_profile_id"
+          ],
+          "tableTo": "profiles",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "set null"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {
+        "Team members can view annual reflection entries": {
+          "name": "Team members can view annual reflection entries",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": [
+            "authenticated"
+          ],
+          "using": "annual_reflection_id IN (SELECT id FROM team_annual_reflections WHERE team_id IN (SELECT team_id FROM profiles WHERE id = current_profile_id() AND access_removed_at IS NULL))"
+        },
+        "Team members can create annual reflection entries": {
+          "name": "Team members can create annual reflection entries",
+          "as": "PERMISSIVE",
+          "for": "INSERT",
+          "to": [
+            "authenticated"
+          ],
+          "withCheck": "annual_reflection_id IN (SELECT id FROM team_annual_reflections WHERE team_id IN (SELECT team_id FROM profiles WHERE id = current_profile_id() AND access_removed_at IS NULL))"
+        },
+        "Team members can update annual reflection entries": {
+          "name": "Team members can update annual reflection entries",
+          "as": "PERMISSIVE",
+          "for": "UPDATE",
+          "to": [
+            "authenticated"
+          ],
+          "using": "annual_reflection_id IN (SELECT id FROM team_annual_reflections WHERE team_id IN (SELECT team_id FROM profiles WHERE id = current_profile_id() AND access_removed_at IS NULL))",
+          "withCheck": "annual_reflection_id IN (SELECT id FROM team_annual_reflections WHERE team_id IN (SELECT team_id FROM profiles WHERE id = current_profile_id() AND access_removed_at IS NULL))"
+        },
+        "Team members can delete annual reflection entries": {
+          "name": "Team members can delete annual reflection entries",
+          "as": "PERMISSIVE",
+          "for": "DELETE",
+          "to": [
+            "authenticated"
+          ],
+          "using": "annual_reflection_id IN (SELECT id FROM team_annual_reflections WHERE team_id IN (SELECT team_id FROM profiles WHERE id = current_profile_id() AND access_removed_at IS NULL))"
+        }
+      },
+      "checkConstraints": {},
+      "isRLSEnabled": true
+    },
+    "public.team_annual_reflections": {
+      "name": "team_annual_reflections",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reflection_month": {
+          "name": "reflection_month",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "removed_at": {
+          "name": "removed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_by_profile_id": {
+          "name": "created_by_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_by_profile_id": {
+          "name": "updated_by_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "team_annual_reflections_team_month_idx": {
+          "name": "team_annual_reflections_team_month_idx",
+          "columns": [
+            {
+              "expression": "team_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "uuid_ops"
+            },
+            {
+              "expression": "reflection_month",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "date_ops"
+            }
+          ],
+          "isUnique": true,
+          "with": {},
+          "method": "btree",
+          "where": "(removed_at IS NULL)",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "team_annual_reflections_team_id_fkey": {
+          "name": "team_annual_reflections_team_id_fkey",
+          "tableFrom": "team_annual_reflections",
+          "columnsFrom": [
+            "team_id"
+          ],
+          "tableTo": "teams",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        },
+        "team_annual_reflections_created_by_profile_id_fkey": {
+          "name": "team_annual_reflections_created_by_profile_id_fkey",
+          "tableFrom": "team_annual_reflections",
+          "columnsFrom": [
+            "created_by_profile_id"
+          ],
+          "tableTo": "profiles",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "restrict"
+        },
+        "team_annual_reflections_updated_by_profile_id_fkey": {
+          "name": "team_annual_reflections_updated_by_profile_id_fkey",
+          "tableFrom": "team_annual_reflections",
+          "columnsFrom": [
+            "updated_by_profile_id"
+          ],
+          "tableTo": "profiles",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "restrict"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {
+        "Team members can view annual reflections": {
+          "name": "Team members can view annual reflections",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": [
+            "authenticated"
+          ],
+          "using": "team_id IN (SELECT team_id FROM profiles WHERE id = current_profile_id() AND access_removed_at IS NULL)"
+        },
+        "Team members can create annual reflections": {
+          "name": "Team members can create annual reflections",
+          "as": "PERMISSIVE",
+          "for": "INSERT",
+          "to": [
+            "authenticated"
+          ],
+          "withCheck": "team_id IN (SELECT team_id FROM profiles WHERE id = current_profile_id() AND access_removed_at IS NULL)"
+        },
+        "Team members can update annual reflections": {
+          "name": "Team members can update annual reflections",
+          "as": "PERMISSIVE",
+          "for": "UPDATE",
+          "to": [
+            "authenticated"
+          ],
+          "using": "team_id IN (SELECT team_id FROM profiles WHERE id = current_profile_id() AND access_removed_at IS NULL)",
+          "withCheck": "team_id IN (SELECT team_id FROM profiles WHERE id = current_profile_id() AND access_removed_at IS NULL)"
+        },
+        "Team members can delete annual reflections": {
+          "name": "Team members can delete annual reflections",
+          "as": "PERMISSIVE",
+          "for": "DELETE",
+          "to": [
+            "authenticated"
+          ],
+          "using": "team_id IN (SELECT team_id FROM profiles WHERE id = current_profile_id() AND access_removed_at IS NULL)"
+        }
+      },
+      "checkConstraints": {
+        "team_annual_reflections_month_check": {
+          "name": "team_annual_reflections_month_check",
+          "value": "EXTRACT(MONTH FROM reflection_month) = 5"
+        }
+      },
+      "isRLSEnabled": true
+    },
+    "public.team_document_versions": {
+      "name": "team_document_versions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "document_id": {
+          "name": "document_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "version_no": {
+          "name": "version_no",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "file_path": {
+          "name": "file_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "file_name": {
+          "name": "file_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "file_size": {
+          "name": "file_size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "effective_from": {
+          "name": "effective_from",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "change_note": {
+          "name": "change_note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_by_profile_id": {
+          "name": "created_by_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "team_document_versions_document_version_idx": {
+          "name": "team_document_versions_document_version_idx",
+          "columns": [
+            {
+              "expression": "document_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "uuid_ops"
+            },
+            {
+              "expression": "version_no",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "int4_ops"
+            }
+          ],
+          "isUnique": true,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "team_document_versions_document_id_fkey": {
+          "name": "team_document_versions_document_id_fkey",
+          "tableFrom": "team_document_versions",
+          "columnsFrom": [
+            "document_id"
+          ],
+          "tableTo": "team_documents",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        },
+        "team_document_versions_created_by_profile_id_fkey": {
+          "name": "team_document_versions_created_by_profile_id_fkey",
+          "tableFrom": "team_document_versions",
+          "columnsFrom": [
+            "created_by_profile_id"
+          ],
+          "tableTo": "profiles",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "restrict"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {
+        "Team members can view document versions": {
+          "name": "Team members can view document versions",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": [
+            "authenticated"
+          ],
+          "using": "document_id IN (\n\t\t\tSELECT team_documents.id\n\t\t\tFROM team_documents\n\t\t\tWHERE team_documents.team_id IN (\n\t\t\t\tSELECT team_id FROM profiles WHERE id = current_profile_id() AND access_removed_at IS NULL\n\t\t\t)\n\t\t)"
+        },
+        "Team members can create document versions": {
+          "name": "Team members can create document versions",
+          "as": "PERMISSIVE",
+          "for": "INSERT",
+          "to": [
+            "authenticated"
+          ],
+          "withCheck": "created_by_profile_id = current_profile_id() AND document_id IN (\n\t\t\tSELECT team_documents.id\n\t\t\tFROM team_documents\n\t\t\tWHERE team_documents.removed_at IS NULL\n\t\t\t\tAND team_documents.team_id IN (\n\t\t\t\t\tSELECT team_id FROM profiles WHERE id = current_profile_id() AND access_removed_at IS NULL\n\t\t\t\t)\n\t\t)"
+        }
+      },
+      "checkConstraints": {
+        "team_document_versions_version_positive": {
+          "name": "team_document_versions_version_positive",
+          "value": "version_no > 0"
+        },
+        "team_document_versions_file_size_positive": {
+          "name": "team_document_versions_file_size_positive",
+          "value": "file_size > 0"
+        }
+      },
+      "isRLSEnabled": true
+    },
+    "public.team_documents": {
+      "name": "team_documents",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "doc_type": {
+          "name": "doc_type",
+          "type": "team_document_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "removed_at": {
+          "name": "removed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_by_profile_id": {
+          "name": "created_by_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_by_profile_id": {
+          "name": "updated_by_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "team_documents_featured_team_type_idx": {
+          "name": "team_documents_featured_team_type_idx",
+          "columns": [
+            {
+              "expression": "team_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "uuid_ops"
+            },
+            {
+              "expression": "doc_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "enum_ops"
+            }
+          ],
+          "isUnique": true,
+          "with": {},
+          "method": "btree",
+          "where": "doc_type IN ('team_contract', 'financial_policy') AND removed_at IS NULL",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "team_documents_team_id_fkey": {
+          "name": "team_documents_team_id_fkey",
+          "tableFrom": "team_documents",
+          "columnsFrom": [
+            "team_id"
+          ],
+          "tableTo": "teams",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        },
+        "team_documents_created_by_profile_id_fkey": {
+          "name": "team_documents_created_by_profile_id_fkey",
+          "tableFrom": "team_documents",
+          "columnsFrom": [
+            "created_by_profile_id"
+          ],
+          "tableTo": "profiles",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "restrict"
+        },
+        "team_documents_updated_by_profile_id_fkey": {
+          "name": "team_documents_updated_by_profile_id_fkey",
+          "tableFrom": "team_documents",
+          "columnsFrom": [
+            "updated_by_profile_id"
+          ],
+          "tableTo": "profiles",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "restrict"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {
+        "Team members can view documents": {
+          "name": "Team members can view documents",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": [
+            "authenticated"
+          ],
+          "using": "team_id IN (SELECT team_id FROM profiles WHERE id = current_profile_id() AND access_removed_at IS NULL)"
+        },
+        "Team members can create documents": {
+          "name": "Team members can create documents",
+          "as": "PERMISSIVE",
+          "for": "INSERT",
+          "to": [
+            "authenticated"
+          ],
+          "withCheck": "team_id IN (SELECT team_id FROM profiles WHERE id = current_profile_id() AND access_removed_at IS NULL) AND created_by_profile_id = current_profile_id() AND updated_by_profile_id = current_profile_id()"
+        },
+        "Team members can update custom documents": {
+          "name": "Team members can update custom documents",
+          "as": "PERMISSIVE",
+          "for": "UPDATE",
+          "to": [
+            "authenticated"
+          ],
+          "using": "doc_type = 'other' AND team_id IN (SELECT team_id FROM profiles WHERE id = current_profile_id() AND access_removed_at IS NULL)",
+          "withCheck": "doc_type = 'other' AND team_id IN (SELECT team_id FROM profiles WHERE id = current_profile_id() AND access_removed_at IS NULL) AND updated_by_profile_id = current_profile_id()"
+        }
+      },
+      "checkConstraints": {
+        "team_documents_title_matches_type": {
+          "name": "team_documents_title_matches_type",
+          "value": "(\n\t\t(doc_type = 'other' AND title IS NOT NULL AND length(trim(title)) > 0)\n\t\tOR (doc_type <> 'other' AND title IS NULL)\n\t)"
+        }
+      },
+      "isRLSEnabled": true
+    },
+    "public.team_reflection_action_steps": {
+      "name": "team_reflection_action_steps",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "team_reflection_id": {
+          "name": "team_reflection_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "assignee_profile_id": {
+          "name": "assignee_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "custom_assignee": {
+          "name": "custom_assignee",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "order_index": {
+          "name": "order_index",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "removed_at": {
+          "name": "removed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_by_profile_id": {
+          "name": "created_by_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "team_reflection_action_steps_reflection_idx": {
+          "name": "team_reflection_action_steps_reflection_idx",
+          "columns": [
+            {
+              "expression": "team_reflection_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "uuid_ops"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "team_reflection_action_steps_team_reflection_id_fkey": {
+          "name": "team_reflection_action_steps_team_reflection_id_fkey",
+          "tableFrom": "team_reflection_action_steps",
+          "columnsFrom": [
+            "team_reflection_id"
+          ],
+          "tableTo": "team_reflections",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        },
+        "team_reflection_action_steps_assignee_profile_id_fkey": {
+          "name": "team_reflection_action_steps_assignee_profile_id_fkey",
+          "tableFrom": "team_reflection_action_steps",
+          "columnsFrom": [
+            "assignee_profile_id"
+          ],
+          "tableTo": "profiles",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "set null"
+        },
+        "team_reflection_action_steps_created_by_profile_id_fkey": {
+          "name": "team_reflection_action_steps_created_by_profile_id_fkey",
+          "tableFrom": "team_reflection_action_steps",
+          "columnsFrom": [
+            "created_by_profile_id"
+          ],
+          "tableTo": "profiles",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "set null"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {
+        "Team members can view action steps": {
+          "name": "Team members can view action steps",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": [
+            "authenticated"
+          ],
+          "using": "team_reflection_id IN (SELECT id FROM team_reflections WHERE team_id IN (SELECT team_id FROM profiles WHERE id = current_profile_id() AND access_removed_at IS NULL))"
+        },
+        "Team members can create action steps": {
+          "name": "Team members can create action steps",
+          "as": "PERMISSIVE",
+          "for": "INSERT",
+          "to": [
+            "authenticated"
+          ],
+          "withCheck": "team_reflection_id IN (SELECT id FROM team_reflections WHERE team_id IN (SELECT team_id FROM profiles WHERE id = current_profile_id() AND access_removed_at IS NULL))"
+        },
+        "Team members can update action steps": {
+          "name": "Team members can update action steps",
+          "as": "PERMISSIVE",
+          "for": "UPDATE",
+          "to": [
+            "authenticated"
+          ],
+          "using": "team_reflection_id IN (SELECT id FROM team_reflections WHERE team_id IN (SELECT team_id FROM profiles WHERE id = current_profile_id() AND access_removed_at IS NULL))",
+          "withCheck": "team_reflection_id IN (SELECT id FROM team_reflections WHERE team_id IN (SELECT team_id FROM profiles WHERE id = current_profile_id() AND access_removed_at IS NULL))"
+        },
+        "Team members can delete action steps": {
+          "name": "Team members can delete action steps",
+          "as": "PERMISSIVE",
+          "for": "DELETE",
+          "to": [
+            "authenticated"
+          ],
+          "using": "team_reflection_id IN (SELECT id FROM team_reflections WHERE team_id IN (SELECT team_id FROM profiles WHERE id = current_profile_id() AND access_removed_at IS NULL))"
+        }
+      },
+      "checkConstraints": {},
+      "isRLSEnabled": true
+    },
+    "public.team_reflections": {
+      "name": "team_reflections",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "month": {
+          "name": "month",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "what_went_well": {
+          "name": "what_went_well",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "what_didnt_go_well": {
+          "name": "what_didnt_go_well",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "what_we_do_differently": {
+          "name": "what_we_do_differently",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "planned_action_steps": {
+          "name": "planned_action_steps",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "responsible_person": {
+          "name": "responsible_person",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "removed_at": {
+          "name": "removed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_by_profile_id": {
+          "name": "created_by_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_by_profile_id": {
+          "name": "updated_by_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "team_reflections_team_month_idx": {
+          "name": "team_reflections_team_month_idx",
+          "columns": [
+            {
+              "expression": "team_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "uuid_ops"
+            },
+            {
+              "expression": "month",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "date_ops"
+            }
+          ],
+          "isUnique": true,
+          "with": {},
+          "method": "btree",
+          "where": "(removed_at IS NULL)",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "team_reflections_team_id_fkey": {
+          "name": "team_reflections_team_id_fkey",
+          "tableFrom": "team_reflections",
+          "columnsFrom": [
+            "team_id"
+          ],
+          "tableTo": "teams",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        },
+        "team_reflections_created_by_profile_id_fkey": {
+          "name": "team_reflections_created_by_profile_id_fkey",
+          "tableFrom": "team_reflections",
+          "columnsFrom": [
+            "created_by_profile_id"
+          ],
+          "tableTo": "profiles",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "restrict"
+        },
+        "team_reflections_updated_by_profile_id_fkey": {
+          "name": "team_reflections_updated_by_profile_id_fkey",
+          "tableFrom": "team_reflections",
+          "columnsFrom": [
+            "updated_by_profile_id"
+          ],
+          "tableTo": "profiles",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "restrict"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {
+        "Team members can view reflections": {
+          "name": "Team members can view reflections",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": [
+            "authenticated"
+          ],
+          "using": "team_id IN (SELECT team_id FROM profiles WHERE id = current_profile_id() AND access_removed_at IS NULL)"
+        },
+        "Team members can create reflections": {
+          "name": "Team members can create reflections",
+          "as": "PERMISSIVE",
+          "for": "INSERT",
+          "to": [
+            "authenticated"
+          ],
+          "withCheck": "team_id IN (SELECT team_id FROM profiles WHERE id = current_profile_id() AND access_removed_at IS NULL)"
+        },
+        "Team members can update reflections": {
+          "name": "Team members can update reflections",
+          "as": "PERMISSIVE",
+          "for": "UPDATE",
+          "to": [
+            "authenticated"
+          ],
+          "using": "team_id IN (SELECT team_id FROM profiles WHERE id = current_profile_id() AND access_removed_at IS NULL)",
+          "withCheck": "team_id IN (SELECT team_id FROM profiles WHERE id = current_profile_id() AND access_removed_at IS NULL)"
+        },
+        "Team members can delete reflections": {
+          "name": "Team members can delete reflections",
+          "as": "PERMISSIVE",
+          "for": "DELETE",
+          "to": [
+            "authenticated"
+          ],
+          "using": "team_id IN (SELECT team_id FROM profiles WHERE id = current_profile_id() AND access_removed_at IS NULL)"
+        }
+      },
+      "checkConstraints": {},
+      "isRLSEnabled": true
+    },
+    "public.teams": {
+      "name": "teams",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "picture": {
+          "name": "picture",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "color": {
+          "name": "color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "onboardingYear": {
+          "name": "onboardingYear",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "removed_at": {
+          "name": "removed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_by_profile_id": {
+          "name": "created_by_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_by_profile_id": {
+          "name": "updated_by_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {
+        "Authenticated users can read teams": {
+          "name": "Authenticated users can read teams",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": [
+            "authenticated"
+          ],
+          "using": "true"
+        }
+      },
+      "checkConstraints": {},
+      "isRLSEnabled": true
+    },
+    "public.tools_techniques": {
+      "name": "tools_techniques",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "profile_id": {
+          "name": "profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tool_type": {
+          "name": "tool_type",
+          "type": "tool_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reflection": {
+          "name": "reflection",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "removed_at": {
+          "name": "removed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_by_profile_id": {
+          "name": "created_by_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_by_profile_id": {
+          "name": "updated_by_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "tools_techniques_profile_idx": {
+          "name": "tools_techniques_profile_idx",
+          "columns": [
+            {
+              "expression": "profile_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "uuid_ops"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "tools_techniques_profile_id_fkey": {
+          "name": "tools_techniques_profile_id_fkey",
+          "tableFrom": "tools_techniques",
+          "columnsFrom": [
+            "profile_id"
+          ],
+          "tableTo": "profiles",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        },
+        "tools_techniques_created_by_profile_id_fkey": {
+          "name": "tools_techniques_created_by_profile_id_fkey",
+          "tableFrom": "tools_techniques",
+          "columnsFrom": [
+            "created_by_profile_id"
+          ],
+          "tableTo": "profiles",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "restrict"
+        },
+        "tools_techniques_updated_by_profile_id_fkey": {
+          "name": "tools_techniques_updated_by_profile_id_fkey",
+          "tableFrom": "tools_techniques",
+          "columnsFrom": [
+            "updated_by_profile_id"
+          ],
+          "tableTo": "profiles",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "restrict"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {
+        "Users can view their own tools and techniques": {
+          "name": "Users can view their own tools and techniques",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": [
+            "authenticated"
+          ],
+          "using": "(profile_id = current_profile_id())"
+        },
+        "Users can create their own tools and techniques": {
+          "name": "Users can create their own tools and techniques",
+          "as": "PERMISSIVE",
+          "for": "INSERT",
+          "to": [
+            "authenticated"
+          ],
+          "withCheck": "(profile_id = current_profile_id())"
+        },
+        "Users can update their own tools and techniques": {
+          "name": "Users can update their own tools and techniques",
+          "as": "PERMISSIVE",
+          "for": "UPDATE",
+          "to": [
+            "authenticated"
+          ],
+          "using": "(profile_id = current_profile_id())",
+          "withCheck": "(profile_id = current_profile_id())"
+        },
+        "Users can delete their own tools and techniques": {
+          "name": "Users can delete their own tools and techniques",
+          "as": "PERMISSIVE",
+          "for": "DELETE",
+          "to": [
+            "authenticated"
+          ],
+          "using": "(profile_id = current_profile_id())"
+        }
+      },
+      "checkConstraints": {},
+      "isRLSEnabled": true
+    }
+  },
+  "enums": {
+    "public.birth_giving_assignment_state": {
+      "name": "birth_giving_assignment_state",
+      "schema": "public",
+      "values": [
+        "present",
+        "missing",
+        "none"
+      ]
+    },
+    "public.birth_giving_duration": {
+      "name": "birth_giving_duration",
+      "schema": "public",
+      "values": [
+        "8h",
+        "24h"
+      ]
+    },
+    "public.birth_giving_event_status": {
+      "name": "birth_giving_event_status",
+      "schema": "public",
+      "values": [
+        "draft",
+        "published"
+      ]
+    },
+    "public.birth_giving_team_result_state": {
+      "name": "birth_giving_team_result_state",
+      "schema": "public",
+      "values": [
+        "pending",
+        "present",
+        "missing"
+      ]
+    },
+    "public.book_list_status": {
+      "name": "book_list_status",
+      "schema": "public",
+      "values": [
+        "processing",
+        "shortlist",
+        "longlist",
+        "archived"
+      ]
+    },
+    "public.book_source": {
+      "name": "book_source",
+      "schema": "public",
+      "values": [
+        "manual",
+        "google_books",
+        "open_library"
+      ]
+    },
+    "public.content_source_kind": {
+      "name": "content_source_kind",
+      "schema": "public",
+      "values": [
+        "podcast",
+        "conference",
+        "program",
+        "other"
+      ]
+    },
+    "public.content_source_status": {
+      "name": "content_source_status",
+      "schema": "public",
+      "values": [
+        "pending_review",
+        "approved",
+        "archived"
+      ]
+    },
+    "public.personality_test_type": {
+      "name": "personality_test_type",
+      "schema": "public",
+      "values": [
+        "gallup",
+        "mbti",
+        "disc",
+        "big_five",
+        "enneagram",
+        "belbin",
+        "other"
+      ]
+    },
+    "public.beta_cohort": {
+      "name": "beta_cohort",
+      "schema": "public",
+      "values": [
+        "A",
+        "B"
+      ]
+    },
+    "public.profile_role": {
+      "name": "profile_role",
+      "schema": "public",
+      "values": [
+        "student",
+        "mentor",
+        "coach",
+        "admin"
+      ]
+    },
+    "public.schedule_type": {
+      "name": "schedule_type",
+      "schema": "public",
+      "values": [
+        "training_session",
+        "houston_calling"
+      ]
+    },
+    "public.attendance_status": {
+      "name": "attendance_status",
+      "schema": "public",
+      "values": [
+        "present",
+        "absent",
+        "excused",
+        "late"
+      ]
+    },
+    "public.annual_reflection_topic": {
+      "name": "annual_reflection_topic",
+      "schema": "public",
+      "values": [
+        "predmety_zkousky_vyucujici",
+        "metodika_a_metriky",
+        "kouci_a_mentori",
+        "tymy_a_tymove_spolecnosti",
+        "individualni_prinos",
+        "komunita",
+        "komunitni_role",
+        "komunitni_akce",
+        "komunitni_a_cross_projekty",
+        "zacleneni_tucnaku",
+        "dalsi"
+      ]
+    },
+    "public.team_document_type": {
+      "name": "team_document_type",
+      "schema": "public",
+      "values": [
+        "team_contract",
+        "financial_policy",
+        "other"
+      ]
+    },
+    "public.tool_type": {
+      "name": "tool_type",
+      "schema": "public",
+      "values": [
+        "model",
+        "technique",
+        "tool"
+      ]
+    }
+  },
+  "schemas": {},
+  "views": {
+    "public.books_with_essay_count": {
+      "name": "books_with_essay_count",
+      "schema": "public",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "title_cs": {
+          "name": "title_cs",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "title_en": {
+          "name": "title_en",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "author": {
+          "name": "author",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "isbn_13": {
+          "name": "isbn_13",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "google_books_cover_url": {
+          "name": "google_books_cover_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "book_points": {
+          "name": "book_points",
+          "type": "numeric(3, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "page_count": {
+          "name": "page_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "preview_link": {
+          "name": "preview_link",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source": {
+          "name": "source",
+          "type": "book_source",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "external_id": {
+          "name": "external_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "list_status": {
+          "name": "list_status",
+          "type": "book_list_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "list_status_changed_at": {
+          "name": "list_status_changed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "list_status_changed_by_profile_id": {
+          "name": "list_status_changed_by_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "list_status_reason": {
+          "name": "list_status_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "highlight_category_id": {
+          "name": "highlight_category_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_rocket_model": {
+          "name": "is_rocket_model",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by_profile_id": {
+          "name": "created_by_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_by_profile_id": {
+          "name": "updated_by_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "essay_count": {
+          "name": "essay_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "definition": "SELECT b.id, b.title_cs, b.title_en, b.author, b.isbn_13, b.description, b.google_books_cover_url, b.book_points, b.page_count, b.preview_link, b.source, b.external_id, b.list_status, b.list_status_changed_at, b.list_status_changed_by_profile_id, b.list_status_reason, b.highlight_category_id, b.is_rocket_model, b.created_at, b.updated_at, b.created_by_profile_id, b.updated_by_profile_id, COALESCE(ec.essay_count, 0) AS essay_count FROM books b LEFT JOIN ( SELECT essays.book_id, count(*)::integer AS essay_count FROM essays WHERE essays.book_id IS NOT NULL AND essays.published_at IS NOT NULL AND essays.removed_at IS NULL GROUP BY essays.book_id) ec ON ec.book_id = b.id",
+      "materialized": false,
+      "isExisting": false
+    }
+  },
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/supabase/migrations/meta/_journal.json
+++ b/supabase/migrations/meta/_journal.json
@@ -750,6 +750,20 @@
       "when": 1788371394730,
       "tag": "20260902174954_breezy_wind_dancer",
       "breakpoints": true
+    },
+    {
+      "idx": 107,
+      "version": "7",
+      "when": 1788375969595,
+      "tag": "20260902190609_curious_matthew_murdock",
+      "breakpoints": true
+    },
+    {
+      "idx": 108,
+      "version": "7",
+      "when": 1788379482531,
+      "tag": "20260902200442_giant_bloodaxe",
+      "breakpoints": true
     }
   ]
 }


### PR DESCRIPTION
## Summary
- Frozen (pre-2026-09-03) essay points now count no matter what happens afterward — book archival, a book_id reassignment, or the book never having been linked/imported into the catalog at all. Applies uniformly across `resolveEssayPoints`, `getEssaySourceDisplay`, all three TS point-aggregation functions in `src/lib/essays/queries.ts`, and the `get_teams_with_member_stats` SQL RPC (two new migrations).
- Replaces the hover-only legacy-points hint with a visible `LegacyPointsBadge` across every essay-rendering surface (essay detail, feed card, my-essay-list, essay card, profile page, coach review list, essay editor).

## Test plan
- [x] `pnpm tsc --noEmit` clean
- [x] `pnpm test` — 1082/1082 passing (178 files)
- [x] Verified locally against a production data mirror: Tuuli team leaderboard now matches the old system's totals exactly (previously several members were short by up to 6 points due to archived books zeroing frozen credit, and essays whose old-system book was never imported at all).
- [ ] Production data still needs the equivalent one-time backfill (book links + `frozen_book_points` fills for ~43 essays org-wide) — tracked separately, not part of this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)