### PR TITLE
Make reading section public

### DIFF
--- a/src/app/(main)/cteni/layout.tsx
+++ b/src/app/(main)/cteni/layout.tsx
@@ -4,8 +4,6 @@ import { createClient } from '@/lib/supabase/server';
 import { getCurrentUserProfile } from '@/lib/auth-helpers';
 import { getCoachUnreadCount } from '@/lib/essays/queries';
 import { CteniTabBar } from '@/components/cteni/cteni-tab-bar';
-import { FeatureComingSoon } from '@/components/beta/feature-coming-soon';
-import { canAccessFeature, type BetaCohort } from '@/lib/feature-access';
 
 export default async function CteniLayout({ children }: { children: ReactNode }) {
   const supabase = await createClient();
@@ -14,18 +12,6 @@ export default async function CteniLayout({ children }: { children: ReactNode })
 
   const profile = await getCurrentUserProfile(supabase, { user });
   if (!profile) redirect('/auth/login');
-  if (
-    !canAccessFeature(
-      {
-        role: profile.role,
-        beta_access_granted_at: profile.beta_access_granted_at,
-        beta_cohort: ((profile as unknown as { beta_cohort: BetaCohort }).beta_cohort ?? "A") as BetaCohort,
-      },
-      "reading",
-    )
-  ) {
-    return <FeatureComingSoon featureName="Čtení" />
-  }
 
   const isCoachOrAdmin = profile.role === 'coach' || profile.role === 'admin';
   let reviewCount = 0;

--- a/src/app/(main)/page.tsx
+++ b/src/app/(main)/page.tsx
@@ -75,12 +75,10 @@ export default async function DashboardPage() {
     beta_cohort: ((profile as unknown as { beta_cohort: BetaCohort }).beta_cohort ?? "A") as BetaCohort,
   };
   const hasMetricsAccess = canAccessFeature(accessProfile, "dashboardMetrics");
-  const hasReadingAccess = canAccessFeature(accessProfile, "reading");
-  const rawLayout = availableWidgetIds(
+  const layout = availableWidgetIds(
     sanitizeWidgetIds(layoutRow?.widgets, profile.role),
     hasMetricsAccess,
   );
-  const layout = hasReadingAccess ? rawLayout : rawLayout.filter((id) => id !== "reading");
 
   const has = (id: DashboardWidgetId) => layout.includes(id);
   const needsUnread =
@@ -110,7 +108,7 @@ export default async function DashboardPage() {
       <QuickActions isCoach={isCoach} unreadCount={unreadEssays.length} />
     );
   }
-  if (has("reading") && hasReadingAccess && stats) {
+  if (has("reading") && stats) {
     nodes["reading"] = <ReadingProgressCard stats={stats} />;
   }
   if (has("reservation")) {
@@ -155,11 +153,7 @@ export default async function DashboardPage() {
 
       <DashboardEditor
         initialLayout={layout}
-        catalog={
-          hasReadingAccess
-            ? availableWidgets(widgetsForRole(profile.role), hasMetricsAccess)
-            : availableWidgets(widgetsForRole(profile.role), hasMetricsAccess).filter((w) => w.id !== "reading")
-        }
+        catalog={availableWidgets(widgetsForRole(profile.role), hasMetricsAccess)}
         nodes={nodes}
       />
 

--- a/src/app/(main)/settings/notifikace/page.tsx
+++ b/src/app/(main)/settings/notifikace/page.tsx
@@ -4,7 +4,6 @@ import { createClient } from '@/lib/supabase/server';
 import { getCurrentUserProfile } from '@/lib/auth-helpers';
 import { NotificationPreferencesForm } from '@/components/settings/notification-preferences-form';
 import { PageHeader } from '@/components/ui/page-header';
-import type { BetaCohort } from '@/lib/feature-access';
 
 export const metadata = {
   title: 'Notifikace | Tappka',
@@ -36,12 +35,6 @@ export default async function NotificationSettingsPage() {
         initialCommentEmail={preferences?.essay_comment_email ?? true}
         initialVoteEmail={preferences?.essay_vote_email ?? true}
         initialBookSubmittedEmail={preferences?.book_submitted_email ?? false}
-        hasBetaAccess={Boolean(profile.beta_access_granted_at)}
-        profile={{
-          role: profile.role,
-          beta_access_granted_at: profile.beta_access_granted_at,
-          beta_cohort: ((profile as unknown as { beta_cohort: BetaCohort }).beta_cohort ?? "A") as BetaCohort,
-        }}
       />
     </div>
   );

--- a/src/app/api/profile/notification-preferences/route.ts
+++ b/src/app/api/profile/notification-preferences/route.ts
@@ -2,7 +2,6 @@ import { NextRequest, NextResponse } from "next/server"
 
 import { createClient } from "@/lib/supabase/server"
 import { getCurrentUserProfile } from "@/lib/auth-helpers"
-import { canAccessFeature, type BetaCohort } from "@/lib/feature-access"
 
 const TOGGLE_KEYS = ["essay_coach_read_email", "essay_comment_email", "essay_vote_email", "book_submitted_email"] as const
 type ToggleKey = (typeof TOGGLE_KEYS)[number]
@@ -15,18 +14,6 @@ export async function PATCH(request: NextRequest) {
 
     const profile = await getCurrentUserProfile(supabase, { user })
     if (!profile) return NextResponse.json({ error: "Profil nenalezen" }, { status: 403 })
-    if (
-      !canAccessFeature(
-        {
-          role: profile.role,
-          beta_access_granted_at: profile.beta_access_granted_at,
-          beta_cohort: ((profile as unknown as { beta_cohort: BetaCohort }).beta_cohort ?? "A") as BetaCohort,
-        },
-        "reading",
-      )
-    ) {
-      return NextResponse.json({ error: "Tato funkce vyžaduje beta přístup" }, { status: 403 })
-    }
 
     const body = await request.json()
     const updates: Partial<Record<ToggleKey, boolean>> = {}

--- a/src/components/settings/notification-preferences-form.test.tsx
+++ b/src/components/settings/notification-preferences-form.test.tsx
@@ -22,7 +22,6 @@ const defaultProps = {
   initialCommentEmail: true,
   initialVoteEmail: false,
   initialBookSubmittedEmail: false,
-  hasBetaAccess: true,
 }
 
 describe("NotificationPreferencesForm", () => {
@@ -55,33 +54,5 @@ describe("NotificationPreferencesForm", () => {
     expect(toggle).toBeChecked() // optimistic update applied synchronously, before the failed fetch resolves
 
     await waitFor(() => expect(toggle).not.toBeChecked()) // rolled back after the failed PATCH
-  })
-
-  it("renders switches disabled and unchecked when the user has no beta access, regardless of initial values", () => {
-    render(<NotificationPreferencesForm {...defaultProps} hasBetaAccess={false} />)
-
-    const switches = screen.getAllByRole("switch")
-    expect(switches).toHaveLength(4)
-    for (const toggle of switches) {
-      expect(toggle).not.toBeChecked()
-      expect(toggle).toBeDisabled()
-    }
-  })
-
-  it("shows a beta-access note linking to /beta when the user has no beta access", () => {
-    render(<NotificationPreferencesForm {...defaultProps} hasBetaAccess={false} />)
-
-    const link = screen.getByRole("link", { name: /beta/i })
-    expect(link).toHaveAttribute("href", "/beta")
-  })
-
-  it("does not fire a fetch call when a disabled switch is clicked without beta access", async () => {
-    render(<NotificationPreferencesForm {...defaultProps} hasBetaAccess={false} />)
-    const toggle = screen.getByRole("switch", { name: "Nový like na tvou esej" })
-
-    fireEvent.click(toggle)
-
-    expect(fetchSpy).not.toHaveBeenCalled()
-    expect(toggle).not.toBeChecked()
   })
 })

--- a/src/components/settings/notification-preferences-form.tsx
+++ b/src/components/settings/notification-preferences-form.tsx
@@ -2,18 +2,14 @@
 
 import { useState } from "react"
 import { useRouter } from "next/navigation"
-import Link from "next/link"
 
 import { Switch } from "@/components/ui/switch"
-import { canAccessFeature, type AccessProfile } from "@/lib/feature-access"
 
 interface NotificationPreferencesFormProps {
   initialCoachReadEmail: boolean
   initialCommentEmail: boolean
   initialVoteEmail: boolean
   initialBookSubmittedEmail: boolean
-  hasBetaAccess?: boolean
-  profile?: AccessProfile | null
 }
 
 type ToggleKey = "essay_coach_read_email" | "essay_comment_email" | "essay_vote_email" | "book_submitted_email"
@@ -30,10 +26,7 @@ export function NotificationPreferencesForm({
   initialCommentEmail,
   initialVoteEmail,
   initialBookSubmittedEmail,
-  hasBetaAccess,
-  profile,
 }: NotificationPreferencesFormProps) {
-  const hasAccess = profile ? canAccessFeature(profile, "reading") : (hasBetaAccess ?? false)
   const router = useRouter()
   const [values, setValues] = useState<Record<ToggleKey, boolean>>({
     essay_coach_read_email: initialCoachReadEmail,
@@ -44,7 +37,6 @@ export function NotificationPreferencesForm({
   const [savingKey, setSavingKey] = useState<ToggleKey | null>(null)
 
   const handleToggle = async (key: ToggleKey, value: boolean) => {
-    if (!hasAccess) return
     setSavingKey(key)
     setValues((prev) => ({ ...prev, [key]: value }))
 
@@ -67,23 +59,14 @@ export function NotificationPreferencesForm({
 
   return (
     <div className="space-y-3">
-      {!hasAccess && (
-        <p className="text-sm text-muted-foreground">
-          Tato funkce je součástí bety. Beta přístup si můžeš zapnout na stránce{" "}
-          <Link href="/beta" className="underline underline-offset-2">
-            Beta přístup
-          </Link>
-          .
-        </p>
-      )}
       {TOGGLES.map(({ key, label }) => (
         <div key={key} className="flex items-center justify-between rounded-lg border bg-background px-4 py-3">
           <span className="text-sm">{label}</span>
           <Switch
             aria-label={label}
-            checked={hasAccess ? values[key] : false}
+            checked={values[key]}
             onCheckedChange={(value) => handleToggle(key, value)}
-            disabled={!hasAccess || savingKey === key}
+            disabled={savingKey === key}
           />
         </div>
       ))}

--- a/src/lib/feature-access.test.ts
+++ b/src/lib/feature-access.test.ts
@@ -12,8 +12,7 @@ describe("canAccessFeature", () => {
       expect(canAccessFeature(nonBeta, f)).toBe(false)
     }
   })
-  it("A gets reading only", () => {
-    expect(canAccessFeature(a, "reading")).toBe(true)
+  it("A gets no beta features (only cohort B is gated in)", () => {
     expect(canAccessFeature(a, "customerMeetings")).toBe(false)
     expect(canAccessFeature(a, "birthGiving")).toBe(false)
   })

--- a/src/lib/feature-access.ts
+++ b/src/lib/feature-access.ts
@@ -1,5 +1,4 @@
 export const BETA_FEATURES = {
-  reading: ["A", "B"],
   customerMeetings: ["B"],
   coaching: ["B"],
   teamReflection: ["B"],

--- a/src/lib/navigation.test.ts
+++ b/src/lib/navigation.test.ts
@@ -37,7 +37,6 @@ describe("navigation config", () => {
       "/tymove-dokumenty",
       "/nastroje-techniky",
       "/osobnostni-testy",
-      "/cteni/prehled",
       "/birth-giving",
     ]);
   });
@@ -51,13 +50,15 @@ describe("navigation config", () => {
     }
   });
 
-  it("maps reading to A,B and others to B only", () => {
-    const reading = NAV_MODULES.find((m) => m.url === "/cteni/prehled")!;
-    expect(reading.feature).toBe("reading");
-    expect(BETA_FEATURES[reading.feature!]).toEqual(["A", "B"]);
-    for (const m of NAV_MODULES.filter((m) => m.feature && m.url !== "/cteni/prehled")) {
+  it("maps all remaining beta features to cohort B only (reading is public)", () => {
+    for (const m of NAV_MODULES.filter((m) => m.feature)) {
       expect(BETA_FEATURES[m.feature!]).toEqual(["B"]);
     }
+  });
+
+  it("does not gate reading behind a beta feature", () => {
+    const reading = NAV_MODULES.find((m) => m.url === "/cteni/prehled")!;
+    expect(reading.feature).toBeUndefined();
   });
 
   it("maps each url to its expected feature key", () => {
@@ -69,14 +70,13 @@ describe("navigation config", () => {
       "/tymove-dokumenty": "teamDocuments",
       "/nastroje-techniky": "toolsTechniques",
       "/osobnostni-testy": "personalityTests",
-      "/cteni/prehled": "reading",
       "/birth-giving": "birthGiving",
     };
     for (const [url, feature] of Object.entries(map)) {
       expect(NAV_MODULES.find((m) => m.url === url)!.feature).toBe(feature);
     }
     for (const m of NAV_MODULES.filter((m) => !m.feature)) {
-      expect(["/", "/reservations", "/komunita"]).toContain(m.url);
+      expect(["/", "/reservations", "/komunita", "/cteni/prehled"]).toContain(m.url);
     }
   });
 });
@@ -112,10 +112,10 @@ describe("getHubModules", () => {
     ]);
   });
 
-  it("keeps only non-feature modules for non-beta users, preserving hub order", () => {
-    expect(getHubModules(null).map((m) => m.url)).toEqual(["/reservations"]);
-    expect(getHubModules(nonBeta).map((m) => m.url)).toEqual(["/reservations"]);
-    expect(getHubModules(undefined).map((m) => m.url)).toEqual(["/reservations"]);
+  it("keeps only non-feature modules (incl. public reading) for non-beta users, preserving hub order", () => {
+    expect(getHubModules(null).map((m) => m.url)).toEqual(["/cteni/prehled", "/reservations"]);
+    expect(getHubModules(nonBeta).map((m) => m.url)).toEqual(["/cteni/prehled", "/reservations"]);
+    expect(getHubModules(undefined).map((m) => m.url)).toEqual(["/cteni/prehled", "/reservations"]);
   });
 
   it("shows reading plus stable for cohort A", () => {
@@ -164,6 +164,6 @@ describe("getHubModules", () => {
       "/birth-giving",
       "/osobnostni-testy",
     ]);
-    expect(getHubModules(false as unknown as AccessProfile).map((m) => m.url)).toEqual(["/reservations"]);
+    expect(getHubModules(false as unknown as AccessProfile).map((m) => m.url)).toEqual(["/cteni/prehled", "/reservations"]);
   });
 });

--- a/src/lib/navigation.ts
+++ b/src/lib/navigation.ts
@@ -45,7 +45,7 @@ export const NAV_MODULES: NavModule[] = [
   { title: "Osobnostní testy", url: "/osobnostni-testy", icon: Brain, feature: "personalityTests", description: "Výsledky osobnostních testů a jejich vývoj v čase." },
   // Čtení renders as a plain link; its sub-navigation lives in
   // src/app/(main)/cteni/layout.tsx as a tab bar.
-  { title: "Čtení", url: "/cteni/prehled", icon: BookOpen, feature: "reading", featured: true, description: "Knihovna knih, eseje a jejich hodnocení." },
+  { title: "Čtení", url: "/cteni/prehled", icon: BookOpen, featured: true, description: "Knihovna knih, eseje a jejich hodnocení." },
   { title: "Birth Giving", url: "/birth-giving", icon: Gift, feature: "birthGiving", description: "Týmová setkání Birth Giving a retrospektivy." },
 ];
 

--- a/src/lib/spotlight.test.ts
+++ b/src/lib/spotlight.test.ts
@@ -77,7 +77,7 @@ describe("spotlight", () => {
   });
 
   describe("getSpotlightItems", () => {
-    it("filters out feature-gated items when user does not have beta access", () => {
+    it("filters out feature-gated items when user does not have beta access, but keeps public reading", () => {
       const nonBetaItems = getSpotlightItems({
         user: { id: "user-1", beta_access_granted_at: null, beta_cohort: "A" },
       });
@@ -85,7 +85,7 @@ describe("spotlight", () => {
       const featureItems = nonBetaItems.filter((i) => i.feature);
       expect(featureItems).toHaveLength(0);
       expect(nonBetaItems.some((i) => i.id === "page-dashboard")).toBe(true);
-      expect(nonBetaItems.some((i) => i.id === "page-cteni")).toBe(false);
+      expect(nonBetaItems.some((i) => i.id === "page-cteni")).toBe(true);
     });
 
     it("shows reading for cohort A but not birthGiving (cohort gating)", () => {

--- a/src/lib/spotlight.ts
+++ b/src/lib/spotlight.ts
@@ -119,7 +119,6 @@ export const RAW_SPOTLIGHT_ITEMS: SpotlightItem[] = [
     description: "Knihovna knih, eseje a jejich hodnocení",
     url: "/cteni/prehled",
     icon: BookOpen,
-    feature: "reading",
     keywords: [
       "čtení",
       "knihy",


### PR DESCRIPTION
## Summary
- Removed `reading` from the beta-cohort feature-access system (`BETA_FEATURES` in `src/lib/feature-access.ts`) so it's available to all users regardless of beta enrollment
- Removed the reading beta-access route guard on `/cteni/*`, the nav/spotlight gating on "Čtení", the dashboard reading widget's beta filtering, and the beta gate on essay/book notification-preference toggles
- Updated tests in `feature-access`, `navigation`, `spotlight`, and `notification-preferences-form` to match

## Test plan
- [x] `pnpm exec tsc --noEmit` passes
- [x] `pnpm test` — 1080 tests pass
- [x] `pnpm lint` — only a pre-existing, unrelated error in `essay-editor-form.tsx` (verified via `git stash`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)