### PR TITLE
Library QR labels, book category pages, essay first-save publish fix

### DIFF
--- a/db/schema/books.ts
+++ b/db/schema/books.ts
@@ -157,14 +157,14 @@ export const bookTags = pgTable("book_tags", {
 export const libraryBooks = pgTable("library_books", {
 	id: uuid().defaultRandom().primaryKey().notNull(),
 	bookId: uuid("book_id").notNull(),
-	isbn13: text("isbn_13"),
+	labelCode: integer("label_code"),
 	createdAt: timestamp("created_at", { withTimezone: true, mode: 'string' }).defaultNow().notNull(),
 	updatedAt: timestamp("updated_at", { withTimezone: true, mode: 'string' }).defaultNow().notNull(),
 	createdByProfileId: uuid("created_by_profile_id").notNull(),
 	updatedByProfileId: uuid("updated_by_profile_id").notNull(),
 }, (table) => [
 	index("library_books_book_id_idx").using("btree", table.bookId.asc().nullsLast().op("uuid_ops")),
-	index("library_books_isbn_13_idx").using("btree", table.isbn13.asc().nullsLast().op("text_ops")).where(sql`(isbn_13 IS NOT NULL)`),
+	unique("library_books_label_code_key").on(table.labelCode),
 	foreignKey({
 			columns: [table.bookId],
 			foreignColumns: [books.id],
@@ -184,6 +184,7 @@ export const libraryBooks = pgTable("library_books", {
 	pgPolicy("Coaches and admins can add library books", { as: "permissive", for: "insert", to: ["authenticated"], withCheck: sql`is_coach_or_admin()` }),
 	pgPolicy("Coaches and admins can update library books", { as: "permissive", for: "update", to: ["authenticated"], using: sql`is_coach_or_admin()`, withCheck: sql`is_coach_or_admin()` }),
 	pgPolicy("Coaches and admins can delete library books", { as: "permissive", for: "delete", to: ["authenticated"], using: sql`is_coach_or_admin()` }),
+	check("library_books_label_code_check", sql`(label_code IS NULL) OR (label_code > 0)`),
 ]).enableRLS();
 
 export const bookLoans = pgTable("book_loans", {

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "test:integration": "vitest run --project integration",
     "test:e2e": "playwright test",
     "test:watch": "vitest --project unit",
+    "library:qr-labels": "node --experimental-strip-types scripts/generate-library-qr-labels.ts",
     "build": "next build",
     "start": "next start",
     "db:migrate": "run-s db:generate supabase:start db:up db:types db:export",

--- a/scripts/generate-library-qr-labels.ts
+++ b/scripts/generate-library-qr-labels.ts
@@ -1,29 +1,25 @@
-// Generates a print-ready HTML sheet of small QR labels, one per physical
-// copy in the TAP Knihovna, for sticking directly on the books. Run with:
-//   pnpm tsx --env-file=.env.local scripts/generate-library-qr-labels.ts
-// Open the output in a browser and print, or use "Save as PDF."
+// Generates five print-ready A4 sheets of sequential QR labels for physical
+// library copies. The labels do not need database rows before they are printed.
+// Run with: node --experimental-strip-types scripts/generate-library-qr-labels.ts
 import { mkdirSync, writeFileSync } from 'node:fs';
 import path from 'node:path';
 
-import { createClient } from '@supabase/supabase-js';
 import QRCode from 'qrcode';
 
-const SUPABASE_URL = process.env.NEXT_PUBLIC_SUPABASE_URL;
-const SERVICE_ROLE_KEY = process.env.SUPABASE_SERVICE_ROLE_KEY;
-const SITE_URL = process.env.SITE_URL ?? 'https://tiimi.cz';
+const DEFAULT_SITE_URL = 'https://tiimi.cz';
+const DEFAULT_START_LABEL_CODE = 1;
+const DEFAULT_LABEL_COUNT = 350;
+const LABEL_CODE_DIGITS = 3;
+const BRAND_RED = '#b31b1b';
+const BRAND_LIGHT = '#fcfff7';
 
-if (!SUPABASE_URL || !SERVICE_ROLE_KEY) {
-  console.error('Missing NEXT_PUBLIC_SUPABASE_URL or SUPABASE_SERVICE_ROLE_KEY in .env.local');
-  process.exit(1);
-}
-
-// Tweak these to change label density — page/column/row counts derive from them.
 const PAGE_WIDTH_MM = 210;
 const PAGE_HEIGHT_MM = 297;
-const PAGE_MARGIN_MM = 8;
-const LABEL_WIDTH_MM = 32;
-const LABEL_HEIGHT_MM = 34;
-const LABEL_GAP_MM = 2;
+const PAGE_MARGIN_MM = 7;
+const LABEL_WIDTH_MM = 27;
+const LABEL_HEIGHT_MM = 27;
+const LABEL_GAP_MM = 1;
+const QR_SIZE_MM = 19;
 
 const COLUMNS = Math.floor(
   (PAGE_WIDTH_MM - PAGE_MARGIN_MM * 2 + LABEL_GAP_MM) / (LABEL_WIDTH_MM + LABEL_GAP_MM),
@@ -33,34 +29,42 @@ const ROWS = Math.floor(
 );
 const LABELS_PER_PAGE = COLUMNS * ROWS;
 
-const supabase = createClient(SUPABASE_URL, SERVICE_ROLE_KEY);
-
-interface LibraryBookRow {
-  id: string;
-  book: { id: string; title_cs: string } | null;
+interface LibraryLabel {
+  code: number;
+  url: string;
 }
 
-interface LabelBook {
-  bookId: string;
-  title: string;
+function readPositiveInteger(value: string | undefined, fallback: number, name: string): number {
+  if (value == null) return fallback;
+
+  const parsed = Number(value);
+  if (!Number.isSafeInteger(parsed) || parsed <= 0) {
+    throw new Error(`${name} must be a positive integer.`);
+  }
+
+  return parsed;
 }
 
-async function fetchLibraryBooks(): Promise<LabelBook[]> {
-  const { data, error } = await supabase.from('library_books').select('id, book:books(id, title_cs)');
-  if (error) throw error;
+function buildLabels(): LibraryLabel[] {
+  const siteUrl = (process.env.SITE_URL ?? DEFAULT_SITE_URL).replace(/\/$/, '');
+  const startCode = readPositiveInteger(
+    process.env.LIBRARY_LABEL_START,
+    DEFAULT_START_LABEL_CODE,
+    'LIBRARY_LABEL_START',
+  );
+  const labelCount = readPositiveInteger(
+    process.env.LIBRARY_LABEL_COUNT,
+    DEFAULT_LABEL_COUNT,
+    'LIBRARY_LABEL_COUNT',
+  );
 
-  return ((data ?? []) as unknown as LibraryBookRow[])
-    .filter((row): row is LibraryBookRow & { book: NonNullable<LibraryBookRow['book']> } => row.book != null)
-    .map((row) => ({ bookId: row.book.id, title: row.book.title_cs }))
-    .sort((a, b) => a.title.localeCompare(b.title, 'cs'));
+  return Array.from({ length: labelCount }, (_, index) => {
+    const code = startCode + index;
+    return { code, url: `${siteUrl}/l/${code}` };
+  });
 }
 
-function escapeHtml(text: string): string {
-  return text.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;').replace(/"/g, '&quot;');
-}
-
-async function buildLabelHtml({ bookId, title }: LabelBook): Promise<string> {
-  const url = `${SITE_URL}/knihovna/${bookId}/pujcit`;
+async function buildLabelHtml({ code, url }: LibraryLabel): Promise<string> {
   const qrSvg = await QRCode.toString(url, {
     type: 'svg',
     margin: 1,
@@ -69,20 +73,25 @@ async function buildLabelHtml({ bookId, title }: LabelBook): Promise<string> {
   });
 
   return `
-    <div class="label">
-      <svg class="brand" viewBox="0 0 512 512" aria-hidden="true">
-        <rect width="512" height="512" rx="128" fill="#b31b1b"/>
-        <text x="256" y="360" font-family="Poppins, sans-serif" font-size="280" font-weight="bold" fill="#fcfff7" text-anchor="middle">T</text>
-      </svg>
+    <div class="label" data-label-code="${code}" data-url="${url}">
+      <div class="brand">
+        <svg class="brand-icon" viewBox="0 0 32 32" aria-hidden="true">
+          <rect width="32" height="32" rx="8" fill="${BRAND_RED}"/>
+          <text x="16" y="23" fill="${BRAND_LIGHT}" font-family="Arial, sans-serif" font-size="20" font-weight="700" text-anchor="middle">T</text>
+        </svg>
+        <span>TAPPKA</span>
+      </div>
       <div class="qr">${qrSvg}</div>
-      <div class="title">${escapeHtml(title)}</div>
+      <div class="caption"><span>KNIHOVNA</span><strong>#${String(code).padStart(LABEL_CODE_DIGITS, '0')}</strong></div>
     </div>`;
 }
 
 function chunk<T>(items: T[], size: number): T[][] {
-  const out: T[][] = [];
-  for (let i = 0; i < items.length; i += size) out.push(items.slice(i, i + size));
-  return out;
+  const chunks: T[][] = [];
+  for (let index = 0; index < items.length; index += size) {
+    chunks.push(items.slice(index, index + size));
+  }
+  return chunks;
 }
 
 function buildDocument(labelHtmls: string[]): string {
@@ -93,50 +102,68 @@ function buildDocument(labelHtmls: string[]): string {
 <html lang="cs">
 <head>
   <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>Tappka – QR štítky knihovny</title>
-  <link rel="preconnect" href="https://fonts.googleapis.com">
-  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-  <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@500;700&display=swap" rel="stylesheet">
   <style>
     @page { size: A4; margin: ${PAGE_MARGIN_MM}mm; }
     * { box-sizing: border-box; }
-    body { margin: 0; font-family: 'Poppins', Arial, sans-serif; }
+    html, body { margin: 0; padding: 0; }
+    body { font-family: Arial, sans-serif; }
     .page {
       display: grid;
       grid-template-columns: repeat(${COLUMNS}, ${LABEL_WIDTH_MM}mm);
       grid-auto-rows: ${LABEL_HEIGHT_MM}mm;
       gap: ${LABEL_GAP_MM}mm;
-      justify-content: start;
+      break-after: page;
       page-break-after: always;
     }
-    .page:last-child { page-break-after: auto; }
+    .page:last-child {
+      break-after: auto;
+      page-break-after: auto;
+    }
     .label {
-      border: 0.2mm dashed #ccc;
+      border: 0.2mm dashed #b8b8b8;
       display: flex;
       flex-direction: column;
       align-items: center;
       justify-content: center;
-      gap: 0.8mm;
-      padding: 1mm;
+      gap: 0.2mm;
       overflow: hidden;
     }
-    .brand { width: 4mm; height: 4mm; flex-shrink: 0; }
-    .qr { width: 22mm; height: 22mm; flex-shrink: 0; }
-    .qr svg { width: 100%; height: 100%; display: block; }
-    .title {
+    .brand {
+      display: flex;
+      align-items: center;
+      gap: 0.7mm;
+      color: ${BRAND_RED};
       font-size: 2.2mm;
-      line-height: 1.15;
-      text-align: center;
-      color: #2c1a1d;
-      max-width: 100%;
-      display: -webkit-box;
-      -webkit-line-clamp: 2;
-      -webkit-box-orient: vertical;
-      overflow: hidden;
+      font-weight: 700;
+      letter-spacing: 0.15mm;
+      line-height: 1;
     }
+    .brand-icon { width: 3mm; height: 3mm; flex: 0 0 auto; }
+    .qr { width: ${QR_SIZE_MM}mm; height: ${QR_SIZE_MM}mm; flex: 0 0 auto; }
+    .qr svg { display: block; width: 100%; height: 100%; }
+    .caption {
+      display: flex;
+      align-items: baseline;
+      gap: 0.8mm;
+      color: ${BRAND_RED};
+      font-size: 1.8mm;
+      font-weight: 600;
+      line-height: 1;
+      letter-spacing: 0.05mm;
+      white-space: nowrap;
+    }
+    .caption strong { color: #000; font-size: 2mm; }
     @media screen {
       body { background: #eee; padding: 10mm 0; }
-      .page { background: white; margin: 0 auto 10mm; box-shadow: 0 1mm 4mm rgba(0,0,0,0.15); }
+      .page {
+        width: ${PAGE_WIDTH_MM - PAGE_MARGIN_MM * 2}mm;
+        min-height: ${PAGE_HEIGHT_MM - PAGE_MARGIN_MM * 2}mm;
+        background: #fff;
+        margin: 0 auto 10mm;
+        box-shadow: 0 1mm 4mm rgb(0 0 0 / 15%);
+      }
     }
   </style>
 </head>
@@ -146,12 +173,9 @@ ${pagesHtml}
 </html>`;
 }
 
-async function main() {
-  const books = await fetchLibraryBooks();
-  console.log(`Found ${books.length} physical copies in the library.`);
-  if (books.length === 0) return;
-
-  const labelHtmls = await Promise.all(books.map(buildLabelHtml));
+async function main(): Promise<void> {
+  const labels = buildLabels();
+  const labelHtmls = await Promise.all(labels.map(buildLabelHtml));
   const html = buildDocument(labelHtmls);
 
   const outDir = path.join(process.cwd(), 'scripts', 'output');
@@ -159,13 +183,15 @@ async function main() {
   const outPath = path.join(outDir, 'library-qr-labels.html');
   writeFileSync(outPath, html, 'utf-8');
 
-  const pageCount = Math.ceil(books.length / LABELS_PER_PAGE);
-  console.log(`${LABELS_PER_PAGE} labels/page (${COLUMNS}×${ROWS}) → ${pageCount} pages for ${books.length} labels.`);
-  console.log(`Written to ${outPath}`);
-  console.log('Open it in a browser and print, or use "Save as PDF."');
+  const pageCount = Math.ceil(labels.length / LABELS_PER_PAGE);
+  const firstCode = labels[0].code;
+  const lastCode = labels.at(-1)?.code ?? firstCode;
+  console.log(`${labels.length} labels (${firstCode}–${lastCode}), ${LABELS_PER_PAGE} per A4 page (${COLUMNS}×${ROWS}).`);
+  console.log(`${pageCount} pages written to ${outPath}`);
+  console.log('Print at 100% scale with browser headers and footers disabled.');
 }
 
-main().catch((err) => {
-  console.error(err);
+main().catch((error: unknown) => {
+  console.error(error);
   process.exit(1);
 });

--- a/src/app/(main)/cteni/eseje/[essayId]/page.tsx
+++ b/src/app/(main)/cteni/eseje/[essayId]/page.tsx
@@ -27,7 +27,6 @@ import { BookStatusBadges } from '@/components/books/book-status-badges';
 import { ContentSourceIllustration } from '@/components/content-sources/content-source-illustration';
 import { CONTENT_SOURCE_KIND_LABELS } from '@/lib/content-sources/types';
 import { getEssaySourceDisplay } from '@/lib/essays/source-display';
-import { LegacyPointsBadge } from '@/components/essays/legacy-points-badge';
 
 interface PageProps {
   params: Promise<{ essayId: string }>;
@@ -166,12 +165,9 @@ export default async function EssayDetailPage({ params }: PageProps) {
               <p className="text-xs text-muted-foreground truncate">{essay.book.author}</p>
             </div>
             {!source.isArchived && source.points > 0 && (
-              <div className="flex shrink-0 items-center gap-1.5">
-                {source.isFrozen && <LegacyPointsBadge />}
-                <Badge variant="secondary" className="shrink-0">
-                  {formatPoints(source.points)} b.
-                </Badge>
-              </div>
+              <Badge variant="secondary" className="shrink-0">
+                {formatPoints(source.points)} b.
+              </Badge>
             )}
           </div>
         </Link>

--- a/src/app/(main)/cteni/knihy/[bookId]/pujcit/page.tsx
+++ b/src/app/(main)/cteni/knihy/[bookId]/pujcit/page.tsx
@@ -3,7 +3,13 @@ import { notFound, redirect } from 'next/navigation';
 import { createClient } from '@/lib/supabase/server';
 import { getCurrentUserProfile } from '@/lib/auth-helpers';
 import { getBookById } from '@/lib/books/queries';
-import { getBookLibraryInfo, getUserActiveLoanDetails } from '@/lib/library/queries';
+import { parseLibraryLabelCode } from '@/lib/library/label-code';
+import {
+  getAvailableCopyByLabelCode,
+  getBookLibraryInfo,
+  getLibraryCopyByLabelCode,
+  getUserActiveLoanDetails,
+} from '@/lib/library/queries';
 import { BorrowPanel } from '@/components/library/borrow-panel';
 import { BookStatusBadges } from '@/components/books/book-status-badges';
 import { PageBack } from '@/components/ui/page-back';
@@ -15,10 +21,15 @@ export const metadata = {
 
 interface PageProps {
   params: Promise<{ bookId: string }>;
+  searchParams: Promise<{ label?: string }>;
 }
 
-export default async function BorrowBookPage({ params }: PageProps) {
+export default async function BorrowBookPage({ params, searchParams }: PageProps) {
   const { bookId } = await params;
+  const { label: rawLabelCode } = await searchParams;
+  const labelCode = rawLabelCode == null ? null : parseLibraryLabelCode(rawLabelCode);
+  if (rawLabelCode != null && labelCode == null) notFound();
+
   const supabase = await createClient();
   const { data: { user } } = await supabase.auth.getUser();
   if (!user) redirect('/auth/login');
@@ -32,6 +43,13 @@ export default async function BorrowBookPage({ params }: PageProps) {
   ]);
 
   if (!book) notFound();
+
+  let selectedCopyAvailable: boolean | null = null;
+  if (labelCode != null) {
+    const selectedCopy = await getLibraryCopyByLabelCode(supabase, labelCode);
+    if (!selectedCopy || selectedCopy.bookId !== bookId) notFound();
+    selectedCopyAvailable = (await getAvailableCopyByLabelCode(supabase, bookId, labelCode)) != null;
+  }
 
   if (!libraryInfo.inLibrary) {
     return (
@@ -55,8 +73,9 @@ export default async function BorrowBookPage({ params }: PageProps) {
         title={book.title_cs}
         author={book.author}
         coverUrl={book.google_books_cover_url}
-        availableCopies={libraryInfo.availableCopies}
-        totalCopies={libraryInfo.totalCopies}
+        availableCopies={selectedCopyAvailable == null ? libraryInfo.availableCopies : Number(selectedCopyAvailable)}
+        totalCopies={selectedCopyAvailable == null ? libraryInfo.totalCopies : 1}
+        labelCode={labelCode}
         initialDueAt={activeLoan?.due_at ?? null}
         book={{
           list_status: book.list_status,

--- a/src/app/(main)/cteni/knihy/nova/page.tsx
+++ b/src/app/(main)/cteni/knihy/nova/page.tsx
@@ -1,21 +1,37 @@
 import { PageHeader } from '@/components/ui/page-header';
 import { PageShell } from '@/components/ui/page-shell';
 import { AddBookFlow } from '@/components/books/add-book/add-book-flow';
+import { parseLibraryLabelCode } from '@/lib/library/label-code';
 
 export const metadata = {
   title: 'Přidat knihu do BOBa | Tappka',
 };
 
 interface NovaKnihaPageProps {
-  searchParams: Promise<{ q?: string; from?: string; essayId?: string }>;
+  searchParams: Promise<{
+    q?: string;
+    from?: string;
+    essayId?: string;
+    label?: string;
+  }>;
 }
 
 export default async function NovaKnihaPage({ searchParams }: NovaKnihaPageProps) {
-  const { q, from, essayId } = await searchParams;
+  const { q, from, essayId, label } = await searchParams;
 
   const cameFromEssay = from === 'esej' && Boolean(essayId);
-  const backHref = cameFromEssay ? `/cteni/eseje/${essayId}/upravit` : '/cteni/hledat';
-  const backLabel = cameFromEssay ? 'Zpět k eseji' : 'Zpět do hledání';
+  const labelCode = from === 'knihovna-stitky' && label
+    ? parseLibraryLabelCode(label)
+    : null;
+  const libraryReturnTo = labelCode == null ? null : `/knihovna/stitky?label=${labelCode}`;
+  const essayReturnTo = cameFromEssay ? `/cteni/eseje/${essayId}/upravit` : null;
+  const returnTo = libraryReturnTo ?? essayReturnTo;
+  const backHref = returnTo ?? '/cteni/hledat';
+  const backLabel = libraryReturnTo
+    ? 'Zpět ke štítku'
+    : cameFromEssay
+      ? 'Zpět k eseji'
+      : 'Zpět do hledání';
 
   return (
     <PageShell size="narrow">
@@ -24,7 +40,7 @@ export default async function NovaKnihaPage({ searchParams }: NovaKnihaPageProps
 
       <AddBookFlow
         initialQuery={q ?? ''}
-        returnTo={cameFromEssay ? `/cteni/eseje/${essayId}/upravit` : null}
+        returnTo={returnTo}
         discardHref={backHref}
       />
     </PageShell>

--- a/src/app/(main)/cteni/knihy/rocket-model/page.tsx
+++ b/src/app/(main)/cteni/knihy/rocket-model/page.tsx
@@ -1,5 +1,5 @@
 import Link from 'next/link';
-import { BookOpen, ExternalLink } from 'lucide-react';
+import { BookOpen, ExternalLink, Rocket } from 'lucide-react';
 import { createClient } from '@/lib/supabase/server';
 import { getRocketModelBooks } from '@/lib/books/queries';
 import { StorageImage } from '@/components/storage/storage-image';
@@ -27,6 +27,11 @@ export default async function RocketModelPage() {
         title="Rocket Model"
         description="Klíčové knihy programu — pomáhají Téčkům nastartovat cestu rychleji a bez oklik"
         count={{ value: books.length, label: pluralizeCz(books.length, ['kniha', 'knihy', 'knih']) }}
+        icon={
+          <span className="flex size-10 sm:size-11 shrink-0 items-center justify-center rounded-xl bg-primary/15 text-primary">
+            <Rocket className="size-5 sm:size-6" />
+          </span>
+        }
       />
 
       {books.length === 0 ? (

--- a/src/app/(main)/cteni/knihy/rocket-model/page.tsx
+++ b/src/app/(main)/cteni/knihy/rocket-model/page.tsx
@@ -8,6 +8,7 @@ import { PageBack } from '@/components/ui/page-back';
 import { PageHeader } from '@/components/ui/page-header';
 import { PageShell } from '@/components/ui/page-shell';
 import { formatPointsWithLabel } from '@/lib/books/points';
+import { structureBookTitle } from '@/lib/books/format-title';
 import { pluralizeCz } from '@/lib/utils/pluralize-cz';
 
 export const metadata = {
@@ -38,31 +39,33 @@ export default async function RocketModelPage() {
         <div className="py-16 text-center text-sm text-muted-foreground">Zatím žádné knihy v Rocket Modelu.</div>
       ) : (
         <div className="divide-y rounded-xl border overflow-hidden bg-card">
-          {books.map((book) => (
-            <div key={book.id} className="group flex gap-3 px-3 py-3">
-              <Link
-                href={`/cteni/knihy/${book.id}`}
-                className="mt-0.5 flex h-16 w-11 shrink-0 items-center justify-center overflow-hidden rounded-md bg-muted"
-              >
-                {book.google_books_cover_url ? (
-                  <StorageImage
-                    storageKey={book.google_books_cover_url}
-                    alt={book.title_cs}
-                    width={44}
-                    height={64}
-                    className="h-full w-full object-cover"
-                  />
-                ) : (
-                  <BookOpen className="size-4 text-muted-foreground/30" />
-                )}
-              </Link>
-              <div className="min-w-0 flex-1 space-y-1 py-0.5">
-                <Link href={`/cteni/knihy/${book.id}`} className="flex items-center gap-1.5">
-                  <p className="line-clamp-1 text-sm font-medium leading-snug transition-colors group-hover:text-primary">
-                    {book.title_cs}
-                  </p>
-                  <BookStatusBadges book={book} />
+          {books.map((book) => {
+            const { title: bookTitle, fullTitle } = structureBookTitle(book.title_cs);
+            return (
+              <div key={book.id} className="group flex gap-3 px-3 py-3">
+                <Link
+                  href={`/cteni/knihy/${book.id}`}
+                  className="mt-0.5 flex h-16 w-11 shrink-0 items-center justify-center overflow-hidden rounded-md bg-muted"
+                >
+                  {book.google_books_cover_url ? (
+                    <StorageImage
+                      storageKey={book.google_books_cover_url}
+                      alt={bookTitle}
+                      width={44}
+                      height={64}
+                      className="h-full w-full object-cover"
+                    />
+                  ) : (
+                    <BookOpen className="size-4 text-muted-foreground/30" />
+                  )}
                 </Link>
+                <div className="min-w-0 flex-1 space-y-1 py-0.5">
+                  <Link href={`/cteni/knihy/${book.id}`} className="flex items-center gap-1.5 min-w-0">
+                    <p className="truncate min-w-0 text-sm font-medium leading-snug transition-colors group-hover:text-primary" title={fullTitle}>
+                      {bookTitle}
+                    </p>
+                    <BookStatusBadges book={book} />
+                  </Link>
                 {book.description && (
                   <p className="line-clamp-2 text-xs leading-relaxed text-muted-foreground">{book.description}</p>
                 )}
@@ -88,7 +91,8 @@ export default async function RocketModelPage() {
                 </div>
               </div>
             </div>
-          ))}
+          );
+        })}
         </div>
       )}
     </PageShell>

--- a/src/app/(main)/cteni/knihy/top-bob/page.tsx
+++ b/src/app/(main)/cteni/knihy/top-bob/page.tsx
@@ -1,3 +1,4 @@
+import { Medal } from 'lucide-react';
 import { createClient } from '@/lib/supabase/server';
 import { getHighlightedBooks, getHighlightCategories } from '@/lib/books/queries';
 import { groupHighlightedBooks } from '@/lib/books/highlight-groups';
@@ -30,6 +31,11 @@ export default async function TopBobPage() {
         title="TOP BOB"
         description="Zlato celé knihovny — když nevíš, co číst dál, tady nešlápneš vedle"
         count={{ value: totalBooks, label: 'knih' }}
+        icon={
+          <span className="flex size-10 sm:size-11 shrink-0 items-center justify-center rounded-xl bg-amber-500/15 text-amber-700 dark:text-amber-400">
+            <Medal className="size-5 sm:size-6" />
+          </span>
+        }
       />
 
       <TopBobBrowser groups={groups} />

--- a/src/app/(main)/knihovna/stitky/page.tsx
+++ b/src/app/(main)/knihovna/stitky/page.tsx
@@ -7,7 +7,7 @@ import { getSessionProfile } from '@/lib/auth/session';
 import { parseLibraryLabelCode } from '@/lib/library/label-code';
 
 interface LibraryLabelsPageProps {
-  searchParams: Promise<{ label?: string }>;
+  searchParams: Promise<{ label?: string; book?: string }>;
 }
 
 const PAGE_DESCRIPTION = 'Naskenuj štítek a přiřaď ho ke konkrétnímu výtisku';
@@ -24,7 +24,7 @@ export default async function LibraryLabelsPage({ searchParams }: LibraryLabelsP
     redirect('/');
   }
 
-  const { label } = await searchParams;
+  const { label, book } = await searchParams;
   const initialLabelCode = label ? parseLibraryLabelCode(label) : null;
 
   return (
@@ -34,7 +34,7 @@ export default async function LibraryLabelsPage({ searchParams }: LibraryLabelsP
         description={PAGE_DESCRIPTION}
         back={{ href: '/cteni/sprava', label: 'Zpět na správu knihovny' }}
       />
-      <LibraryLabelAssignment initialLabelCode={initialLabelCode} />
+      <LibraryLabelAssignment initialLabelCode={initialLabelCode} initialBookId={book ?? null} />
     </PageShell>
   );
 }

--- a/src/app/(main)/knihovna/stitky/page.tsx
+++ b/src/app/(main)/knihovna/stitky/page.tsx
@@ -1,0 +1,40 @@
+import { redirect } from 'next/navigation';
+
+import { LibraryLabelAssignment } from '@/components/library/library-label-assignment';
+import { PageHeader } from '@/components/ui/page-header';
+import { PageShell } from '@/components/ui/page-shell';
+import { getSessionProfile } from '@/lib/auth/session';
+import { parseLibraryLabelCode } from '@/lib/library/label-code';
+
+interface LibraryLabelsPageProps {
+  searchParams: Promise<{ label?: string }>;
+}
+
+const PAGE_DESCRIPTION = 'Naskenuj štítek a přiřaď ho ke konkrétnímu výtisku';
+
+export const metadata = {
+  title: 'Přiřazení štítků | Tappka',
+  description: PAGE_DESCRIPTION,
+  robots: { index: false, follow: false },
+};
+
+export default async function LibraryLabelsPage({ searchParams }: LibraryLabelsPageProps) {
+  const profile = await getSessionProfile();
+  if (!profile || (profile.role !== 'coach' && profile.role !== 'admin')) {
+    redirect('/');
+  }
+
+  const { label } = await searchParams;
+  const initialLabelCode = label ? parseLibraryLabelCode(label) : null;
+
+  return (
+    <PageShell size="narrow">
+      <PageHeader
+        title="Přiřazení knihovních štítků"
+        description={PAGE_DESCRIPTION}
+        back={{ href: '/cteni/sprava', label: 'Zpět na správu knihovny' }}
+      />
+      <LibraryLabelAssignment initialLabelCode={initialLabelCode} />
+    </PageShell>
+  );
+}

--- a/src/app/(main)/komunita/profil/[id]/page.tsx
+++ b/src/app/(main)/komunita/profil/[id]/page.tsx
@@ -27,7 +27,6 @@ import { Tabs, TabsContent, TabsList, TabsTrigger, TabsTriggerCount } from '@/co
 import { ROLE_LABELS, ROLE_COLORS } from '@/lib/komunita/types';
 import { formatPointsWithLabel } from '@/lib/books/points';
 import { getEssaySourceDisplay } from '@/lib/essays/source-display';
-import { LegacyPointsBadge } from '@/components/essays/legacy-points-badge';
 import { cn } from '@/lib/utils';
 
 interface PageProps {
@@ -242,12 +241,9 @@ export default async function ProfilePage({ params, searchParams }: PageProps) {
                             {source.title}
                             {essay.book && <BookStatusBadges book={essay.book} />}
                             {source.points > 0 && (
-                              <>
-                                {source.isFrozen && <LegacyPointsBadge />}
-                                <span className="ml-1 font-medium text-foreground">
-                                  · {formatPointsWithLabel(source.points)}
-                                </span>
-                              </>
+                              <span className="ml-1 font-medium text-foreground">
+                                · {formatPointsWithLabel(source.points)}
+                              </span>
                             )}
                           </p>
                           {excerpt && excerpt.length > 20 && (

--- a/src/app/api/essays/route.ts
+++ b/src/app/api/essays/route.ts
@@ -83,9 +83,10 @@ export async function POST(request: NextRequest) {
       return NextResponse.json({ error: sourceError }, { status: 400 });
     }
 
-    // The essay may be empty in every field at creation time — it exists so
-    // autosave has somewhere to write. It becomes visible to others once
-    // autosave gives it a title (see PATCH /api/essays/[id]).
+    // The essay may be empty in every field at creation time — a title-less
+    // essay stays a private draft. There is no explicit publish step: it
+    // becomes visible to everyone the moment it first has a title, whether
+    // that happens here on the first save or later (see PATCH /api/essays/[id]).
     const trimmedTitle = typeof title === 'string' ? title.trim() : '';
     if (trimmedTitle.length > MAX_TITLE_LENGTH) {
       return NextResponse.json({ error: 'Název eseje je příliš dlouhý' }, { status: 400 });
@@ -105,7 +106,7 @@ export async function POST(request: NextRequest) {
         author_profile_id: profile.id,
         book_id: book_id ?? null,
         content_source_id: content_source_id ?? null,
-        published_at: null,
+        published_at: trimmedTitle ? new Date().toISOString() : null,
         created_by_profile_id: profile.id,
         updated_by_profile_id: profile.id,
       })

--- a/src/app/api/library/books/[bookId]/borrow/route.ts
+++ b/src/app/api/library/books/[bookId]/borrow/route.ts
@@ -2,8 +2,12 @@ import { NextRequest, NextResponse, after } from 'next/server';
 
 import { createClient } from '@/lib/supabase/server';
 import { getCurrentUserProfile } from '@/lib/auth-helpers';
-import { getAvailableCopyForBook } from '@/lib/library/queries';
+import { parseLibraryLabelCode } from '@/lib/library/label-code';
+import { getAvailableCopyByLabelCode, getAvailableCopyForBook } from '@/lib/library/queries';
 import { notifyBookBorrowed } from '@/lib/notifications/library-notifications';
+
+const LOAN_DURATION_DAYS = 30;
+const MILLISECONDS_PER_DAY = 24 * 60 * 60 * 1000;
 
 interface RouteContext {
   params: Promise<{ bookId: string }>;
@@ -19,13 +23,22 @@ export async function POST(request: NextRequest, { params }: RouteContext) {
     const profile = await getCurrentUserProfile(supabase, { user });
     if (!profile) return NextResponse.json({ error: 'Profil nenalezen' }, { status: 403 });
 
-    const availableCopyId = await getAvailableCopyForBook(supabase, bookId);
+    const rawLabelCode = request.nextUrl.searchParams.get('label');
+    const labelCode = rawLabelCode == null ? null : parseLibraryLabelCode(rawLabelCode);
+    if (rawLabelCode != null && labelCode == null) {
+      return NextResponse.json({ error: 'Neplatný kód štítku' }, { status: 400 });
+    }
+
+    const availableCopyId = labelCode == null
+      ? await getAvailableCopyForBook(supabase, bookId)
+      : await getAvailableCopyByLabelCode(supabase, bookId, labelCode);
     if (!availableCopyId) {
-      return NextResponse.json({ error: 'Žádná dostupná kopie' }, { status: 409 });
+      const message = labelCode == null ? 'Žádná dostupná kopie' : 'Tento výtisk není dostupný';
+      return NextResponse.json({ error: message }, { status: 409 });
     }
 
     const now = new Date().toISOString();
-    const dueAt = new Date(Date.now() + 30 * 24 * 60 * 60 * 1000).toISOString();
+    const dueAt = new Date(Date.now() + LOAN_DURATION_DAYS * MILLISECONDS_PER_DAY).toISOString();
 
     const { data: loan, error } = await supabase
       .from('book_loans')

--- a/src/app/api/library/books/route.ts
+++ b/src/app/api/library/books/route.ts
@@ -30,7 +30,6 @@ export async function GET(request: NextRequest) {
       return {
         id: lb.id,
         book_id: lb.book_id,
-        isbn_13: lb.isbn_13,
         created_at: lb.created_at,
         book: lb.book,
         totalCopies: info.totalCopies,
@@ -59,7 +58,7 @@ export async function POST(request: NextRequest) {
       return NextResponse.json({ error: 'Nemáš oprávnění' }, { status: 403 });
     }
 
-    const body: { book_id: string; isbn_13?: string } = await request.json();
+    const body: { book_id: string } = await request.json();
 
     if (!body.book_id?.trim()) {
       return NextResponse.json({ error: 'ID knihy je povinné' }, { status: 400 });
@@ -69,7 +68,6 @@ export async function POST(request: NextRequest) {
       .from('library_books')
       .insert({
         book_id: body.book_id.trim(),
-        isbn_13: body.isbn_13 ?? null,
         created_by_profile_id: profile.id,
         updated_by_profile_id: profile.id,
       })

--- a/src/app/api/library/catalog-search/route.ts
+++ b/src/app/api/library/catalog-search/route.ts
@@ -1,0 +1,40 @@
+import { NextRequest, NextResponse } from 'next/server';
+
+import { getCurrentUserProfile } from '@/lib/auth-helpers';
+import { searchCatalogBooks, type CatalogSearchBook } from '@/lib/books/catalog-search';
+import { createClient } from '@/lib/supabase/server';
+
+const SEARCH_RESULT_LIMIT = 10;
+const CATALOG_COLUMNS = 'id, title_cs, title_en, author, isbn_13, google_books_cover_url';
+
+export async function GET(request: NextRequest) {
+  try {
+    const supabase = await createClient();
+    const { data: { user } } = await supabase.auth.getUser();
+    if (!user) return NextResponse.json({ error: 'Neautorizováno' }, { status: 401 });
+
+    const profile = await getCurrentUserProfile(supabase, { user });
+    if (!profile || (profile.role !== 'coach' && profile.role !== 'admin')) {
+      return NextResponse.json({ error: 'Nemáš oprávnění' }, { status: 403 });
+    }
+
+    const query = request.nextUrl.searchParams.get('q')?.trim() ?? '';
+    if (!query) return NextResponse.json({ data: [] });
+
+    const { data, error } = await supabase
+      .from('books')
+      .select(CATALOG_COLUMNS);
+
+    if (error) throw error;
+
+    const results = searchCatalogBooks(
+      (data ?? []) as CatalogSearchBook[],
+      query,
+      SEARCH_RESULT_LIMIT,
+    );
+    return NextResponse.json({ data: results });
+  } catch (error) {
+    console.error('GET /api/library/catalog-search error:', error);
+    return NextResponse.json({ error: 'Hledání selhalo' }, { status: 500 });
+  }
+}

--- a/src/app/api/library/labels/[labelCode]/route.ts
+++ b/src/app/api/library/labels/[labelCode]/route.ts
@@ -1,0 +1,178 @@
+import { NextRequest, NextResponse } from 'next/server';
+
+import { getCurrentUserProfile } from '@/lib/auth-helpers';
+import { parseLibraryLabelCode } from '@/lib/library/label-code';
+import { createClient } from '@/lib/supabase/server';
+import type { Insertable, Updatable } from '@/lib/supabase/tables';
+
+interface RouteContext {
+  params: Promise<{ labelCode: string }>;
+}
+
+interface BookSummary {
+  id: string;
+  title_cs: string;
+  author: string;
+  google_books_cover_url: string | null;
+}
+
+async function getAuthorizedContext() {
+  const supabase = await createClient();
+  const { data: { user } } = await supabase.auth.getUser();
+  if (!user) return { error: NextResponse.json({ error: 'Neautorizováno' }, { status: 401 }) };
+
+  const profile = await getCurrentUserProfile(supabase, { user });
+  if (!profile || (profile.role !== 'coach' && profile.role !== 'admin')) {
+    return { error: NextResponse.json({ error: 'Nemáš oprávnění' }, { status: 403 }) };
+  }
+
+  return { supabase, profile };
+}
+
+export async function GET(_request: NextRequest, { params }: RouteContext) {
+  try {
+    const { labelCode: rawLabelCode } = await params;
+    const labelCode = parseLibraryLabelCode(rawLabelCode);
+    if (labelCode == null) {
+      return NextResponse.json({ error: 'Neplatný kód štítku' }, { status: 400 });
+    }
+
+    const context = await getAuthorizedContext();
+    if ('error' in context) return context.error;
+
+    const { data, error } = await context.supabase
+      .from('library_books')
+      .select('id, book_id, book:books!inner(id, title_cs, author, google_books_cover_url)')
+      .filter('label_code', 'eq', String(labelCode))
+      .maybeSingle();
+
+    if (error) throw error;
+    if (!data) {
+      return NextResponse.json({ error: 'Štítek zatím není přiřazený' }, { status: 404 });
+    }
+
+    return NextResponse.json({
+      data: {
+        id: data.id,
+        book_id: data.book_id,
+        label_code: labelCode,
+        book: data.book as BookSummary,
+      },
+    });
+  } catch (error) {
+    console.error('GET /api/library/labels/[labelCode] error:', error);
+    return NextResponse.json({ error: 'Nepodařilo se načíst štítek' }, { status: 500 });
+  }
+}
+
+export async function POST(request: NextRequest, { params }: RouteContext) {
+  try {
+    const { labelCode: rawLabelCode } = await params;
+    const labelCode = parseLibraryLabelCode(rawLabelCode);
+    if (labelCode == null) {
+      return NextResponse.json({ error: 'Neplatný kód štítku' }, { status: 400 });
+    }
+
+    const context = await getAuthorizedContext();
+    if ('error' in context) return context.error;
+
+    const body: { book_id?: unknown } = await request.json();
+    const bookId = typeof body.book_id === 'string' ? body.book_id.trim() : '';
+    if (!bookId) {
+      return NextResponse.json({ error: 'Kniha je povinná' }, { status: 400 });
+    }
+
+    const [{ data: existingLabel, error: labelError }, { data: book, error: bookError }] = await Promise.all([
+      context.supabase
+        .from('library_books')
+        .select('id, book_id')
+        .filter('label_code', 'eq', String(labelCode))
+        .maybeSingle(),
+      context.supabase
+        .from('books')
+        .select('id, title_cs, author, google_books_cover_url')
+        .eq('id', bookId)
+        .maybeSingle(),
+    ]);
+
+    if (labelError) throw labelError;
+    if (bookError) throw bookError;
+    if (existingLabel) {
+      return NextResponse.json(
+        { error: 'Štítek už je přiřazený', data: existingLabel },
+        { status: 409 },
+      );
+    }
+    if (!book) {
+      return NextResponse.json({ error: 'Kniha nebyla nalezena' }, { status: 404 });
+    }
+
+    const { data: unlabelledCopy, error: copyError } = await context.supabase
+      .from('library_books')
+      .select('id')
+      .eq('book_id', bookId)
+      .filter('label_code', 'is', null)
+      .order('created_at', { ascending: true })
+      .limit(1)
+      .maybeSingle();
+
+    if (copyError) throw copyError;
+
+    const now = new Date().toISOString();
+    let libraryBookId: string;
+    let reusedExistingCopy = false;
+
+    if (unlabelledCopy) {
+      const updateValues: Updatable<'library_books'> & { label_code: number } = {
+        label_code: labelCode,
+        updated_at: now,
+        updated_by_profile_id: context.profile.id,
+      };
+      const { data: updated, error: updateError } = await context.supabase
+        .from('library_books')
+        .update(updateValues)
+        .eq('id', unlabelledCopy.id)
+        .select('id')
+        .single();
+
+      if (updateError) throw updateError;
+      libraryBookId = updated.id;
+      reusedExistingCopy = true;
+    } else {
+      const insertValues: Insertable<'library_books'> & { label_code: number } = {
+        book_id: bookId,
+        label_code: labelCode,
+        created_by_profile_id: context.profile.id,
+        updated_by_profile_id: context.profile.id,
+      };
+      const { data: inserted, error: insertError } = await context.supabase
+        .from('library_books')
+        .insert(insertValues)
+        .select('id')
+        .single();
+
+      if (insertError) throw insertError;
+      libraryBookId = inserted.id;
+    }
+
+    return NextResponse.json({
+      data: {
+        id: libraryBookId,
+        book_id: bookId,
+        label_code: labelCode,
+        reused_existing_copy: reusedExistingCopy,
+        book,
+      },
+    }, { status: 201 });
+  } catch (error) {
+    const errorCode = typeof error === 'object' && error && 'code' in error
+      ? String(error.code)
+      : null;
+    if (errorCode === '23505') {
+      return NextResponse.json({ error: 'Štítek už je přiřazený' }, { status: 409 });
+    }
+
+    console.error('POST /api/library/labels/[labelCode] error:', error);
+    return NextResponse.json({ error: 'Nepodařilo se přiřadit štítek' }, { status: 500 });
+  }
+}

--- a/src/app/l/[labelCode]/page.tsx
+++ b/src/app/l/[labelCode]/page.tsx
@@ -1,0 +1,34 @@
+import { notFound, redirect } from 'next/navigation';
+
+import { getSessionProfile } from '@/lib/auth/session';
+import { parseLibraryLabelCode } from '@/lib/library/label-code';
+import { getLibraryCopyByLabelCode } from '@/lib/library/queries';
+import { createClient } from '@/lib/supabase/server';
+
+interface LibraryLabelPageProps {
+  params: Promise<{ labelCode: string }>;
+}
+
+export const metadata = {
+  title: 'Knihovna | Tappka',
+  robots: { index: false, follow: false },
+};
+
+export default async function LibraryLabelPage({ params }: LibraryLabelPageProps) {
+  const { labelCode: rawLabelCode } = await params;
+  const labelCode = parseLibraryLabelCode(rawLabelCode);
+  if (labelCode == null) notFound();
+
+  const supabase = await createClient();
+  const copy = await getLibraryCopyByLabelCode(supabase, labelCode);
+
+  if (!copy) {
+    const profile = await getSessionProfile();
+    if (profile?.role === 'coach' || profile?.role === 'admin') {
+      redirect(`/knihovna/stitky?label=${labelCode}`);
+    }
+    notFound();
+  }
+
+  redirect(`/cteni/knihy/${copy.bookId}/pujcit?label=${labelCode}`);
+}

--- a/src/components/books/add-book/add-book-flow.test.tsx
+++ b/src/components/books/add-book/add-book-flow.test.tsx
@@ -203,6 +203,35 @@ describe('AddBookFlow', () => {
     );
   });
 
+  it('preserves existing return parameters and returns duplicates too', async () => {
+    persist('review', {
+      candidate: null,
+      enriched: ENRICHED,
+      citations: [],
+      manual: false,
+      appealing: false,
+    });
+
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({
+      ok: false,
+      status: 409,
+      json: async () => ({ existingId: 'dup-1' }),
+    }));
+
+    render(
+      <AddBookFlow
+        initialQuery=""
+        returnTo="/knihovna/stitky?label=7"
+        discardHref="/knihovna/stitky?label=7"
+      />,
+    );
+    await userEvent.click(await screen.findByRole('button', { name: /odeslat/i }));
+
+    await waitFor(() =>
+      expect(push).toHaveBeenCalledWith('/knihovna/stitky?label=7&book=dup-1'),
+    );
+  });
+
   describe('discarding the draft', () => {
     const DRAFT = {
       candidate: { ...CANDIDATE, source: 'google_books' },

--- a/src/components/books/add-book/add-book-flow.tsx
+++ b/src/components/books/add-book/add-book-flow.tsx
@@ -28,6 +28,7 @@ import { StepSearch } from './step-search';
 import { EMPTY_DRAFT, type AddBookDraft } from './types';
 
 const DRAFT_STORAGE_KEY = 'tappka:add-book-draft';
+const INTERNAL_URL_BASE = 'https://tappka.local';
 
 type Step = 'gate' | 'search' | 'enriching' | 'rejected' | 'review';
 
@@ -64,6 +65,12 @@ interface AddBookFlowProps {
   returnTo: string | null;
   /** Where to go when the submitter discards the in-progress draft. */
   discardHref: string;
+}
+
+function buildReturnUrl(returnTo: string, bookId: string) {
+  const url = new URL(returnTo, INTERNAL_URL_BASE);
+  url.searchParams.set('book', bookId);
+  return `${url.pathname}${url.search}${url.hash}`;
 }
 
 export function AddBookFlow({ initialQuery, returnTo, discardHref }: AddBookFlowProps) {
@@ -139,7 +146,11 @@ export function AddBookFlow({ initialQuery, returnTo, discardHref }: AddBookFlow
         if (res.status === 409 && json.existingId) {
           toast.info('Tuhle knihu už v BOBovi máme.');
           window.sessionStorage.removeItem(DRAFT_STORAGE_KEY);
-          router.push(`/cteni/knihy/${json.existingId}`);
+          router.push(
+            returnTo
+              ? buildReturnUrl(returnTo, json.existingId)
+              : `/cteni/knihy/${json.existingId}`,
+          );
           return;
         }
 
@@ -152,7 +163,9 @@ export function AddBookFlow({ initialQuery, returnTo, discardHref }: AddBookFlow
         window.sessionStorage.removeItem(DRAFT_STORAGE_KEY);
         toast.success('Kniha odeslána ke schválení.');
         router.push(
-          returnTo ? `${returnTo}?book=${json.data.id}` : `/cteni/knihy/${json.data.id}`,
+          returnTo
+            ? buildReturnUrl(returnTo, json.data.id)
+            : `/cteni/knihy/${json.data.id}`,
         );
       } catch {
         toast.error('Nepodařilo se připojit k serveru.');

--- a/src/components/books/book-card.tsx
+++ b/src/components/books/book-card.tsx
@@ -5,6 +5,7 @@ import { StorageImage } from '@/components/storage/storage-image';
 import { BookStatusBadges } from './book-status-badges';
 import { BOOK_CATEGORY_LABELS } from '@/lib/books/types';
 import { formatPointsWithLabel } from '@/lib/books/points';
+import { structureBookTitle } from '@/lib/books/format-title';
 import type { BookWithProfiles } from '@/lib/books/types';
 
 interface BookCardProps {
@@ -14,6 +15,7 @@ interface BookCardProps {
 
 export function BookCard({ book, libraryInfo }: BookCardProps) {
   const pointsLabel = formatPointsWithLabel(book.book_points);
+  const { title: bookTitle, fullTitle } = structureBookTitle(book.title_cs);
 
   return (
     <div className="flex gap-3 px-3 py-2.5 rounded-xl border bg-card hover:shadow-sm transition-shadow group">
@@ -21,7 +23,7 @@ export function BookCard({ book, libraryInfo }: BookCardProps) {
         {book.google_books_cover_url ? (
           <StorageImage
             storageKey={book.google_books_cover_url}
-            alt={book.title_cs}
+            alt={bookTitle}
             className="w-full h-full object-cover"
             width={40}
             height={56}
@@ -32,9 +34,9 @@ export function BookCard({ book, libraryInfo }: BookCardProps) {
       </Link>
 
       <div className="flex-1 min-w-0 flex flex-col justify-center gap-0.5">
-        <Link href={`/cteni/knihy/${book.id}`} className="flex items-center gap-1.5">
-          <p className="font-semibold text-sm leading-snug line-clamp-1 group-hover:text-primary transition-colors">
-            {book.title_cs}
+        <Link href={`/cteni/knihy/${book.id}`} className="flex items-center gap-1.5 min-w-0">
+          <p className="font-semibold text-sm leading-snug truncate min-w-0 group-hover:text-primary transition-colors" title={fullTitle}>
+            {bookTitle}
           </p>
           <BookStatusBadges book={book} />
         </Link>

--- a/src/components/books/book-status-badges.tsx
+++ b/src/components/books/book-status-badges.tsx
@@ -116,7 +116,7 @@ export function BookStatusBadges({ book, variant = 'compact', className }: BookS
   if (!hasBadge) return null;
 
   return (
-    <span className={cn('inline-flex items-center gap-1.5', className)}>
+    <span className={cn('inline-flex items-center gap-1.5 shrink-0', className)}>
       <VerifiedBadge status={book.list_status} />
       {book.is_rocket_model && <RocketBadge />}
       {book.highlight_category && <HighlightBadge category={book.highlight_category} variant={variant} />}

--- a/src/components/books/feed-book-card.tsx
+++ b/src/components/books/feed-book-card.tsx
@@ -9,6 +9,7 @@ import { ProfileAvatar } from '@/components/profile-avatar';
 import { BookStatusBadges } from './book-status-badges';
 import { BOOK_CATEGORY_LABELS } from '@/lib/books/types';
 import { formatPoints, pointsNumber } from '@/lib/books/points';
+import { structureBookTitle } from '@/lib/books/format-title';
 import { cn } from '@/lib/utils';
 import type { BookWithProfiles } from '@/lib/books/types';
 
@@ -38,6 +39,7 @@ export function FeedBookCard({
 }: FeedBookCardProps) {
   const points = pointsNumber(book.book_points);
   const primaryTag = book.tags[0] ? (BOOK_CATEGORY_LABELS[book.tags[0]] ?? book.tags[0]) : null;
+  const { title: bookTitle, fullTitle } = structureBookTitle(book.title_cs);
 
   return (
     <article
@@ -56,7 +58,7 @@ export function FeedBookCard({
             {book.google_books_cover_url ? (
               <StorageImage
                 storageKey={book.google_books_cover_url}
-                alt={book.title_cs}
+                alt={bookTitle}
                 width={48}
                 height={68}
                 className="size-full object-cover"
@@ -67,9 +69,9 @@ export function FeedBookCard({
           </Link>
 
           <div className="min-w-0 space-y-0.5">
-            <Link href={`/cteni/knihy/${book.id}`} className="flex items-center gap-1.5 flex-wrap">
-              <h3 className="font-bold text-sm sm:text-base text-foreground leading-snug group-hover:text-primary transition-colors line-clamp-1">
-                {book.title_cs}
+            <Link href={`/cteni/knihy/${book.id}`} className="flex items-center gap-1.5 min-w-0">
+              <h3 className="font-bold text-sm sm:text-base text-foreground leading-snug group-hover:text-primary transition-colors truncate min-w-0" title={fullTitle}>
+                {bookTitle}
               </h3>
               <BookStatusBadges book={book} />
             </Link>

--- a/src/components/books/top-bob-browser.tsx
+++ b/src/components/books/top-bob-browser.tsx
@@ -3,6 +3,7 @@ import { BookOpen, ExternalLink } from 'lucide-react';
 import { StorageImage } from '@/components/storage/storage-image';
 import { BookStatusBadges } from './book-status-badges';
 import { formatPointsWithLabel } from '@/lib/books/points';
+import { structureBookTitle } from '@/lib/books/format-title';
 import type { BookWithProfiles } from '@/lib/books/types';
 import type { HighlightedGroup } from '@/lib/books/highlight-groups';
 
@@ -42,6 +43,8 @@ export function TopBobBrowser({ groups }: TopBobBrowserProps) {
 }
 
 function TopBobBookRow({ book }: { book: BookWithProfiles }) {
+  const { title: bookTitle, fullTitle } = structureBookTitle(book.title_cs);
+
   return (
     <div className="group flex gap-3 px-3 py-3">
       <Link
@@ -51,7 +54,7 @@ function TopBobBookRow({ book }: { book: BookWithProfiles }) {
         {book.google_books_cover_url ? (
           <StorageImage
             storageKey={book.google_books_cover_url}
-            alt={book.title_cs}
+            alt={bookTitle}
             width={44}
             height={64}
             className="h-full w-full object-cover"
@@ -61,9 +64,9 @@ function TopBobBookRow({ book }: { book: BookWithProfiles }) {
         )}
       </Link>
       <div className="min-w-0 flex-1 space-y-1 py-0.5">
-        <Link href={`/cteni/knihy/${book.id}`} className="flex items-center gap-1.5">
-          <p className="line-clamp-1 text-sm font-medium leading-snug transition-colors group-hover:text-primary">
-            {book.title_cs}
+        <Link href={`/cteni/knihy/${book.id}`} className="flex items-center gap-1.5 min-w-0">
+          <p className="truncate min-w-0 text-sm font-medium leading-snug transition-colors group-hover:text-primary" title={fullTitle}>
+            {bookTitle}
           </p>
           <BookStatusBadges book={book} />
         </Link>

--- a/src/components/essays/coach-review-list.tsx
+++ b/src/components/essays/coach-review-list.tsx
@@ -694,12 +694,17 @@ function ReviewRow({
                       {source.title}
                     </span>
                     {source.points > 0 && (
-                      <>
-                        {source.isFrozen && <LegacyPointsBadge />}
+                      source.isFrozen ? (
+                        <LegacyPointsBadge
+                          points={source.points}
+                          label={pointsLabel(source.points)}
+                          className="shrink-0"
+                        />
+                      ) : (
                         <span className="rounded-full bg-primary/10 px-1.5 py-0.5 text-xs font-semibold tabular-nums text-primary">
                           {formatPoints(source.points)} {pointsLabel(source.points)}
                         </span>
-                      </>
+                      )
                     )}
                     {essay.book && <BookStatusBadges book={essay.book} />}
                   </>

--- a/src/components/essays/essay-card.tsx
+++ b/src/components/essays/essay-card.tsx
@@ -8,7 +8,6 @@ import { BookStatusBadges } from '@/components/books/book-status-badges';
 import { ContentSourceIllustration, CONTENT_SOURCE_KIND_ICONS } from '@/components/content-sources/content-source-illustration';
 import { formatPoints } from '@/lib/books/points';
 import { getEssaySourceDisplay } from '@/lib/essays/source-display';
-import { LegacyPointsBadge } from '@/components/essays/legacy-points-badge';
 import type { EssayWithDetails } from '@/lib/essays/types';
 
 interface EssayCardProps {
@@ -77,12 +76,9 @@ export function EssayCard({ essay, showVoteButton = false, initialVoted = false 
                 <span className="truncate">{source.title}</span>
                 {essay.book && <BookStatusBadges book={essay.book} />}
                 {!source.isArchived && source.points > 0 && (
-                  <div className="flex shrink-0 ml-auto items-center gap-1.5">
-                    {source.isFrozen && <LegacyPointsBadge />}
-                    <span className="shrink-0 font-medium text-foreground">
-                      {formatPoints(source.points)} b.
-                    </span>
-                  </div>
+                  <span className="shrink-0 ml-auto font-medium text-foreground">
+                    {formatPoints(source.points)} b.
+                  </span>
                 )}
                 {source.isArchived && (
                   <span className="shrink-0 ml-auto text-destructive">0 b.</span>

--- a/src/components/essays/essay-editor-form.tsx
+++ b/src/components/essays/essay-editor-form.tsx
@@ -427,13 +427,14 @@ export function EssayEditorForm({ initialEssay }: EssayEditorFormProps) {
 
             <div className="flex items-center gap-2 sm:gap-3 shrink-0">
               {(selectedBook.list_status !== 'archived' || selectedBookPointsFrozen) && (
-                <>
-                  {selectedBookPointsFrozen && <LegacyPointsBadge />}
+                selectedBookPointsFrozen ? (
+                  <LegacyPointsBadge points={selectedBookPoints} className="shrink-0" />
+                ) : (
                   <span className="inline-flex items-center rounded-full bg-primary/10 px-2.5 py-0.5 text-xs font-semibold text-primary">
                     <span className="font-heading tabular-nums">{formatPoints(selectedBookPoints)}</span>
                     <span className="ml-1 text-[11px] font-normal text-primary/80">b.</span>
                   </span>
-                </>
+                )
               )}
 
               <Button

--- a/src/components/essays/legacy-points-badge.test.tsx
+++ b/src/components/essays/legacy-points-badge.test.tsx
@@ -1,0 +1,33 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import { LegacyPointsBadge } from './legacy-points-badge';
+
+describe('LegacyPointsBadge', () => {
+  it('renders staré label with lock icon', () => {
+    render(<LegacyPointsBadge />);
+    expect(screen.getByText('staré')).toBeInTheDocument();
+  });
+
+  it('renders unified segmented badge with points when provided', () => {
+    render(<LegacyPointsBadge points={3} />);
+    expect(screen.getByText('staré')).toBeInTheDocument();
+    expect(screen.getByText('3 b.')).toBeInTheDocument();
+  });
+
+  it('formats decimal points properly', () => {
+    render(<LegacyPointsBadge points={0.5} />);
+    expect(screen.getByText('0,50 b.')).toBeInTheDocument();
+  });
+
+  it('respects a custom label', () => {
+    render(<LegacyPointsBadge points={3} label="body" />);
+    expect(screen.getByText('staré')).toBeInTheDocument();
+    expect(screen.getByText('3 body')).toBeInTheDocument();
+  });
+
+  it('omits the points segment when points prop is undefined', () => {
+    render(<LegacyPointsBadge />);
+    expect(screen.getByText('staré')).toBeInTheDocument();
+    expect(screen.queryByText(/b\./)).not.toBeInTheDocument();
+  });
+});

--- a/src/components/essays/legacy-points-badge.tsx
+++ b/src/components/essays/legacy-points-badge.tsx
@@ -3,23 +3,50 @@
 import { Lock } from 'lucide-react';
 
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip';
+import { formatPoints } from '@/lib/books/points';
+import { cn } from '@/lib/utils';
+
+export interface LegacyPointsBadgeProps {
+  points?: number | string | null;
+  label?: string;
+  className?: string;
+}
 
 /**
- * Always-visible marker for essays whose points are frozen to the old
- * system's scoring (pre-2026-09-03) — a bare `title` attribute needs a hover
- * to discover at all, so this renders as its own small badge instead, with
- * the fuller explanation still available on hover/focus.
+ * Compact marker for essays whose points are frozen to the old
+ * system's scoring (pre-2026-09-03). When points are provided, renders
+ * a unified segmented badge `[🔒 staré | 3 b.]`.
  */
-export function LegacyPointsBadge() {
+export function LegacyPointsBadge({ points, label = 'b.', className }: LegacyPointsBadgeProps) {
+  const hasPoints = points != null;
+
   return (
     <Tooltip>
       <TooltipTrigger asChild>
-        <span className="inline-flex items-center gap-1 rounded-full bg-warning/15 text-warning-strong px-1.5 py-0.5 text-[10px] font-medium leading-none">
-          <Lock className="size-2.5 shrink-0" />
-          staré bodování
+        <span
+          className={cn(
+            'inline-flex items-center overflow-hidden rounded-full border border-warning/35 bg-warning/10 text-xs leading-none select-none',
+            className
+          )}
+        >
+          <span
+            className={cn(
+              'inline-flex items-center gap-1 bg-warning/25 text-warning-strong px-1.5 py-0.5 text-[10px] font-medium',
+              hasPoints && 'border-r border-warning/35'
+            )}
+          >
+            <Lock className="size-2.5 shrink-0" />
+            <span>staré</span>
+          </span>
+          {hasPoints && (
+            <span className="px-1.5 py-0.5 text-xs font-semibold tabular-nums text-foreground">
+              {formatPoints(points)} {label}
+            </span>
+          )}
         </span>
       </TooltipTrigger>
       <TooltipContent>Body za tuto esej jsou zamčené ze staršího systému.</TooltipContent>
     </Tooltip>
   );
 }
+

--- a/src/components/essays/my-essay-list.tsx
+++ b/src/components/essays/my-essay-list.tsx
@@ -97,12 +97,13 @@ export function MyEssayList({ essays, votedEssayIds = new Set() }: MyEssayListPr
                   </h3>
                 </div>
                 {hasPoints && (
-                  <div className="flex shrink-0 items-center gap-1.5">
-                    {source.isFrozen && <LegacyPointsBadge />}
+                  source.isFrozen ? (
+                    <LegacyPointsBadge points={points} className="shrink-0" />
+                  ) : (
                     <span className="shrink-0 text-xs font-semibold tabular-nums bg-primary/10 text-primary px-1.5 py-0.5 rounded-full">
                       {formatPoints(points)} b.
                     </span>
-                  </div>
+                  )
                 )}
                 {isRejected && (
                   <span className="shrink-0 text-xs font-semibold tabular-nums bg-destructive/10 text-destructive px-1.5 py-0.5 rounded-full">

--- a/src/components/essays/social-essay-feed-card.tsx
+++ b/src/components/essays/social-essay-feed-card.tsx
@@ -15,6 +15,7 @@ import { getEssaySourceDisplay } from '@/lib/essays/source-display';
 import { countWords, formatReadingTime } from '@/lib/essays/text-stats';
 import { formatRelativeTime, isRecentEssay } from '@/lib/essays/date-helpers';
 import { cn } from '@/lib/utils';
+import { structureBookTitle } from '@/lib/books/format-title';
 import type { EssayWithDetails } from '@/lib/essays/types';
 
 export interface AuthorGamificationStats {
@@ -150,40 +151,45 @@ export function SocialEssayFeedCard({
 
       {/* 2. Source Connection Capsule (book or content source) */}
       {essay.book ? (
-        <Link
-          href={`/cteni/knihy/${essay.book.id}`}
-          className="flex items-center gap-2.5 rounded-xl border bg-muted/40 p-2 transition-colors hover:bg-muted/70"
-        >
-          <div className="flex h-10 w-7 shrink-0 items-center justify-center overflow-hidden rounded bg-muted">
-            {essay.book.google_books_cover_url ? (
-              <StorageImage
-                storageKey={essay.book.google_books_cover_url}
-                alt={essay.book.title_cs}
-                width={28}
-                height={40}
-                className="size-full object-cover"
-              />
-            ) : (
-              <BookOpen className="size-3.5 text-muted-foreground/50" />
-            )}
-          </div>
+        (() => {
+          const { title: bookTitle, fullTitle } = structureBookTitle(essay.book.title_cs);
+          return (
+            <Link
+              href={`/cteni/knihy/${essay.book.id}`}
+              className="flex items-center gap-2.5 rounded-xl border bg-muted/40 p-2 transition-colors hover:bg-muted/70"
+            >
+              <div className="flex h-10 w-7 shrink-0 items-center justify-center overflow-hidden rounded bg-muted">
+                {essay.book.google_books_cover_url ? (
+                  <StorageImage
+                    storageKey={essay.book.google_books_cover_url}
+                    alt={bookTitle}
+                    width={28}
+                    height={40}
+                    className="size-full object-cover"
+                  />
+                ) : (
+                  <BookOpen className="size-3.5 text-muted-foreground/50" />
+                )}
+              </div>
 
-          <div className="min-w-0 flex-1">
-            <div className="flex items-center gap-1.5 flex-wrap">
-              <span className="truncate text-xs font-medium text-foreground">
-                {essay.book.title_cs}
-              </span>
-              <BookStatusBadges book={essay.book} />
-            </div>
-            <p className="truncate text-[11px] text-muted-foreground">{essay.book.author}</p>
-          </div>
+              <div className="min-w-0 flex-1">
+                <div className="flex items-center gap-1.5 min-w-0">
+                  <span className="truncate min-w-0 text-xs font-medium text-foreground" title={fullTitle}>
+                    {bookTitle}
+                  </span>
+                  <BookStatusBadges book={essay.book} />
+                </div>
+                <p className="truncate text-[11px] text-muted-foreground">{essay.book.author}</p>
+              </div>
 
-          {!source.isArchived && source.points > 0 && (
-            <Badge variant="secondary" className="shrink-0 text-xs font-semibold">
-              {formatPoints(source.points)} b.
-            </Badge>
-          )}
-        </Link>
+              {!source.isArchived && source.points > 0 && (
+                <Badge variant="secondary" className="shrink-0 text-xs font-semibold">
+                  {formatPoints(source.points)} b.
+                </Badge>
+              )}
+            </Link>
+          );
+        })()
       ) : essay.content_source ? (
         /* Content sources have no detail page to link to — same capsule, no link. */
         <div className="flex items-center gap-2.5 rounded-xl border bg-muted/40 p-2">

--- a/src/components/essays/social-essay-feed-card.tsx
+++ b/src/components/essays/social-essay-feed-card.tsx
@@ -12,7 +12,6 @@ import { Button } from '@/components/ui/button';
 import { formatPoints } from '@/lib/books/points';
 import { CONTENT_SOURCE_KIND_LABELS } from '@/lib/content-sources/types';
 import { getEssaySourceDisplay } from '@/lib/essays/source-display';
-import { LegacyPointsBadge } from '@/components/essays/legacy-points-badge';
 import { countWords, formatReadingTime } from '@/lib/essays/text-stats';
 import { formatRelativeTime, isRecentEssay } from '@/lib/essays/date-helpers';
 import { cn } from '@/lib/utils';
@@ -180,12 +179,9 @@ export function SocialEssayFeedCard({
           </div>
 
           {!source.isArchived && source.points > 0 && (
-            <div className="flex shrink-0 items-center gap-1.5">
-              {source.isFrozen && <LegacyPointsBadge />}
-              <Badge variant="secondary" className="shrink-0 text-xs font-semibold">
-                {formatPoints(source.points)} b.
-              </Badge>
-            </div>
+            <Badge variant="secondary" className="shrink-0 text-xs font-semibold">
+              {formatPoints(source.points)} b.
+            </Badge>
           )}
         </Link>
       ) : essay.content_source ? (

--- a/src/components/library/active-loans-card.test.tsx
+++ b/src/components/library/active-loans-card.test.tsx
@@ -25,7 +25,7 @@ const makeLoan = (overrides: Partial<BookLoanWithDetails> = {}): BookLoanWithDet
   library_book: {
     id: 'lib-1',
     book_id: 'book-1',
-    isbn_13: '9780132350884',
+    label_code: null,
     created_by_profile_id: 'user-1',
     updated_by_profile_id: 'user-1',
     created_at: '2026-08-01T10:00:00.000Z',
@@ -45,7 +45,6 @@ const makeLoan = (overrides: Partial<BookLoanWithDetails> = {}): BookLoanWithDet
       created_at: '2026-08-01T10:00:00.000Z',
       description: null,
       google_books_cover_url: null,
-      isbn_13: null,
       page_count: 400,
       preview_link: null,
       tags: [],

--- a/src/components/library/borrow-panel.test.tsx
+++ b/src/components/library/borrow-panel.test.tsx
@@ -75,6 +75,22 @@ describe('BorrowPanel', () => {
     expect(screen.getByText('30. srpna 2026')).toBeInTheDocument();
   });
 
+  it('borrows the exact labelled copy opened from its QR code', async () => {
+    fetchSpy.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ data: { due_at: '2026-08-30T00:00:00.000Z' } }),
+    } as Response);
+
+    const user = userEvent.setup();
+    render(<BorrowPanel {...base} labelCode={7} availableCopies={1} totalCopies={1} />);
+
+    expect(screen.getByText('Výtisk #007')).toBeInTheDocument();
+    expect(screen.getByText('Tento výtisk je k dispozici.')).toBeInTheDocument();
+    await user.click(screen.getByRole('button', { name: /Půjčit si/i }));
+
+    expect(fetchSpy).toHaveBeenCalledWith('/api/library/books/book-1/borrow?label=7', { method: 'POST' });
+  });
+
   it('shows an error toast and returns to idle when borrowing fails', async () => {
     const toastModule = await import('sonner');
     const errorSpy = vi.spyOn(toastModule.toast, 'error').mockImplementation(() => '');

--- a/src/components/library/borrow-panel.tsx
+++ b/src/components/library/borrow-panel.tsx
@@ -12,6 +12,7 @@ import { StorageImage } from '@/components/storage/storage-image';
 import { BookStatusBadges } from '@/components/books/book-status-badges';
 import { ReturnButton } from './return-button';
 import type { BookWithProfiles } from '@/lib/books/types';
+import { formatLibraryLabelCode } from '@/lib/library/label-code';
 
 interface BorrowPanelProps {
   bookId: string;
@@ -20,6 +21,7 @@ interface BorrowPanelProps {
   coverUrl: string | null;
   availableCopies: number;
   totalCopies: number;
+  labelCode?: number | null;
   initialDueAt?: string | null;
   /** Status fields for the badge row next to the title — omit to hide badges. */
   book?: Pick<BookWithProfiles, 'list_status' | 'is_rocket_model' | 'highlight_category'>;
@@ -36,6 +38,7 @@ export function BorrowPanel({
   coverUrl,
   availableCopies,
   totalCopies,
+  labelCode = null,
   initialDueAt = null,
   book,
 }: BorrowPanelProps) {
@@ -46,7 +49,8 @@ export function BorrowPanel({
   const handleBorrow = async () => {
     setBorrowing(true);
     try {
-      const res = await fetch(`/api/library/books/${bookId}/borrow`, { method: 'POST' });
+      const labelQuery = labelCode == null ? '' : `?label=${labelCode}`;
+      const res = await fetch(`/api/library/books/${bookId}/borrow${labelQuery}`, { method: 'POST' });
       const body = await res.json().catch(() => null);
       if (!res.ok) throw new Error(body?.error ?? 'Nepodařilo se vypůjčit knihu');
       setDueAt(body.data.due_at);
@@ -132,10 +136,15 @@ export function BorrowPanel({
           </div>
         )}
         <p className="text-muted-foreground">{author}</p>
+        {labelCode != null && (
+          <p className="text-sm font-medium text-primary">Výtisk {formatLibraryLabelCode(labelCode)}</p>
+        )}
       </div>
 
       <p className="text-sm text-muted-foreground">
-        {availableCopies > 0
+        {labelCode != null
+          ? (availableCopies > 0 ? 'Tento výtisk je k dispozici.' : 'Tento výtisk je momentálně půjčený.')
+          : availableCopies > 0
           ? `${availableCopies} z ${totalCopies} kopií je teď k dispozici.`
           : `Všech ${totalCopies} kopií je momentálně půjčeno.`}
       </p>

--- a/src/components/library/library-import-scanner.tsx
+++ b/src/components/library/library-import-scanner.tsx
@@ -62,7 +62,7 @@ export function LibraryImportScanner() {
       const res = await fetch('/api/library/books', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ book_id: book.id, isbn_13: book.isbn_13 }),
+        body: JSON.stringify({ book_id: book.id }),
       });
       if (!res.ok) {
         const err = await res.json();

--- a/src/components/library/library-label-assignment.test.tsx
+++ b/src/components/library/library-label-assignment.test.tsx
@@ -57,7 +57,7 @@ describe('LibraryLabelAssignment', () => {
     expect(fetchMock).toHaveBeenCalledWith('/api/library/labels/7');
   });
 
-  it('searches the catalogue and assigns the selected book to the copy', async () => {
+  it('searches automatically after typing and assigns the selected book to the copy', async () => {
     const fetchMock = vi.fn((input: string | URL | Request, init?: RequestInit) => {
       const url = String(input);
       if (url === '/api/library/labels/7' && init?.method === 'POST') {
@@ -72,7 +72,7 @@ describe('LibraryLabelAssignment', () => {
       if (url === '/api/library/labels/7') {
         return Promise.resolve({ ok: false, status: 404 } as Response);
       }
-      if (url.startsWith('/api/books/search')) {
+      if (url.startsWith('/api/library/catalog-search')) {
         return Promise.resolve({
           ok: true,
           status: 200,
@@ -88,8 +88,11 @@ describe('LibraryLabelAssignment', () => {
     await screen.findByText('2. Kniha');
 
     await user.type(screen.getByRole('textbox', { name: 'Hledat knihu' }), 'Atomové návyky');
-    await user.click(screen.getByRole('button', { name: 'Hledat' }));
     await screen.findByText('James Clear');
+    expect(fetchMock).toHaveBeenCalledWith(
+      '/api/library/catalog-search?q=Atomov%C3%A9%20n%C3%A1vyky',
+      expect.objectContaining({ signal: expect.any(AbortSignal) }),
+    );
     await user.click(screen.getByRole('button', { name: 'Přiřadit' }));
 
     expect(await screen.findByText('Výtisk je připravený')).toBeInTheDocument();
@@ -98,5 +101,57 @@ describe('LibraryLabelAssignment', () => {
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ book_id: BOOK.id }),
     }));
+  });
+
+  it('offers adding a missing book even when search has matches', async () => {
+    const fetchMock = vi.fn((input: string | URL | Request) => {
+      const url = String(input);
+      if (url === '/api/library/labels/7') {
+        return Promise.resolve({ ok: false, status: 404 } as Response);
+      }
+      return Promise.resolve({
+        ok: true,
+        status: 200,
+        json: async () => ({ data: [BOOK] }),
+      } as Response);
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    const user = userEvent.setup();
+    render(<LibraryLabelAssignment initialLabelCode={7} />);
+    await screen.findByText('2. Kniha');
+    await user.type(screen.getByRole('textbox', { name: 'Hledat knihu' }), 'Atomové');
+
+    const link = await screen.findByRole('link', { name: 'Přidat novou knihu' });
+    expect(link).toHaveAttribute(
+      'href',
+      '/cteni/knihy/nova?q=Atomov%C3%A9&from=knihovna-stitky&label=7',
+    );
+  });
+
+  it('automatically assigns a book after returning from the add flow', async () => {
+    const fetchMock = vi.fn((input: string | URL | Request, init?: RequestInit) => {
+      const url = String(input);
+      if (url === '/api/library/labels/7' && init?.method === 'POST') {
+        return Promise.resolve({
+          ok: true,
+          status: 201,
+          json: async () => ({
+            data: { id: 'copy-1', book_id: BOOK.id, label_code: 7, book: BOOK },
+          }),
+        } as Response);
+      }
+      return Promise.resolve({ ok: false, status: 404 } as Response);
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    render(<LibraryLabelAssignment initialLabelCode={7} initialBookId={BOOK.id} />);
+
+    expect(await screen.findByText('Výtisk je připravený')).toBeInTheDocument();
+    expect(fetchMock).toHaveBeenCalledWith('/api/library/labels/7', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ book_id: BOOK.id }),
+    });
   });
 });

--- a/src/components/library/library-label-assignment.test.tsx
+++ b/src/components/library/library-label-assignment.test.tsx
@@ -1,0 +1,102 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('react-barcode-scanner', () => ({
+  BarcodeScanner: ({
+    options,
+    onCapture,
+  }: {
+    options: { formats: string[] };
+    onCapture: (barcodes: Array<{ rawValue: string; format: string }>) => void;
+  }) => {
+    const scansQrCode = options.formats.includes('qr_code');
+    return (
+      <button
+        type="button"
+        onClick={() => onCapture([{
+          rawValue: scansQrCode ? 'https://tiimi.cz/l/7' : '9788027504376',
+          format: scansQrCode ? 'qr_code' : 'ean_13',
+        }])}
+      >
+        {scansQrCode ? 'test-scan-label' : 'test-scan-isbn'}
+      </button>
+    );
+  },
+}));
+
+vi.mock('sonner', () => ({
+  toast: { error: vi.fn(), success: vi.fn() },
+}));
+
+import { LibraryLabelAssignment } from './library-label-assignment';
+
+const BOOK = {
+  id: 'book-1',
+  title_cs: 'Atomové návyky',
+  author: 'James Clear',
+  isbn_13: '9788027504376',
+  google_books_cover_url: null,
+};
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe('LibraryLabelAssignment', () => {
+  it('reads a Tappka label URL and advances to book selection', async () => {
+    const fetchMock = vi.fn().mockResolvedValue({ ok: false, status: 404 } as Response);
+    vi.stubGlobal('fetch', fetchMock);
+
+    const user = userEvent.setup();
+    render(<LibraryLabelAssignment initialLabelCode={null} />);
+    await user.click(screen.getByRole('button', { name: 'test-scan-label' }));
+
+    expect(await screen.findByText('#007')).toBeInTheDocument();
+    expect(await screen.findByText('2. Kniha')).toBeInTheDocument();
+    expect(fetchMock).toHaveBeenCalledWith('/api/library/labels/7');
+  });
+
+  it('searches the catalogue and assigns the selected book to the copy', async () => {
+    const fetchMock = vi.fn((input: string | URL | Request, init?: RequestInit) => {
+      const url = String(input);
+      if (url === '/api/library/labels/7' && init?.method === 'POST') {
+        return Promise.resolve({
+          ok: true,
+          status: 201,
+          json: async () => ({
+            data: { id: 'copy-1', book_id: BOOK.id, label_code: 7, book: BOOK },
+          }),
+        } as Response);
+      }
+      if (url === '/api/library/labels/7') {
+        return Promise.resolve({ ok: false, status: 404 } as Response);
+      }
+      if (url.startsWith('/api/books/search')) {
+        return Promise.resolve({
+          ok: true,
+          status: 200,
+          json: async () => ({ data: [BOOK] }),
+        } as Response);
+      }
+      return Promise.reject(new Error(`Unexpected request: ${url}`));
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    const user = userEvent.setup();
+    render(<LibraryLabelAssignment initialLabelCode={7} />);
+    await screen.findByText('2. Kniha');
+
+    await user.type(screen.getByRole('textbox', { name: 'Hledat knihu' }), 'Atomové návyky');
+    await user.click(screen.getByRole('button', { name: 'Hledat' }));
+    await screen.findByText('James Clear');
+    await user.click(screen.getByRole('button', { name: 'Přiřadit' }));
+
+    expect(await screen.findByText('Výtisk je připravený')).toBeInTheDocument();
+    await waitFor(() => expect(fetchMock).toHaveBeenCalledWith('/api/library/labels/7', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ book_id: BOOK.id }),
+    }));
+  });
+});

--- a/src/components/library/library-label-assignment.tsx
+++ b/src/components/library/library-label-assignment.tsx
@@ -1,8 +1,8 @@
 'use client';
 
-import { useCallback, useEffect, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import Link from 'next/link';
-import { BookOpen, Camera, CheckCircle2, QrCode, RotateCcw, Search, X } from 'lucide-react';
+import { BookOpen, Camera, CheckCircle2, Plus, QrCode, RotateCcw, Search, X } from 'lucide-react';
 import { BarcodeScanner } from 'react-barcode-scanner';
 import { toast } from 'sonner';
 import 'react-barcode-scanner/polyfill';
@@ -16,6 +16,8 @@ import { Spinner } from '@/components/ui/spinner';
 import { formatLibraryLabelCode, parseLibraryLabelCode } from '@/lib/library/label-code';
 
 const SCANNER_DELAY_MS = 400;
+const SEARCH_DEBOUNCE_MS = 350;
+const MIN_SEARCH_LENGTH = 2;
 
 const LABEL_STATUS = {
   idle: 'idle',
@@ -48,9 +50,13 @@ interface AssignedCopy {
 
 interface LibraryLabelAssignmentProps {
   initialLabelCode: number | null;
+  initialBookId?: string | null;
 }
 
-export function LibraryLabelAssignment({ initialLabelCode }: LibraryLabelAssignmentProps) {
+export function LibraryLabelAssignment({
+  initialLabelCode,
+  initialBookId = null,
+}: LibraryLabelAssignmentProps) {
   const [labelCode, setLabelCode] = useState<number | null>(initialLabelCode);
   const [manualLabelCode, setManualLabelCode] = useState(initialLabelCode?.toString() ?? '');
   const [labelStatus, setLabelStatus] = useState<keyof typeof LABEL_STATUS>(
@@ -65,6 +71,7 @@ export function LibraryLabelAssignment({ initialLabelCode }: LibraryLabelAssignm
   const [results, setResults] = useState<BookSearchResult[] | null>(null);
   const [searching, setSearching] = useState(false);
   const [assigningBookId, setAssigningBookId] = useState<string | null>(null);
+  const returnedBookHandled = useRef(false);
 
   useEffect(() => {
     if (labelCode == null) return;
@@ -128,42 +135,55 @@ export function LibraryLabelAssignment({ initialLabelCode }: LibraryLabelAssignm
     acceptLabelValue(manualLabelCode);
   };
 
-  const handleSearch = useCallback(async (searchQuery?: string) => {
-    const trimmedQuery = (searchQuery ?? query).trim();
-    if (!trimmedQuery) return;
+  useEffect(() => {
+    const trimmedQuery = query.trim();
+    if (labelStatus !== LABEL_STATUS.unassigned || trimmedQuery.length < MIN_SEARCH_LENGTH) return;
 
-    setSearching(true);
-    setResults(null);
-    try {
-      const response = await fetch(`/api/books/search?q=${encodeURIComponent(trimmedQuery)}`);
-      const body: { data?: BookSearchResult[]; error?: string } = await response.json();
-      if (!response.ok) throw new Error(body.error ?? 'Nepodařilo se vyhledat knihy');
-      setResults(body.data ?? []);
-    } catch (error) {
-      toast.error(error instanceof Error ? error.message : 'Nepodařilo se vyhledat knihy');
-    } finally {
-      setSearching(false);
-    }
-  }, [query]);
+    const controller = new AbortController();
+    const timer = window.setTimeout(async () => {
+      setSearching(true);
+      try {
+        const response = await fetch(
+          `/api/library/catalog-search?q=${encodeURIComponent(trimmedQuery)}`,
+          { signal: controller.signal },
+        );
+        const body: { data?: BookSearchResult[]; error?: string } = await response.json();
+        if (!response.ok) throw new Error(body.error ?? 'Nepodařilo se vyhledat knihy');
+        setResults(body.data ?? []);
+      } catch (error) {
+        if (!controller.signal.aborted) {
+          toast.error(error instanceof Error ? error.message : 'Nepodařilo se vyhledat knihy');
+        }
+      } finally {
+        if (!controller.signal.aborted) setSearching(false);
+      }
+    }, SEARCH_DEBOUNCE_MS);
+
+    return () => {
+      window.clearTimeout(timer);
+      controller.abort();
+    };
+  }, [labelStatus, query]);
 
   const handleBookCapture = useCallback((barcodes: DetectedBarcode[]) => {
     const value = barcodes[0]?.rawValue;
     if (!value) return;
 
     setQuery(value);
+    setResults(null);
+    setSearching(false);
     setShowBookScanner(false);
-    void handleSearch(value);
-  }, [handleSearch]);
+  }, []);
 
-  const handleAssign = async (book: BookSearchResult) => {
+  const handleAssign = useCallback(async (bookId: string) => {
     if (labelCode == null) return;
 
-    setAssigningBookId(book.id);
+    setAssigningBookId(bookId);
     try {
       const response = await fetch(`/api/library/labels/${labelCode}`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ book_id: book.id }),
+        body: JSON.stringify({ book_id: bookId }),
       });
       const body: { data?: AssignedCopy; error?: string } = await response.json();
       if (!response.ok || !body.data) {
@@ -173,13 +193,26 @@ export function LibraryLabelAssignment({ initialLabelCode }: LibraryLabelAssignm
       setAssignedCopy(body.data);
       setJustAssigned(true);
       setLabelStatus(LABEL_STATUS.assigned);
-      toast.success(`${formatLibraryLabelCode(labelCode)} je přiřazený ke knize „${book.title_cs}“`);
+      toast.success(
+        `${formatLibraryLabelCode(labelCode)} je přiřazený ke knize „${body.data.book.title_cs}“`,
+      );
     } catch (error) {
       toast.error(error instanceof Error ? error.message : 'Nepodařilo se přiřadit štítek');
     } finally {
       setAssigningBookId(null);
     }
-  };
+  }, [labelCode]);
+
+  useEffect(() => {
+    if (
+      initialBookId == null
+      || labelStatus !== LABEL_STATUS.unassigned
+      || returnedBookHandled.current
+    ) return;
+
+    returnedBookHandled.current = true;
+    void handleAssign(initialBookId);
+  }, [handleAssign, initialBookId, labelStatus]);
 
   const resetForNextLabel = () => {
     setLabelCode(null);
@@ -314,22 +347,24 @@ export function LibraryLabelAssignment({ initialLabelCode }: LibraryLabelAssignm
               </div>
             )}
 
-            <form
-              onSubmit={(event) => {
-                event.preventDefault();
-                void handleSearch();
-              }}
-              className="flex gap-2"
-            >
-              <Input
-                value={query}
-                onChange={(event) => setQuery(event.target.value)}
-                placeholder="Název, autor:ka nebo ISBN"
-                aria-label="Hledat knihu"
-              />
-              <Button type="submit" disabled={!query.trim() || searching} size="icon" aria-label="Hledat">
-                {searching ? <Spinner className="size-4" /> : <Search className="size-4" />}
-              </Button>
+            <div className="flex gap-2">
+              <div className="relative min-w-0 flex-1">
+                <Search className="pointer-events-none absolute top-1/2 left-3 size-4 -translate-y-1/2 text-muted-foreground" />
+                <Input
+                  value={query}
+                  onChange={(event) => {
+                    setQuery(event.target.value);
+                    setResults(null);
+                    setSearching(false);
+                  }}
+                  placeholder="Název, autor:ka nebo ISBN"
+                  aria-label="Hledat knihu"
+                  className="pr-9 pl-9"
+                />
+                {searching && (
+                  <Spinner className="absolute top-1/2 right-3 size-4 -translate-y-1/2 text-muted-foreground" />
+                )}
+              </div>
               <Button
                 type="button"
                 variant="outline"
@@ -339,7 +374,11 @@ export function LibraryLabelAssignment({ initialLabelCode }: LibraryLabelAssignm
               >
                 {showBookScanner ? <X className="size-4" /> : <Camera className="size-4" />}
               </Button>
-            </form>
+            </div>
+
+            {query.trim().length > 0 && query.trim().length < MIN_SEARCH_LENGTH && (
+              <p className="text-xs text-muted-foreground">Pro vyhledání zadej alespoň 2 znaky</p>
+            )}
 
             {results?.length === 0 && (
               <Empty>
@@ -348,11 +387,6 @@ export function LibraryLabelAssignment({ initialLabelCode }: LibraryLabelAssignm
                   <EmptyTitle>Kniha není v katalogu</EmptyTitle>
                   <EmptyDescription>Nejdřív ji přidej do BOBa a potom se vrať ke štítku</EmptyDescription>
                 </EmptyHeader>
-                <Button asChild variant="outline">
-                  <Link href={`/cteni/knihy/nova?q=${encodeURIComponent(query)}&from=${encodeURIComponent(`/knihovna/stitky?label=${labelCode}`)}`}>
-                    Přidat knihu
-                  </Link>
-                </Button>
               </Empty>
             )}
 
@@ -384,12 +418,29 @@ export function LibraryLabelAssignment({ initialLabelCode }: LibraryLabelAssignm
                       type="button"
                       size="sm"
                       disabled={assigningBookId != null}
-                      onClick={() => void handleAssign(book)}
+                      onClick={() => void handleAssign(book.id)}
                     >
                       {assigningBookId === book.id ? <Spinner className="size-4" /> : 'Přiřadit'}
                     </Button>
                   </div>
                 ))}
+              </div>
+            )}
+
+            {results && (
+              <div className="flex flex-col gap-3 rounded-lg border border-dashed p-4 sm:flex-row sm:items-center sm:justify-between">
+                <div>
+                  <p className="text-sm font-medium">Kniha tu není?</p>
+                  <p className="text-xs text-muted-foreground">
+                    Přidej ji do BOBa a ke štítku se vrátíš automaticky.
+                  </p>
+                </div>
+                <Button asChild variant="outline" className="gap-2">
+                  <Link href={`/cteni/knihy/nova?q=${encodeURIComponent(query)}&from=knihovna-stitky&label=${labelCode}`}>
+                    <Plus className="size-4" />
+                    Přidat novou knihu
+                  </Link>
+                </Button>
               </div>
             )}
           </CardContent>

--- a/src/components/library/library-label-assignment.tsx
+++ b/src/components/library/library-label-assignment.tsx
@@ -1,0 +1,400 @@
+'use client';
+
+import { useCallback, useEffect, useState } from 'react';
+import Link from 'next/link';
+import { BookOpen, Camera, CheckCircle2, QrCode, RotateCcw, Search, X } from 'lucide-react';
+import { BarcodeScanner } from 'react-barcode-scanner';
+import { toast } from 'sonner';
+import 'react-barcode-scanner/polyfill';
+
+import { StorageImage } from '@/components/storage/storage-image';
+import { Button } from '@/components/ui/button';
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
+import { Empty, EmptyDescription, EmptyHeader, EmptyMedia, EmptyTitle } from '@/components/ui/empty';
+import { Input } from '@/components/ui/input';
+import { Spinner } from '@/components/ui/spinner';
+import { formatLibraryLabelCode, parseLibraryLabelCode } from '@/lib/library/label-code';
+
+const SCANNER_DELAY_MS = 400;
+
+const LABEL_STATUS = {
+  idle: 'idle',
+  checking: 'checking',
+  unassigned: 'unassigned',
+  assigned: 'assigned',
+  error: 'error',
+} as const;
+
+interface DetectedBarcode {
+  rawValue: string;
+  format: string;
+}
+
+interface BookSearchResult {
+  id: string;
+  title_cs: string;
+  author: string;
+  isbn_13?: string | null;
+  google_books_cover_url: string | null;
+}
+
+interface AssignedCopy {
+  id: string;
+  book_id: string;
+  label_code: number;
+  reused_existing_copy?: boolean;
+  book: BookSearchResult;
+}
+
+interface LibraryLabelAssignmentProps {
+  initialLabelCode: number | null;
+}
+
+export function LibraryLabelAssignment({ initialLabelCode }: LibraryLabelAssignmentProps) {
+  const [labelCode, setLabelCode] = useState<number | null>(initialLabelCode);
+  const [manualLabelCode, setManualLabelCode] = useState(initialLabelCode?.toString() ?? '');
+  const [labelStatus, setLabelStatus] = useState<keyof typeof LABEL_STATUS>(
+    initialLabelCode == null ? LABEL_STATUS.idle : LABEL_STATUS.checking,
+  );
+  const [checkAttempt, setCheckAttempt] = useState(0);
+  const [assignedCopy, setAssignedCopy] = useState<AssignedCopy | null>(null);
+  const [justAssigned, setJustAssigned] = useState(false);
+  const [showLabelScanner, setShowLabelScanner] = useState(initialLabelCode == null);
+  const [showBookScanner, setShowBookScanner] = useState(false);
+  const [query, setQuery] = useState('');
+  const [results, setResults] = useState<BookSearchResult[] | null>(null);
+  const [searching, setSearching] = useState(false);
+  const [assigningBookId, setAssigningBookId] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (labelCode == null) return;
+
+    let cancelled = false;
+    const checkLabel = async () => {
+      setLabelStatus(LABEL_STATUS.checking);
+      setAssignedCopy(null);
+      setJustAssigned(false);
+
+      try {
+        const response = await fetch(`/api/library/labels/${labelCode}`);
+        if (cancelled) return;
+
+        if (response.status === 404) {
+          setLabelStatus(LABEL_STATUS.unassigned);
+          return;
+        }
+
+        const body: { data?: AssignedCopy; error?: string } = await response.json();
+        if (!response.ok || !body.data) {
+          throw new Error(body.error ?? 'Nepodařilo se ověřit štítek');
+        }
+
+        setAssignedCopy(body.data);
+        setLabelStatus(LABEL_STATUS.assigned);
+      } catch (error) {
+        if (cancelled) return;
+        setLabelStatus(LABEL_STATUS.error);
+        toast.error(error instanceof Error ? error.message : 'Nepodařilo se ověřit štítek');
+      }
+    };
+
+    void checkLabel();
+    return () => {
+      cancelled = true;
+    };
+  }, [checkAttempt, labelCode]);
+
+  const acceptLabelValue = useCallback((value: string) => {
+    const parsed = parseLibraryLabelCode(value);
+    if (parsed == null) {
+      toast.error('QR kód neobsahuje platný knihovní štítek');
+      return;
+    }
+
+    setLabelCode(parsed);
+    setManualLabelCode(parsed.toString());
+    setShowLabelScanner(false);
+    setQuery('');
+    setResults(null);
+  }, []);
+
+  const handleLabelCapture = useCallback((barcodes: DetectedBarcode[]) => {
+    const value = barcodes[0]?.rawValue;
+    if (value) acceptLabelValue(value);
+  }, [acceptLabelValue]);
+
+  const handleManualLabel = (event: React.FormEvent) => {
+    event.preventDefault();
+    acceptLabelValue(manualLabelCode);
+  };
+
+  const handleSearch = useCallback(async (searchQuery?: string) => {
+    const trimmedQuery = (searchQuery ?? query).trim();
+    if (!trimmedQuery) return;
+
+    setSearching(true);
+    setResults(null);
+    try {
+      const response = await fetch(`/api/books/search?q=${encodeURIComponent(trimmedQuery)}`);
+      const body: { data?: BookSearchResult[]; error?: string } = await response.json();
+      if (!response.ok) throw new Error(body.error ?? 'Nepodařilo se vyhledat knihy');
+      setResults(body.data ?? []);
+    } catch (error) {
+      toast.error(error instanceof Error ? error.message : 'Nepodařilo se vyhledat knihy');
+    } finally {
+      setSearching(false);
+    }
+  }, [query]);
+
+  const handleBookCapture = useCallback((barcodes: DetectedBarcode[]) => {
+    const value = barcodes[0]?.rawValue;
+    if (!value) return;
+
+    setQuery(value);
+    setShowBookScanner(false);
+    void handleSearch(value);
+  }, [handleSearch]);
+
+  const handleAssign = async (book: BookSearchResult) => {
+    if (labelCode == null) return;
+
+    setAssigningBookId(book.id);
+    try {
+      const response = await fetch(`/api/library/labels/${labelCode}`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ book_id: book.id }),
+      });
+      const body: { data?: AssignedCopy; error?: string } = await response.json();
+      if (!response.ok || !body.data) {
+        throw new Error(body.error ?? 'Nepodařilo se přiřadit štítek');
+      }
+
+      setAssignedCopy(body.data);
+      setJustAssigned(true);
+      setLabelStatus(LABEL_STATUS.assigned);
+      toast.success(`${formatLibraryLabelCode(labelCode)} je přiřazený ke knize „${book.title_cs}“`);
+    } catch (error) {
+      toast.error(error instanceof Error ? error.message : 'Nepodařilo se přiřadit štítek');
+    } finally {
+      setAssigningBookId(null);
+    }
+  };
+
+  const resetForNextLabel = () => {
+    setLabelCode(null);
+    setManualLabelCode('');
+    setLabelStatus(LABEL_STATUS.idle);
+    setAssignedCopy(null);
+    setJustAssigned(false);
+    setQuery('');
+    setResults(null);
+    setShowBookScanner(false);
+    setShowLabelScanner(true);
+  };
+
+  return (
+    <div className="space-y-4">
+      <Card>
+        <CardHeader>
+          <CardTitle className="flex items-center gap-2">
+            <QrCode className="size-5 text-primary" />
+            1. Štítek výtisku
+          </CardTitle>
+          <CardDescription>Naskenuj nalepený QR kód nebo zadej číslo pod ním</CardDescription>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          {showLabelScanner && (
+            <div className="relative aspect-video w-full overflow-hidden rounded-lg border bg-foreground">
+              <BarcodeScanner
+                options={{ delay: SCANNER_DELAY_MS, formats: ['qr_code'] }}
+                onCapture={handleLabelCapture}
+                paused={false}
+              />
+              <p className="absolute inset-x-3 bottom-3 rounded-md bg-background/90 px-3 py-2 text-center text-xs text-foreground">
+                Namiř kameru na QR štítek Tappky
+              </p>
+            </div>
+          )}
+
+          <form onSubmit={handleManualLabel} className="flex gap-2">
+            <Input
+              value={manualLabelCode}
+              onChange={(event) => setManualLabelCode(event.target.value)}
+              inputMode="numeric"
+              pattern="[0-9]*"
+              placeholder="Např. 001"
+              aria-label="Číslo knihovního štítku"
+            />
+            <Button type="submit" variant="outline" disabled={!manualLabelCode.trim()}>
+              Použít
+            </Button>
+            <Button
+              type="button"
+              variant="outline"
+              size="icon"
+              onClick={() => setShowLabelScanner((visible) => !visible)}
+              aria-label={showLabelScanner ? 'Zavřít skener štítku' : 'Skenovat štítek'}
+            >
+              {showLabelScanner ? <X className="size-4" /> : <Camera className="size-4" />}
+            </Button>
+          </form>
+
+          {labelCode != null && (
+            <div className="flex items-center justify-between gap-3 rounded-lg bg-primary/10 px-4 py-3">
+              <div>
+                <p className="text-xs font-medium text-primary">Vybraný štítek</p>
+                <p className="font-heading text-2xl font-bold text-primary">
+                  {formatLibraryLabelCode(labelCode)}
+                </p>
+              </div>
+              {labelStatus === LABEL_STATUS.checking && <Spinner className="size-5 text-primary" />}
+            </div>
+          )}
+        </CardContent>
+      </Card>
+
+      {labelStatus === LABEL_STATUS.assigned && assignedCopy && (
+        <Card className={justAssigned ? 'border-success bg-success/10' : undefined}>
+          <CardHeader>
+            <CardTitle className="flex items-center gap-2">
+              <CheckCircle2 className={justAssigned ? 'size-5 text-success-strong' : 'size-5 text-primary'} />
+              {justAssigned ? 'Výtisk je připravený' : 'Štítek už je přiřazený'}
+            </CardTitle>
+            <CardDescription>
+              {formatLibraryLabelCode(assignedCopy.label_code)} · {assignedCopy.book.title_cs}
+            </CardDescription>
+          </CardHeader>
+          <CardContent className="flex flex-wrap gap-2">
+            <Button asChild variant="outline">
+              <Link href={`/cteni/knihy/${assignedCopy.book_id}`}>Otevřít knihu</Link>
+            </Button>
+            <Button onClick={resetForNextLabel} className="gap-2">
+              <RotateCcw className="size-4" />
+              Další štítek
+            </Button>
+          </CardContent>
+        </Card>
+      )}
+
+      {labelStatus === LABEL_STATUS.error && (
+        <Card>
+          <CardContent className="flex items-center justify-between gap-3">
+            <p className="text-sm text-destructive">Štítek se nepodařilo ověřit</p>
+            <Button type="button" variant="outline" onClick={() => setCheckAttempt((attempt) => attempt + 1)}>
+              Zkusit znovu
+            </Button>
+          </CardContent>
+        </Card>
+      )}
+
+      {labelStatus === LABEL_STATUS.unassigned && labelCode != null && (
+        <Card>
+          <CardHeader>
+            <CardTitle className="flex items-center gap-2">
+              <BookOpen className="size-5 text-primary" />
+              2. Kniha
+            </CardTitle>
+            <CardDescription>Najdi titul v katalogu podle názvu, autora:ky nebo ISBN</CardDescription>
+          </CardHeader>
+          <CardContent className="space-y-4">
+            {showBookScanner && (
+              <div className="relative aspect-video w-full overflow-hidden rounded-lg border bg-foreground">
+                <BarcodeScanner
+                  options={{
+                    delay: SCANNER_DELAY_MS,
+                    formats: ['ean_13', 'ean_8', 'upc_a', 'upc_e', 'code_128'],
+                  }}
+                  onCapture={handleBookCapture}
+                  paused={false}
+                />
+                <p className="absolute inset-x-3 bottom-3 rounded-md bg-background/90 px-3 py-2 text-center text-xs text-foreground">
+                  Namiř kameru na ISBN čárový kód knihy
+                </p>
+              </div>
+            )}
+
+            <form
+              onSubmit={(event) => {
+                event.preventDefault();
+                void handleSearch();
+              }}
+              className="flex gap-2"
+            >
+              <Input
+                value={query}
+                onChange={(event) => setQuery(event.target.value)}
+                placeholder="Název, autor:ka nebo ISBN"
+                aria-label="Hledat knihu"
+              />
+              <Button type="submit" disabled={!query.trim() || searching} size="icon" aria-label="Hledat">
+                {searching ? <Spinner className="size-4" /> : <Search className="size-4" />}
+              </Button>
+              <Button
+                type="button"
+                variant="outline"
+                size="icon"
+                onClick={() => setShowBookScanner((visible) => !visible)}
+                aria-label={showBookScanner ? 'Zavřít skener ISBN' : 'Skenovat ISBN'}
+              >
+                {showBookScanner ? <X className="size-4" /> : <Camera className="size-4" />}
+              </Button>
+            </form>
+
+            {results?.length === 0 && (
+              <Empty>
+                <EmptyHeader>
+                  <EmptyMedia variant="icon"><BookOpen /></EmptyMedia>
+                  <EmptyTitle>Kniha není v katalogu</EmptyTitle>
+                  <EmptyDescription>Nejdřív ji přidej do BOBa a potom se vrať ke štítku</EmptyDescription>
+                </EmptyHeader>
+                <Button asChild variant="outline">
+                  <Link href={`/cteni/knihy/nova?q=${encodeURIComponent(query)}&from=${encodeURIComponent(`/knihovna/stitky?label=${labelCode}`)}`}>
+                    Přidat knihu
+                  </Link>
+                </Button>
+              </Empty>
+            )}
+
+            {results && results.length > 0 && (
+              <div className="space-y-2" aria-live="polite">
+                {results.map((book) => (
+                  <div key={book.id} className="flex items-center gap-3 rounded-lg border bg-card p-3">
+                    <div className="flex h-16 w-11 shrink-0 items-center justify-center overflow-hidden rounded-md bg-muted">
+                      {book.google_books_cover_url ? (
+                        <StorageImage
+                          storageKey={book.google_books_cover_url}
+                          alt=""
+                          width={44}
+                          height={64}
+                          className="h-full w-full object-cover"
+                        />
+                      ) : (
+                        <BookOpen className="size-4 text-muted-foreground" />
+                      )}
+                    </div>
+                    <div className="min-w-0 flex-1">
+                      <p className="truncate text-sm font-semibold">{book.title_cs}</p>
+                      <p className="truncate text-xs text-muted-foreground">{book.author}</p>
+                      {book.isbn_13 && (
+                        <p className="text-xs text-muted-foreground">ISBN {book.isbn_13}</p>
+                      )}
+                    </div>
+                    <Button
+                      type="button"
+                      size="sm"
+                      disabled={assigningBookId != null}
+                      onClick={() => void handleAssign(book)}
+                    >
+                      {assigningBookId === book.id ? <Spinner className="size-4" /> : 'Přiřadit'}
+                    </Button>
+                  </div>
+                ))}
+              </div>
+            )}
+          </CardContent>
+        </Card>
+      )}
+    </div>
+  );
+}

--- a/src/components/metrics/metric-progress.test.tsx
+++ b/src/components/metrics/metric-progress.test.tsx
@@ -25,4 +25,63 @@ describe("MetricProgress", () => {
     const bar = container.querySelector('[data-slot="metric-bar"]')
     expect(bar).toHaveStyle({ width: "100%" })
   })
+
+  it("renders mobile single semester chunk and desktop 6-segment bar", () => {
+    const { container } = render(
+      <MetricProgress
+        currentSemester={3}
+        goals={[
+          { current: 2, target: 20, label: "tento semestr" },
+          { current: 42, target: 120, label: "za studium" },
+        ]}
+      />,
+    )
+
+    // Mobile view (< sm): single bar showing current semester chunk (2/20 = 10%)
+    const mobileBar = container.querySelector('.sm\\:hidden [data-slot="metric-bar"]')
+    expect(mobileBar).toHaveStyle({ width: "10%" })
+    expect(screen.getByText("2/20")).toBeInTheDocument()
+    expect(screen.getByText("(zbývá 18)")).toBeInTheDocument()
+
+    // Desktop view (>= sm): 6 semester segment bars
+    const desktopBars = container.querySelectorAll('.hidden.sm\\:block [data-slot="metric-bar"]')
+    expect(desktopBars).toHaveLength(6)
+
+    // Sem 1 (0..20): 100% full
+    expect(desktopBars[0]).toHaveStyle({ width: "100%" })
+    // Sem 2 (20..40): 100% full
+    expect(desktopBars[1]).toHaveStyle({ width: "100%" })
+    // Sem 3 (40..60): 42 - 40 = 2 / 20 = 10%
+    expect(desktopBars[2]).toHaveStyle({ width: "10%" })
+    // Sem 4..6: 0%
+    expect(desktopBars[3]).toHaveStyle({ width: "0%" })
+    expect(desktopBars[4]).toHaveStyle({ width: "0%" })
+    expect(desktopBars[5]).toHaveStyle({ width: "0%" })
+
+    // Milestones 20, 40, 60, 80, 100, 120 rendered
+    expect(screen.getByText("20")).toBeInTheDocument()
+    expect(screen.getByText("40")).toBeInTheDocument()
+    expect(screen.getByText("60")).toBeInTheDocument()
+    expect(screen.getByText("80")).toBeInTheDocument()
+    expect(screen.getByText("100")).toBeInTheDocument()
+    expect(screen.getByText("120")).toBeInTheDocument()
+  })
+
+  it("correctly credits carry-over points into current semester even when current semester goal is 0", () => {
+    const { container } = render(
+      <MetricProgress
+        currentSemester={3}
+        goals={[
+          { current: 0, target: 20, label: "tento semestr" },
+          { current: 42, target: 120, label: "za studium" },
+        ]}
+      />,
+    )
+
+    // Mobile view should credit the 2 carry-over points from previous semesters (42 - 40 = 2)
+    const mobileBar = container.querySelector('.sm\\:hidden [data-slot="metric-bar"]')
+    expect(mobileBar).toHaveStyle({ width: "10%" })
+    expect(screen.getByText("2/20")).toBeInTheDocument()
+    expect(screen.getByText("(zbývá 18)")).toBeInTheDocument()
+  })
 })

--- a/src/components/metrics/metric-progress.tsx
+++ b/src/components/metrics/metric-progress.tsx
@@ -53,28 +53,39 @@ export function MetricProgress({
 
   const studyPercent = studyTarget > 0 ? Math.round((totalAchieved / studyTarget) * 100) : 0
 
+  // Current semester specific chunk progress (for mobile view)
+  const activeSemStart = (activeSemester - 1) * semesterTarget
+  const activeSemCurrent = Math.max(
+    semesterGoal?.current ?? 0,
+    Math.max(0, totalAchieved - activeSemStart),
+  )
+  const isSemPassed = totalAchieved >= activeExpectedMilestone || activeSemCurrent >= semesterTarget
+  const semSurplus = Math.max(cumulativeDelta, activeSemCurrent - semesterTarget)
+  const activeSemRemaining = Math.max(0, semesterTarget - activeSemCurrent)
+  const activeSemFill = Math.min(100, Math.max(0, (activeSemCurrent / semesterTarget) * 100))
+
   return (
     <details className="group rounded-lg border border-border/40 bg-muted/20 p-3 text-xs transition-colors hover:bg-muted/30">
       <summary className="focus-ring cursor-pointer list-none [&::-webkit-details-marker]:hidden">
-        {/* Mobile View (< sm): Clean 3-tier layout */}
+        {/* Mobile View (< sm): Current Semester Chunk */}
         <div className="space-y-1.5 sm:hidden">
           <div className="flex items-center justify-between">
             <div className="flex items-center gap-1.5">
               <span className="font-semibold text-foreground">{activeSemester}. semestr</span>
-              {isCumulativePassed ? (
+              {isSemPassed ? (
                 <span className="inline-flex items-center gap-1 font-semibold text-success-strong">
                   <Check className="size-3.5 stroke-[2.5]" />
-                  Splněno {cumulativeDelta > 0 ? `(+${cumulativeDelta})` : ""}
+                  Splněno {semSurplus > 0 ? `(+${semSurplus})` : ""}
                 </span>
               ) : (
                 <span className="text-[11px] text-muted-foreground">
-                  (zbývá {Math.abs(cumulativeDelta)})
+                  (zbývá {activeSemRemaining})
                 </span>
               )}
             </div>
 
             <span className="font-bold tabular-nums text-foreground">
-              {totalAchieved}/{activeExpectedMilestone}
+              {activeSemCurrent}/{semesterTarget}
             </span>
           </div>
 
@@ -82,18 +93,20 @@ export function MetricProgress({
             <div
               data-slot="metric-bar"
               className={`h-full rounded-full transition-all duration-300 ${
-                isCumulativePassed ? "bg-success" : "bg-foreground/75"
+                isSemPassed ? "bg-success" : "bg-foreground/75"
               }`}
               style={{
-                width: `${Math.min(100, Math.max(0, (totalAchieved / activeExpectedMilestone) * 100))}%`,
+                width: `${activeSemFill}%`,
               }}
             />
           </div>
 
-          <div className="flex items-center justify-between text-[11px] tabular-nums text-muted-foreground/80">
-            <span>Celkem: {totalAchieved}/{studyTarget}</span>
-            <span>({studyPercent}%)</span>
-          </div>
+          {studyGoal && (
+            <div className="flex items-center justify-between text-[11px] tabular-nums text-muted-foreground/80">
+              <span>Celkem: {totalAchieved}/{studyTarget}</span>
+              <span>({studyPercent}%)</span>
+            </div>
+          )}
         </div>
 
         {/* Desktop View (>= sm): Header + 6-Segment Cumulative Milestone Bar */}
@@ -125,14 +138,9 @@ export function MetricProgress({
               </span>
               <span className="text-[11px]">({studyPercent}%)</span>
 
-              {/* Accessible fallback for semester ratio */}
+              {/* Accessible fallback for semester label */}
               {semesterGoal && (
-                <span className="sr-only">
-                  <span>{semesterGoal.label}</span>
-                  <span>
-                    {semesterGoal.current}/{semesterGoal.target}
-                  </span>
-                </span>
+                <span className="sr-only">{semesterGoal.label}</span>
               )}
             </div>
           </div>
@@ -199,17 +207,4 @@ export function MetricProgress({
     </details>
   )
 }
-
-
-
-
-
-
-
-
-
-
-
-
-
 

--- a/src/components/search/search-page-client.test.tsx
+++ b/src/components/search/search-page-client.test.tsx
@@ -32,6 +32,7 @@ function mockSearchEndpoints({
     const url = typeof input === 'string' ? input : (input as Request).url;
     if (url.startsWith('/api/essays')) return Promise.resolve(jsonResponse({ data: essays }));
     if (url.startsWith('/api/books/search')) return Promise.resolve(jsonResponse({ data: books }));
+    if (url.startsWith('/api/books?')) return Promise.resolve(jsonResponse({ data: books }));
     if (url.startsWith('/api/content-sources')) return Promise.resolve(jsonResponse({ data: sources }));
     throw new Error(`unexpected fetch: ${url}`);
   });
@@ -91,5 +92,59 @@ describe('SearchPageClient — search results', () => {
 
     expect(await screen.findByText('Atomic Habits')).toBeInTheDocument();
     expect(screen.queryByText(/Ostatní zdroje/)).not.toBeInTheDocument();
+  });
+});
+
+describe('SearchPageClient — category subpages', () => {
+  it('renders category subpage with themed banner, description, and switcher', async () => {
+    mockSearchEndpoints({
+      books: [{
+        id: 'b1', title_cs: 'Radikální otevřenost', author: 'Kim Scott', google_books_cover_url: null,
+        in_library: false, list_status: 'shortlist', is_rocket_model: false, highlight_category: null, tags: ['Leadership'],
+      }],
+    });
+    const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime });
+
+    render(<SearchPageClient {...requiredProps} />);
+
+    // Click on Leadership category card in the overview grid
+    const leadershipCard = screen.getByRole('button', { name: /Leadership/i });
+    await user.click(leadershipCard);
+
+    // Verify category header with title and Czech description
+    expect(await screen.findByRole('heading', { level: 2, name: 'Leadership' })).toBeInTheDocument();
+    expect(screen.getByText('Vedení lidí, budování týmů a inspirativní vůdcovství')).toBeInTheDocument();
+
+    // Verify category switcher pills are present
+    expect(screen.getByRole('button', { name: /Finance & ekonomika/i })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /Marketing/i })).toBeInTheDocument();
+
+    // Verify back navigation button
+    const backBtn = screen.getByRole('button', { name: /Zpět na přehled/i });
+    expect(backBtn).toBeInTheDocument();
+
+    await user.click(backBtn);
+    expect(await screen.findByText('Knihy podle kategorií')).toBeInTheDocument();
+  });
+
+  it('allows switching categories directly from the subpage horizontal switcher', async () => {
+    mockSearchEndpoints({
+      books: [],
+    });
+    const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime });
+
+    render(<SearchPageClient {...requiredProps} />);
+
+    // Click on Marketing category
+    await user.click(screen.getByRole('button', { name: /Marketing/i }));
+    expect(await screen.findByRole('heading', { level: 2, name: 'Marketing' })).toBeInTheDocument();
+    expect(screen.getByText('Budování značky, porozumění trhu a zákaznická zkušenost')).toBeInTheDocument();
+
+    // Switch to Osobní rozvoj using horizontal switcher
+    const personalDevBtn = screen.getByRole('button', { name: /Osobní rozvoj/i });
+    await user.click(personalDevBtn);
+
+    expect(await screen.findByRole('heading', { level: 2, name: 'Osobní rozvoj' })).toBeInTheDocument();
+    expect(screen.getByText('Návyky, mentální odolnost, sebereflexe a osobní růst')).toBeInTheDocument();
   });
 });

--- a/src/components/search/search-page-client.tsx
+++ b/src/components/search/search-page-client.tsx
@@ -19,8 +19,17 @@ import {
   Briefcase,
   Megaphone,
   Boxes,
+  Library,
 } from 'lucide-react';
 import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
+import {
+  Empty,
+  EmptyDescription,
+  EmptyHeader,
+  EmptyMedia,
+  EmptyTitle,
+} from '@/components/ui/empty';
 import { Input } from '@/components/ui/input';
 import { PageShell } from '@/components/ui/page-shell';
 import { StorageImage } from '@/components/storage/storage-image';
@@ -34,6 +43,7 @@ import { DiscoveryMixedFeed } from './discovery-mixed-feed';
 import type { AuthorGamificationStats } from '@/components/essays/social-essay-feed-card';
 import { BOOK_CATEGORY_LABELS } from '@/lib/books/types';
 import { cn } from '@/lib/utils';
+import { pluralizeCz } from '@/lib/utils/pluralize-cz';
 import { usePersistedState } from '@/lib/hooks/use-persisted-state';
 import { getEssaySourceDisplay } from '@/lib/essays/source-display';
 import type { EssayWithDetails } from '@/lib/essays/types';
@@ -74,15 +84,80 @@ interface SearchPageClientProps {
 const CATEGORIES = Object.entries(BOOK_CATEGORY_LABELS);
 const FINE_POINTER_QUERY = '(pointer: fine)';
 
-const CATEGORY_META: Record<string, { icon: React.ElementType; color: string }> = {
-  'Finance & ekonomika': { icon: TrendingUp, color: 'text-emerald-600 dark:text-emerald-400 bg-emerald-500/10' },
-  'Inovace & kreativita': { icon: Lightbulb, color: 'text-amber-600 dark:text-amber-400 bg-amber-500/10' },
-  'Komunikace & prodej': { icon: MessageSquare, color: 'text-blue-600 dark:text-blue-400 bg-blue-500/10' },
-  Leadership: { icon: Crown, color: 'text-purple-600 dark:text-purple-400 bg-purple-500/10' },
-  Management: { icon: Briefcase, color: 'text-indigo-600 dark:text-indigo-400 bg-indigo-500/10' },
-  Marketing: { icon: Megaphone, color: 'text-rose-600 dark:text-rose-400 bg-rose-500/10' },
-  Multidisciplinární: { icon: Boxes, color: 'text-cyan-600 dark:text-cyan-400 bg-cyan-500/10' },
-  'Osobní rozvoj': { icon: Sparkles, color: 'text-orange-600 dark:text-orange-400 bg-orange-500/10' },
+interface CategoryMeta {
+  icon: React.ElementType;
+  color: string;
+  bannerBg: string;
+  borderColor: string;
+  badgeColor: string;
+  description: string;
+}
+
+const CATEGORY_META: Record<string, CategoryMeta> = {
+  'Finance & ekonomika': {
+    icon: TrendingUp,
+    color: 'text-emerald-600 dark:text-emerald-400 bg-emerald-500/10 dark:bg-emerald-500/15',
+    bannerBg: 'bg-gradient-to-br from-emerald-500/10 via-card to-card',
+    borderColor: 'border-emerald-500/20 dark:border-emerald-500/30',
+    badgeColor: 'bg-emerald-500/15 text-emerald-700 dark:text-emerald-300',
+    description: 'Investice, finanční řízení, trhy a ekonomické souvislosti',
+  },
+  'Inovace & kreativita': {
+    icon: Lightbulb,
+    color: 'text-amber-600 dark:text-amber-400 bg-amber-500/10 dark:bg-amber-500/15',
+    bannerBg: 'bg-gradient-to-br from-amber-500/10 via-card to-card',
+    borderColor: 'border-amber-500/20 dark:border-amber-500/30',
+    badgeColor: 'bg-amber-500/15 text-amber-700 dark:text-amber-300',
+    description: 'Kreativní myšlení, inovativní přístupy a hledání nových cest',
+  },
+  'Komunikace & prodej': {
+    icon: MessageSquare,
+    color: 'text-blue-600 dark:text-blue-400 bg-blue-500/10 dark:bg-blue-500/15',
+    bannerBg: 'bg-gradient-to-br from-blue-500/10 via-card to-card',
+    borderColor: 'border-blue-500/20 dark:border-blue-500/30',
+    badgeColor: 'bg-blue-500/15 text-blue-700 dark:text-blue-300',
+    description: 'Vyjednávání, přesvědčivá komunikace a prodejní dovednosti',
+  },
+  Leadership: {
+    icon: Crown,
+    color: 'text-purple-600 dark:text-purple-400 bg-purple-500/10 dark:bg-purple-500/15',
+    bannerBg: 'bg-gradient-to-br from-purple-500/10 via-card to-card',
+    borderColor: 'border-purple-500/20 dark:border-purple-500/30',
+    badgeColor: 'bg-purple-500/15 text-purple-700 dark:text-purple-300',
+    description: 'Vedení lidí, budování týmů a inspirativní vůdcovství',
+  },
+  Management: {
+    icon: Briefcase,
+    color: 'text-indigo-600 dark:text-indigo-400 bg-indigo-500/10 dark:bg-indigo-500/15',
+    bannerBg: 'bg-gradient-to-br from-indigo-500/10 via-card to-card',
+    borderColor: 'border-indigo-500/20 dark:border-indigo-500/30',
+    badgeColor: 'bg-indigo-500/15 text-indigo-700 dark:text-indigo-300',
+    description: 'Organizace, procesy, strategické řízení a efektivita práce',
+  },
+  Marketing: {
+    icon: Megaphone,
+    color: 'text-rose-600 dark:text-rose-400 bg-rose-500/10 dark:bg-rose-500/15',
+    bannerBg: 'bg-gradient-to-br from-rose-500/10 via-card to-card',
+    borderColor: 'border-rose-500/20 dark:border-rose-500/30',
+    badgeColor: 'bg-rose-500/15 text-rose-700 dark:text-rose-300',
+    description: 'Budování značky, porozumění trhu a zákaznická zkušenost',
+  },
+  Multidisciplinární: {
+    icon: Boxes,
+    color: 'text-cyan-600 dark:text-cyan-400 bg-cyan-500/10 dark:bg-cyan-500/15',
+    bannerBg: 'bg-gradient-to-br from-cyan-500/10 via-card to-card',
+    borderColor: 'border-cyan-500/20 dark:border-cyan-500/30',
+    badgeColor: 'bg-cyan-500/15 text-cyan-700 dark:text-cyan-300',
+    description: 'Široký rozhled, propojování oborů a systémové myšlení',
+  },
+  'Osobní rozvoj': {
+    icon: Sparkles,
+    color: 'text-orange-600 dark:text-orange-400 bg-orange-500/10 dark:bg-orange-500/15',
+    bannerBg: 'bg-gradient-to-br from-orange-500/10 via-card to-card',
+    borderColor: 'border-orange-500/20 dark:border-orange-500/30',
+    badgeColor: 'bg-orange-500/15 text-orange-700 dark:text-orange-300',
+    description: 'Návyky, mentální odolnost, sebereflexe a osobní růst',
+  },
 };
 
 export function SearchPageClient({
@@ -195,11 +270,13 @@ export function SearchPageClient({
           )
         ) : selectedCategory ? (
           <CategoryBooksView
+            categoryKey={selectedCategory}
             label={BOOK_CATEGORY_LABELS[selectedCategory] ?? selectedCategory}
             books={categoryBooks}
             loading={categoryLoading}
             libraryFilterEnabled={libraryFilterEnabled}
             onToggleLibraryFilter={setLibraryFilterEnabled}
+            onSelectCategory={setSelectedCategory}
             onBack={() => setSelectedCategory(null)}
           />
         ) : (
@@ -407,55 +484,152 @@ function CategoryGridSection({
 // ─── Category view ─────────────────────────────────────────────────────────────
 
 function CategoryBooksView({
+  categoryKey,
   label,
   books,
   loading,
   libraryFilterEnabled,
   onToggleLibraryFilter,
+  onSelectCategory,
   onBack,
 }: {
+  categoryKey: string;
   label: string;
   books: (BookWithProfiles & { essay_count?: number })[];
   loading: boolean;
   libraryFilterEnabled: boolean;
   onToggleLibraryFilter: (enabled: boolean) => void;
+  onSelectCategory: (key: string) => void;
   onBack: () => void;
 }) {
+  const meta = CATEGORY_META[categoryKey];
+  const Icon = meta?.icon ?? BookOpen;
+
   return (
     <div className="space-y-6">
-      <div className="flex flex-wrap items-center justify-between gap-3 border-b pb-4">
-        <div>
-          <button
-            type="button"
-            onClick={onBack}
-            className="mb-1.5 inline-flex items-center gap-1 text-xs font-medium text-muted-foreground hover:text-foreground transition-colors cursor-pointer"
-          >
-            <ArrowLeft className="size-3.5" />
-            Zpět na přehled
-          </button>
-          <h2 className="text-xl font-bold text-foreground">{label}</h2>
-        </div>
+      {/* Top navigation: Back button & Horizontal Category Switcher */}
+      <div className="space-y-2.5">
+        <button
+          type="button"
+          onClick={onBack}
+          className="inline-flex min-h-[44px] items-center gap-1.5 text-xs font-medium text-muted-foreground hover:text-foreground transition-colors cursor-pointer px-1 -ml-1 focus-ring rounded-md"
+        >
+          <ArrowLeft className="size-3.5" />
+          Zpět na přehled
+        </button>
 
-        <label className="flex items-center gap-2 text-xs text-muted-foreground cursor-pointer">
-          <input
-            type="checkbox"
-            checked={libraryFilterEnabled}
-            onChange={(e) => onToggleLibraryFilter(e.target.checked)}
-            className="rounded border-border accent-primary"
-          />
-          Pouze knihy v TAP Knihovně
-        </label>
+        {/* Quick horizontal category switcher */}
+        <div className="flex items-center gap-1.5 overflow-x-auto no-scrollbar -mx-1 px-1 pb-1">
+          {CATEGORIES.map(([catKey, catLabel]) => {
+            const catMeta = CATEGORY_META[catKey];
+            const CatIcon = catMeta?.icon ?? BookOpen;
+            const isCurrent = catKey === categoryKey;
+            return (
+              <button
+                key={catKey}
+                type="button"
+                onClick={() => onSelectCategory(catKey)}
+                className={cn(
+                  'shrink-0 inline-flex items-center gap-1.5 px-3 py-1.5 rounded-lg text-xs font-medium transition-all cursor-pointer border',
+                  isCurrent
+                    ? cn(catMeta?.badgeColor ?? 'bg-primary/10 text-primary', 'font-semibold border-current/25 shadow-2xs')
+                    : 'bg-card text-muted-foreground hover:text-foreground hover:bg-muted/60 border-border/70'
+                )}
+              >
+                <CatIcon className="size-3.5" />
+                <span>{catLabel}</span>
+              </button>
+            );
+          })}
+        </div>
       </div>
 
+      {/* Visual Category Hero Banner */}
+      <div
+        className={cn(
+          'relative overflow-hidden rounded-2xl border p-4 sm:p-5 transition-colors',
+          meta?.bannerBg ?? 'bg-card',
+          meta?.borderColor ?? 'border-border'
+        )}
+      >
+        {/* Subtle decorative watermark icon */}
+        <Icon
+          className="absolute -right-3 -bottom-3 size-28 sm:size-36 text-foreground opacity-[0.03] dark:opacity-[0.05] pointer-events-none -rotate-12 select-none"
+          aria-hidden="true"
+        />
+
+        <div className="relative flex flex-col sm:flex-row sm:items-center justify-between gap-4">
+          <div className="flex items-start sm:items-center gap-3.5 sm:gap-4 min-w-0">
+            <span className={cn('flex size-11 sm:size-13 shrink-0 items-center justify-center rounded-xl shadow-2xs', meta?.color)}>
+              <Icon className="size-5 sm:size-6.5" />
+            </span>
+            <div className="min-w-0 space-y-0.5">
+              <div className="flex items-center gap-2 flex-wrap">
+                <h2 className="font-heading text-lg sm:text-xl font-bold tracking-tight text-foreground">
+                  {label}
+                </h2>
+                {!loading && (
+                  <span className={cn('inline-flex items-center px-2 py-0.5 rounded-full text-[11px] font-medium', meta?.badgeColor)}>
+                    {books.length} {pluralizeCz(books.length, ['kniha', 'knihy', 'knih'])}
+                  </span>
+                )}
+              </div>
+              {meta?.description && (
+                <p className="text-xs sm:text-sm text-muted-foreground leading-relaxed">
+                  {meta.description}
+                </p>
+              )}
+            </div>
+          </div>
+
+          {/* TAP Knihovna filter toggle */}
+          <button
+            type="button"
+            role="switch"
+            aria-checked={libraryFilterEnabled}
+            onClick={() => onToggleLibraryFilter(!libraryFilterEnabled)}
+            className={cn(
+              'shrink-0 self-start sm:self-auto inline-flex items-center gap-2 px-3 py-2 rounded-xl border text-xs font-medium transition-all cursor-pointer select-none',
+              libraryFilterEnabled
+                ? 'bg-primary/10 border-primary/30 text-primary font-semibold shadow-2xs'
+                : 'bg-card/90 hover:bg-card border-border text-muted-foreground hover:text-foreground'
+            )}
+          >
+            <Library className="size-3.5" />
+            <span>Pouze v TAP Knihovně</span>
+            {libraryFilterEnabled && <span className="size-1.5 rounded-full bg-primary" />}
+          </button>
+        </div>
+      </div>
+
+      {/* Book list / loading / empty states */}
       {loading ? (
         <div className="flex justify-center py-16">
           <div className="size-6 animate-spin rounded-full border-2 border-primary border-t-transparent" />
         </div>
       ) : books.length === 0 ? (
-        <div className="text-center py-16 space-y-2">
-          <BookOpen className="size-10 mx-auto text-muted-foreground/40" />
-          <p className="text-muted-foreground text-sm">Žádné knihy v kategorii {label}</p>
-        </div>
+        <Empty>
+          <EmptyMedia variant="icon" className={meta?.color}>
+            <Icon className="size-5" />
+          </EmptyMedia>
+          <EmptyHeader>
+            <EmptyTitle>Žádné knihy v kategorii {label}</EmptyTitle>
+            <EmptyDescription>
+              {libraryFilterEnabled
+                ? 'V TAP Knihovně zatím nemáme žádné knihy s tímto štítkem. Zkus vypnout filtr.'
+                : `V kategorii ${label} zatím nejsou žádné knihy.`}
+            </EmptyDescription>
+          </EmptyHeader>
+          {libraryFilterEnabled && (
+            <Button
+              variant="outline"
+              size="sm"
+              onClick={() => onToggleLibraryFilter(false)}
+            >
+              Zobrazit všechny knihy v kategorii
+            </Button>
+          )}
+        </Empty>
       ) : (
         <div className="space-y-2">
           {books.map((book) => (

--- a/src/components/search/search-page-client.tsx
+++ b/src/components/search/search-page-client.tsx
@@ -317,7 +317,7 @@ function TopPicksCard({ groups }: { groups: HighlightedGroup[] }) {
   return (
     <Link
       href="/cteni/knihy/top-bob"
-      className="group flex items-center gap-2 sm:gap-3 rounded-xl border border-amber-200/70 bg-gradient-to-r from-amber-500/10 via-card to-card p-2.5 sm:p-3 transition-all hover:border-amber-400 hover:shadow-sm dark:border-amber-900/50 dark:from-amber-950/30"
+      className="group flex items-center gap-2 sm:gap-3 rounded-xl border border-amber-200/70 bg-gradient-to-r from-amber-500/10 via-card to-card p-2.5 sm:p-3 transition-all hover:border-amber-400 hover:shadow-sm dark:border-amber-900/50 dark:from-amber-950/30 cursor-pointer"
     >
       <span className="flex size-7 sm:size-8 shrink-0 items-center justify-center rounded-lg bg-amber-500/15 text-amber-700 dark:text-amber-400">
         <Medal className="size-3.5 sm:size-4" />
@@ -340,7 +340,7 @@ function RocketModelCard({ books }: { books: BookWithProfiles[] }) {
   return (
     <Link
       href="/cteni/knihy/rocket-model"
-      className="group flex items-center gap-2 sm:gap-3 rounded-xl border border-primary/20 bg-gradient-to-r from-primary/10 via-card to-card p-2.5 sm:p-3 transition-all hover:border-primary/50 hover:shadow-sm dark:border-primary/30 dark:from-primary/15"
+      className="group flex items-center gap-2 sm:gap-3 rounded-xl border border-primary/20 bg-gradient-to-r from-primary/10 via-card to-card p-2.5 sm:p-3 transition-all hover:border-primary/50 hover:shadow-sm dark:border-primary/30 dark:from-primary/15 cursor-pointer"
     >
       <span className="flex size-7 sm:size-8 shrink-0 items-center justify-center rounded-lg bg-primary/15 text-primary">
         <Rocket className="size-3.5 sm:size-4" />
@@ -382,7 +382,7 @@ function CategoryGridSection({
               key={key}
               type="button"
               onClick={() => onSelectCategory(key)}
-              className="group flex items-center gap-2.5 sm:gap-3 rounded-xl border bg-card p-2.5 sm:p-3 text-left transition-all hover:border-primary/40 hover:shadow-xs focus-ring"
+              className="group flex items-center gap-2.5 sm:gap-3 rounded-xl border bg-card p-2.5 sm:p-3 text-left transition-all hover:border-primary/40 hover:shadow-xs focus-ring cursor-pointer"
             >
               <span className={cn('flex size-8 sm:size-9 shrink-0 items-center justify-center rounded-lg', meta.color)}>
                 <Icon className="size-4 sm:size-4.5" />
@@ -428,7 +428,7 @@ function CategoryBooksView({
           <button
             type="button"
             onClick={onBack}
-            className="mb-1.5 inline-flex items-center gap-1 text-xs font-medium text-muted-foreground hover:text-foreground transition-colors"
+            className="mb-1.5 inline-flex items-center gap-1 text-xs font-medium text-muted-foreground hover:text-foreground transition-colors cursor-pointer"
           >
             <ArrowLeft className="size-3.5" />
             Zpět na přehled

--- a/src/components/search/search-page-client.tsx
+++ b/src/components/search/search-page-client.tsx
@@ -44,6 +44,7 @@ import type { AuthorGamificationStats } from '@/components/essays/social-essay-f
 import { BOOK_CATEGORY_LABELS } from '@/lib/books/types';
 import { cn } from '@/lib/utils';
 import { pluralizeCz } from '@/lib/utils/pluralize-cz';
+import { structureBookTitle } from '@/lib/books/format-title';
 import { usePersistedState } from '@/lib/hooks/use-persisted-state';
 import { getEssaySourceDisplay } from '@/lib/essays/source-display';
 import type { EssayWithDetails } from '@/lib/essays/types';
@@ -674,33 +675,36 @@ function SearchResultsView({
             Knihy ({books.length})
           </h2>
           <div className="divide-y rounded-xl border overflow-hidden bg-card">
-            {books.map((book) => (
-              <Link
-                key={book.id}
-                href={`/cteni/knihy/${book.id}`}
-                className="flex items-center gap-3 px-4 py-3 hover:bg-muted/50 transition-colors"
-              >
-                <div className="shrink-0 w-8 h-11 rounded overflow-hidden bg-muted flex items-center justify-center">
-                  {book.google_books_cover_url ? (
-                    <StorageImage storageKey={book.google_books_cover_url} alt={book.title_cs} width={32} height={44} className="w-full h-full object-cover" />
-                  ) : (
-                    <BookOpen className="size-3.5 text-muted-foreground/40" />
-                  )}
-                </div>
-                <div className="flex-1 min-w-0">
-                  <div className="flex items-center gap-1.5">
-                    <p className="text-sm font-medium truncate">{book.title_cs}</p>
-                    <BookStatusBadges book={book} />
+            {books.map((book) => {
+              const { title: bookTitle, fullTitle } = structureBookTitle(book.title_cs);
+              return (
+                <Link
+                  key={book.id}
+                  href={`/cteni/knihy/${book.id}`}
+                  className="flex items-center gap-3 px-4 py-3 hover:bg-muted/50 transition-colors"
+                >
+                  <div className="shrink-0 w-8 h-11 rounded overflow-hidden bg-muted flex items-center justify-center">
+                    {book.google_books_cover_url ? (
+                      <StorageImage storageKey={book.google_books_cover_url} alt={bookTitle} width={32} height={44} className="w-full h-full object-cover" />
+                    ) : (
+                      <BookOpen className="size-3.5 text-muted-foreground/40" />
+                    )}
                   </div>
-                  <p className="text-xs text-muted-foreground truncate">{book.author}</p>
-                </div>
-                {book.in_library && (
-                  <Badge variant="default" className="text-[11px] px-2.5 py-1">
-                    V TAPu
-                  </Badge>
-                )}
-              </Link>
-            ))}
+                  <div className="flex-1 min-w-0">
+                    <div className="flex items-center gap-1.5 min-w-0">
+                      <p className="text-sm font-medium truncate min-w-0" title={fullTitle}>{bookTitle}</p>
+                      <BookStatusBadges book={book} />
+                    </div>
+                    <p className="text-xs text-muted-foreground truncate">{book.author}</p>
+                  </div>
+                  {book.in_library && (
+                    <Badge variant="default" className="text-[11px] px-2.5 py-1 shrink-0">
+                      V TAPu
+                    </Badge>
+                  )}
+                </Link>
+              );
+            })}
           </div>
         </section>
       )}

--- a/src/components/ui/page-header.test.tsx
+++ b/src/components/ui/page-header.test.tsx
@@ -32,4 +32,10 @@ describe("PageHeader", () => {
       expect(screen.queryByRole("link")).not.toBeInTheDocument()
     })
   })
+
+  it("renders an optional icon alongside the title", () => {
+    render(<PageHeader title="TOP BOB" icon={<span data-testid="header-icon">icon</span>} />)
+    expect(screen.getByTestId("header-icon")).toBeInTheDocument()
+    expect(screen.getByRole("heading", { level: 1, name: "TOP BOB" })).toBeInTheDocument()
+  })
 })

--- a/src/components/ui/page-header.tsx
+++ b/src/components/ui/page-header.tsx
@@ -8,16 +8,20 @@ interface PageHeaderProps {
   count?: { value: number; label: string }
   action?: ReactNode
   back?: { href: string; label: string }
+  icon?: ReactNode
 }
 
-export function PageHeader({ title, description, count, action, back }: PageHeaderProps) {
+export function PageHeader({ title, description, count, action, back, icon }: PageHeaderProps) {
   return (
     <div className="space-y-1">
       {back && <PageBack href={back.href} label={back.label} />}
       <div className="flex flex-wrap items-start justify-between gap-x-4 gap-y-2">
-        <div className="space-y-1">
-          <h1 className="font-heading text-2xl font-bold tracking-tight sm:text-3xl">{title}</h1>
-          {description && <p className="text-sm leading-relaxed text-muted-foreground">{description}</p>}
+        <div className="flex items-start gap-3 sm:gap-4">
+          {icon && <div className="shrink-0 pt-0.5">{icon}</div>}
+          <div className="space-y-1">
+            <h1 className="font-heading text-2xl font-bold tracking-tight sm:text-3xl">{title}</h1>
+            {description && <p className="text-sm leading-relaxed text-muted-foreground">{description}</p>}
+          </div>
         </div>
         {(count || action) && (
           <div className="flex min-h-9 items-center gap-3 pt-0.5">

--- a/src/lib/books/catalog-search.test.ts
+++ b/src/lib/books/catalog-search.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from 'vitest';
+
+import { searchCatalogBooks, type CatalogSearchBook } from './catalog-search';
+
+const BOOKS: CatalogSearchBook[] = [
+  {
+    id: 'profit-first',
+    title_cs: 'Nejdřív zisk',
+    title_en: 'Profit First',
+    author: 'Mike Michalowicz',
+    isbn_13: '9780241341032',
+    google_books_cover_url: null,
+  },
+  {
+    id: 'business-school',
+    title_cs: 'Škola businessu',
+    title_en: 'The Business School',
+    author: 'Robert T. Kiyosaki, Sharon L. Lechter',
+    isbn_13: '9788073491000',
+    google_books_cover_url: null,
+  },
+];
+
+describe('searchCatalogBooks', () => {
+  it('matches Czech titles without requiring diacritics', () => {
+    expect(searchCatalogBooks(BOOKS, 'nejdriv zisk', 10).map((book) => book.id))
+      .toEqual(['profit-first']);
+  });
+
+  it('matches authors, including names stored with comma-separated co-authors', () => {
+    expect(searchCatalogBooks(BOOKS, 'Sharon Lechter', 10).map((book) => book.id))
+      .toEqual(['business-school']);
+    expect(searchCatalogBooks(BOOKS, 'Michalowicz', 10).map((book) => book.id))
+      .toEqual(['profit-first']);
+  });
+
+  it('matches English titles and ISBN', () => {
+    expect(searchCatalogBooks(BOOKS, 'Profit First', 10).map((book) => book.id))
+      .toEqual(['profit-first']);
+    expect(searchCatalogBooks(BOOKS, '9788073491000', 10).map((book) => book.id))
+      .toEqual(['business-school']);
+  });
+
+  it('ranks a title match ahead of an author match', () => {
+    const titleMatch = { ...BOOKS[0], id: 'title-match', title_cs: 'Mike' };
+    expect(searchCatalogBooks([BOOKS[0], titleMatch], 'Mike', 10).map((book) => book.id))
+      .toEqual(['title-match', 'profit-first']);
+  });
+});

--- a/src/lib/books/catalog-search.ts
+++ b/src/lib/books/catalog-search.ts
@@ -1,0 +1,70 @@
+import type { Tables } from '@/lib/supabase/tables';
+
+const NON_ALPHANUMERIC_PATTERN = /[^a-z0-9\s]/g;
+const COMBINING_MARK_PATTERN = /[\u0300-\u036f]/g;
+const WHITESPACE_PATTERN = /\s+/g;
+
+const SEARCH_SCORE = {
+  exactIsbn: 1_000,
+  exactTitle: 900,
+  titlePrefix: 800,
+  titleContains: 700,
+  exactAuthor: 600,
+  authorPrefix: 500,
+  authorContains: 400,
+  allTokens: 300,
+} as const;
+
+export type CatalogSearchBook = Pick<
+  Tables<'books'>,
+  'id' | 'title_cs' | 'title_en' | 'author' | 'isbn_13' | 'google_books_cover_url'
+>;
+
+function normalizeSearchText(value: string): string {
+  return value
+    .normalize('NFD')
+    .replace(COMBINING_MARK_PATTERN, '')
+    .toLowerCase()
+    .replace(NON_ALPHANUMERIC_PATTERN, ' ')
+    .replace(WHITESPACE_PATTERN, ' ')
+    .trim();
+}
+
+function scoreBook(book: CatalogSearchBook, normalizedQuery: string): number {
+  const titleCs = normalizeSearchText(book.title_cs);
+  const titleEn = normalizeSearchText(book.title_en ?? '');
+  const author = normalizeSearchText(book.author);
+  const isbn = normalizeSearchText(book.isbn_13 ?? '');
+  const titles = [titleCs, titleEn];
+
+  if (isbn === normalizedQuery) return SEARCH_SCORE.exactIsbn;
+  if (titles.some((title) => title === normalizedQuery)) return SEARCH_SCORE.exactTitle;
+  if (titles.some((title) => title.startsWith(normalizedQuery))) return SEARCH_SCORE.titlePrefix;
+  if (titles.some((title) => title.includes(normalizedQuery))) return SEARCH_SCORE.titleContains;
+  if (author === normalizedQuery) return SEARCH_SCORE.exactAuthor;
+  if (author.startsWith(normalizedQuery)) return SEARCH_SCORE.authorPrefix;
+  if (author.includes(normalizedQuery)) return SEARCH_SCORE.authorContains;
+
+  const searchableText = `${titleCs} ${titleEn} ${author} ${isbn}`;
+  const tokens = normalizedQuery.split(' ').filter(Boolean);
+  return tokens.every((token) => searchableText.includes(token)) ? SEARCH_SCORE.allTokens : 0;
+}
+
+export function searchCatalogBooks(
+  books: CatalogSearchBook[],
+  query: string,
+  limit: number,
+): CatalogSearchBook[] {
+  const normalizedQuery = normalizeSearchText(query);
+  if (!normalizedQuery || limit <= 0) return [];
+
+  return books
+    .map((book) => ({ book, score: scoreBook(book, normalizedQuery) }))
+    .filter(({ score }) => score > 0)
+    .sort((left, right) => (
+      right.score - left.score
+      || left.book.title_cs.localeCompare(right.book.title_cs, 'cs')
+    ))
+    .slice(0, limit)
+    .map(({ book }) => book);
+}

--- a/src/lib/books/format-title.test.ts
+++ b/src/lib/books/format-title.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from 'vitest';
+import { cleanBookTitle, structureBookTitle } from './format-title';
+
+describe('cleanBookTitle', () => {
+  it('strips leading and trailing quotes', () => {
+    expect(cleanBookTitle('"Velká kniha"')).toBe('Velká kniha');
+    expect(cleanBookTitle('„Restart“')).toBe('Restart');
+    expect(cleanBookTitle('“Thinking, Fast and Slow”')).toBe('Thinking, Fast and Slow');
+    expect(cleanBookTitle("'Deep Work'")).toBe('Deep Work');
+  });
+
+  it('handles empty or whitespace strings', () => {
+    expect(cleanBookTitle('')).toBe('');
+    expect(cleanBookTitle('   ')).toBe('');
+  });
+
+  it('preserves inner punctuation', () => {
+    expect(cleanBookTitle('Thinking, Fast and Slow')).toBe('Thinking, Fast and Slow');
+  });
+});
+
+describe('structureBookTitle', () => {
+  it('splits main title and subtitle separated by colon', () => {
+    const result = structureBookTitle(
+      '"Velká kniha týmových koučovacích her: Rychlé a efektivní aktivity pro nabuzení, motivaci a týmovou spolupráci"',
+    );
+    expect(result.title).toBe('Velká kniha týmových koučovacích her');
+    expect(result.subtitle).toBe('Rychlé a efektivní aktivity pro nabuzení, motivaci a týmovou spolupráci');
+    expect(result.fullTitle).toBe(
+      'Velká kniha týmových koučovacích her: Rychlé a efektivní aktivity pro nabuzení, motivaci a týmovou spolupráci',
+    );
+  });
+
+  it('splits main title and subtitle separated by dash', () => {
+    const result = structureBookTitle('Start with Why - How Great Leaders Inspire Everyone to Take Action');
+    expect(result.title).toBe('Start with Why');
+    expect(result.subtitle).toBe('How Great Leaders Inspire Everyone to Take Action');
+  });
+
+  it('returns clean title when no subtitle is present', () => {
+    const result = structureBookTitle('"Restart"');
+    expect(result.title).toBe('Restart');
+    expect(result.subtitle).toBeUndefined();
+    expect(result.fullTitle).toBe('Restart');
+  });
+
+  it('handles empty string', () => {
+    const result = structureBookTitle('');
+    expect(result.title).toBe('');
+    expect(result.subtitle).toBeUndefined();
+  });
+});

--- a/src/lib/books/format-title.ts
+++ b/src/lib/books/format-title.ts
@@ -1,0 +1,60 @@
+/**
+ * Strips surrounding quotation marks (standard and typographical quotes) and trims whitespace.
+ * e.g. '"Velká kniha"' -> 'Velká kniha', '„Restart“' -> 'Restart'
+ */
+export function cleanBookTitle(raw: string): string {
+  if (!raw) return '';
+  return raw
+    .trim()
+    .replace(/^["'„“”»«`]+/, '')
+    .replace(/["'„“”»«`]+$/, '')
+    .trim();
+}
+
+export interface StructuredBookTitle {
+  /** The clean main title of the book. */
+  title: string;
+  /** The subtitle if present (separated by colon or dash). */
+  subtitle?: string;
+  /** The full cleaned title (main + subtitle). */
+  fullTitle: string;
+}
+
+/**
+ * Structures a book title by cleaning stray quotes and splitting main title from subtitle.
+ * Handles separators like ': ', ' - ', ' – ', ' — '.
+ */
+export function structureBookTitle(raw: string): StructuredBookTitle {
+  const cleaned = cleanBookTitle(raw);
+  if (!cleaned) return { title: '', fullTitle: '' };
+
+  // 1. Colon separator: "Velká kniha: Rychlé a efektivní..."
+  const colonIndex = cleaned.indexOf(': ');
+  if (colonIndex > 0) {
+    const main = cleanBookTitle(cleaned.slice(0, colonIndex));
+    const sub = cleanBookTitle(cleaned.slice(colonIndex + 2));
+    if (main && sub) {
+      return {
+        title: main,
+        subtitle: sub,
+        fullTitle: `${main}: ${sub}`,
+      };
+    }
+  }
+
+  // 2. Dash separator: "Title - Subtitle"
+  const dashMatch = cleaned.match(/^(.*?)\s+[-–—]\s+(.*)$/);
+  if (dashMatch && dashMatch[1] && dashMatch[2]) {
+    const main = cleanBookTitle(dashMatch[1]);
+    const sub = cleanBookTitle(dashMatch[2]);
+    if (main.length >= 3 && sub.length >= 3) {
+      return {
+        title: main,
+        subtitle: sub,
+        fullTitle: `${main} – ${sub}`,
+      };
+    }
+  }
+
+  return { title: cleaned, fullTitle: cleaned };
+}

--- a/src/lib/library/label-code.test.ts
+++ b/src/lib/library/label-code.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from 'vitest';
+
+import { formatLibraryLabelCode, parseLibraryLabelCode } from './label-code';
+
+describe('parseLibraryLabelCode', () => {
+  it.each([
+    ['1', 1],
+    ['001', 1],
+    ['https://tiimi.cz/l/42', 42],
+    ['https://tiimi.cz/l/350/', 350],
+  ])('reads %s as label %i', (value, expected) => {
+    expect(parseLibraryLabelCode(value)).toBe(expected);
+  });
+
+  it.each([
+    '',
+    '0',
+    '-1',
+    '1.5',
+    'https://tiimi.cz/?l=1',
+    'https://tiimi.cz/books/1',
+    'https://example.com/l/1',
+  ])(
+    'rejects %s',
+    (value) => {
+      expect(parseLibraryLabelCode(value)).toBeNull();
+    },
+  );
+});
+
+describe('formatLibraryLabelCode', () => {
+  it('pads short codes for the printed label format', () => {
+    expect(formatLibraryLabelCode(7)).toBe('#007');
+    expect(formatLibraryLabelCode(350)).toBe('#350');
+  });
+});

--- a/src/lib/library/label-code.ts
+++ b/src/lib/library/label-code.ts
@@ -1,0 +1,36 @@
+const POSITIVE_INTEGER_PATTERN = /^\d+$/;
+const LIBRARY_LABEL_PATH_PATTERN = /^\/l\/(\d+)\/?$/;
+const DISPLAY_CODE_LENGTH = 3;
+const PRODUCTION_HOST = 'tiimi.cz';
+const LOCAL_HOSTS = ['localhost', '127.0.0.1'] as const;
+
+function parsePositiveInteger(value: string): number | null {
+  if (!POSITIVE_INTEGER_PATTERN.test(value)) return null;
+
+  const parsed = Number(value);
+  return Number.isSafeInteger(parsed) && parsed > 0 ? parsed : null;
+}
+
+export function parseLibraryLabelCode(value: string): number | null {
+  const trimmed = value.trim();
+  const directCode = parsePositiveInteger(trimmed);
+  if (directCode != null) return directCode;
+
+  try {
+    const url = new URL(trimmed);
+    const isTappkaHost = url.hostname === PRODUCTION_HOST || url.hostname.endsWith(`.${PRODUCTION_HOST}`);
+    const isLocalHost = LOCAL_HOSTS.some((hostname) => hostname === url.hostname);
+    if (!isTappkaHost && !isLocalHost) {
+      return null;
+    }
+
+    const match = url.pathname.match(LIBRARY_LABEL_PATH_PATTERN);
+    return match?.[1] ? parsePositiveInteger(match[1]) : null;
+  } catch {
+    return null;
+  }
+}
+
+export function formatLibraryLabelCode(code: number): string {
+  return `#${String(code).padStart(DISPLAY_CODE_LENGTH, '0')}`;
+}

--- a/src/lib/library/queries.ts
+++ b/src/lib/library/queries.ts
@@ -263,10 +263,45 @@ export async function getAvailableCopyForBook(
   return available ?? null;
 }
 
+export async function getLibraryCopyByLabelCode(
+  supabase: SupabaseClient<Database>,
+  labelCode: number,
+): Promise<{ id: string; bookId: string } | null> {
+  const { data, error } = await supabase
+    .from('library_books')
+    .select('id, book_id')
+    .filter('label_code', 'eq', String(labelCode))
+    .maybeSingle();
+
+  if (error) throw error;
+  if (!data) return null;
+
+  return { id: data.id, bookId: data.book_id };
+}
+
+export async function getAvailableCopyByLabelCode(
+  supabase: SupabaseClient<Database>,
+  bookId: string,
+  labelCode: number,
+): Promise<string | null> {
+  const copy = await getLibraryCopyByLabelCode(supabase, labelCode);
+  if (!copy || copy.bookId !== bookId) return null;
+
+  const { data: activeLoan, error } = await supabase
+    .from('book_loans')
+    .select('id')
+    .eq('library_book_id', copy.id)
+    .is('returned_at', null)
+    .limit(1)
+    .maybeSingle();
+
+  if (error) throw error;
+  return activeLoan ? null : copy.id;
+}
+
 export async function findOrCreateLibraryCopy(
   supabase: SupabaseClient<Database>,
   bookId: string,
-  isbn13: string | null,
   profileId: string,
 ): Promise<string> {
   const { data: existing, error: searchError } = await supabase
@@ -283,7 +318,6 @@ export async function findOrCreateLibraryCopy(
     .from('library_books')
     .insert({
       book_id: bookId,
-      isbn_13: isbn13,
       created_by_profile_id: profileId,
       updated_by_profile_id: profileId,
     })

--- a/src/lib/library/types.ts
+++ b/src/lib/library/types.ts
@@ -28,7 +28,6 @@ export interface BookCopyStatus {
 export interface LibraryBookResult {
   id: string;
   book_id: string;
-  isbn_13: string | null;
   created_at: string;
   book: BookWithProfiles;
   totalCopies: number;

--- a/src/lib/supabase/database.types.ts
+++ b/src/lib/supabase/database.types.ts
@@ -1249,7 +1249,7 @@ export type Database = {
           created_at: string
           created_by_profile_id: string
           id: string
-          isbn_13: string | null
+          label_code: number | null
           updated_at: string
           updated_by_profile_id: string
         }
@@ -1258,7 +1258,7 @@ export type Database = {
           created_at?: string
           created_by_profile_id: string
           id?: string
-          isbn_13?: string | null
+          label_code?: number | null
           updated_at?: string
           updated_by_profile_id: string
         }
@@ -1267,7 +1267,7 @@ export type Database = {
           created_at?: string
           created_by_profile_id?: string
           id?: string
-          isbn_13?: string | null
+          label_code?: number | null
           updated_at?: string
           updated_by_profile_id?: string
         }

--- a/supabase/migrations/20260902232613_library_copy_label_codes.sql
+++ b/supabase/migrations/20260902232613_library_copy_label_codes.sql
@@ -1,0 +1,5 @@
+DROP INDEX "library_books_isbn_13_idx";--> statement-breakpoint
+ALTER TABLE "library_books" ADD COLUMN "label_code" integer;--> statement-breakpoint
+ALTER TABLE "library_books" DROP COLUMN "isbn_13";--> statement-breakpoint
+ALTER TABLE "library_books" ADD CONSTRAINT "library_books_label_code_key" UNIQUE("label_code");--> statement-breakpoint
+ALTER TABLE "library_books" ADD CONSTRAINT "library_books_label_code_check" CHECK ((label_code IS NULL) OR (label_code > 0));

--- a/supabase/migrations/meta/20260902232613_snapshot.json
+++ b/supabase/migrations/meta/20260902232613_snapshot.json
@@ -1,0 +1,7618 @@
+{
+  "id": "2ece0ebf-e862-40d4-a9e9-96f724c58706",
+  "prevId": "5ef433e8-889b-4ca1-9942-c6b73c58867c",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.birth_giving_events": {
+      "name": "birth_giving_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "customer": {
+          "name": "customer",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "starts_at": {
+          "name": "starts_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "duration": {
+          "name": "duration",
+          "type": "birth_giving_duration",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "birth_giving_event_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'draft'"
+        },
+        "organizer_profile_ids": {
+          "name": "organizer_profile_ids",
+          "type": "uuid[]",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "assignment_state": {
+          "name": "assignment_state",
+          "type": "birth_giving_assignment_state",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'none'"
+        },
+        "assignment_storage_path": {
+          "name": "assignment_storage_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "assignment_file_name": {
+          "name": "assignment_file_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "assignment_mime_type": {
+          "name": "assignment_mime_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "assignment_file_size": {
+          "name": "assignment_file_size",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "assignment_uploaded_at": {
+          "name": "assignment_uploaded_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "assignment_uploaded_by_profile_id": {
+          "name": "assignment_uploaded_by_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "removed_at": {
+          "name": "removed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "removed_by_profile_id": {
+          "name": "removed_by_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_by_profile_id": {
+          "name": "created_by_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_by_profile_id": {
+          "name": "updated_by_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "birth_giving_events_identity_idx": {
+          "name": "birth_giving_events_identity_idx",
+          "columns": [
+            {
+              "expression": "lower(regexp_replace(trim(normalize(\"name\", NFKC)), '[[:space:]]+', ' ', 'g'))",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "lower(regexp_replace(trim(normalize(\"customer\", NFKC)), '[[:space:]]+', ' ', 'g'))",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "starts_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "timestamptz_ops"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "birth_giving_events_status_starts_at_idx": {
+          "name": "birth_giving_events_status_starts_at_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "starts_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "birth_giving_events_removed_by_profile_id_fkey": {
+          "name": "birth_giving_events_removed_by_profile_id_fkey",
+          "tableFrom": "birth_giving_events",
+          "tableTo": "profiles",
+          "columnsFrom": [
+            "removed_by_profile_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "birth_giving_events_assignment_uploaded_by_fkey": {
+          "name": "birth_giving_events_assignment_uploaded_by_fkey",
+          "tableFrom": "birth_giving_events",
+          "tableTo": "profiles",
+          "columnsFrom": [
+            "assignment_uploaded_by_profile_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "birth_giving_events_created_by_profile_id_fkey": {
+          "name": "birth_giving_events_created_by_profile_id_fkey",
+          "tableFrom": "birth_giving_events",
+          "tableTo": "profiles",
+          "columnsFrom": [
+            "created_by_profile_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "birth_giving_events_updated_by_profile_id_fkey": {
+          "name": "birth_giving_events_updated_by_profile_id_fkey",
+          "tableFrom": "birth_giving_events",
+          "tableTo": "profiles",
+          "columnsFrom": [
+            "updated_by_profile_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {
+        "Community can view published BG events, organizers view drafts": {
+          "name": "Community can view published BG events, organizers view drafts",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": [
+            "authenticated"
+          ],
+          "using": "EXISTS (\n  SELECT 1\n  FROM profiles caller_profile\n  JOIN users caller_user ON caller_user.id = caller_profile.user_id\n  WHERE caller_profile.id = current_profile_id()\n    AND caller_profile.access_removed_at IS NULL\n    AND caller_profile.beta_access_granted_at IS NOT NULL\n    AND caller_user.verified_work_email IS NOT NULL\n) AND \"birth_giving_events\".\"removed_at\" IS NULL AND (\"birth_giving_events\".\"status\" = 'published' OR current_profile_id() = ANY(\"birth_giving_events\".\"organizer_profile_ids\"))"
+        }
+      },
+      "checkConstraints": {
+        "birth_giving_events_name_check": {
+          "name": "birth_giving_events_name_check",
+          "value": "length(trim(\"birth_giving_events\".\"name\")) > 0"
+        },
+        "birth_giving_events_customer_check": {
+          "name": "birth_giving_events_customer_check",
+          "value": "length(trim(\"birth_giving_events\".\"customer\")) > 0"
+        },
+        "birth_giving_events_organizers_check": {
+          "name": "birth_giving_events_organizers_check",
+          "value": "cardinality(\"birth_giving_events\".\"organizer_profile_ids\") > 0 AND cardinality(array_remove(\"birth_giving_events\".\"organizer_profile_ids\", NULL)) = cardinality(\"birth_giving_events\".\"organizer_profile_ids\")"
+        },
+        "birth_giving_events_assignment_check": {
+          "name": "birth_giving_events_assignment_check",
+          "value": "(\n    \"birth_giving_events\".\"assignment_state\" = 'present'\n    AND \"birth_giving_events\".\"assignment_storage_path\" IS NOT NULL\n    AND length(trim(\"birth_giving_events\".\"assignment_storage_path\")) > 0\n    AND \"birth_giving_events\".\"assignment_storage_path\" LIKE 'birth-giving/assignments/' || \"birth_giving_events\".\"id\"::text || '/%'\n    AND \"birth_giving_events\".\"assignment_file_name\" IS NOT NULL\n    AND length(trim(\"birth_giving_events\".\"assignment_file_name\")) > 0\n    AND \"birth_giving_events\".\"assignment_mime_type\" IS NOT NULL\n    AND length(trim(\"birth_giving_events\".\"assignment_mime_type\")) > 0\n    AND \"birth_giving_events\".\"assignment_file_size\" > 0\n    AND \"birth_giving_events\".\"assignment_uploaded_at\" IS NOT NULL\n    AND \"birth_giving_events\".\"assignment_uploaded_by_profile_id\" IS NOT NULL\n  ) OR (\n    \"birth_giving_events\".\"assignment_state\" IN ('none', 'missing')\n    AND \"birth_giving_events\".\"assignment_storage_path\" IS NULL\n    AND \"birth_giving_events\".\"assignment_file_name\" IS NULL\n    AND \"birth_giving_events\".\"assignment_mime_type\" IS NULL\n    AND \"birth_giving_events\".\"assignment_file_size\" IS NULL\n    AND \"birth_giving_events\".\"assignment_uploaded_at\" IS NULL\n    AND \"birth_giving_events\".\"assignment_uploaded_by_profile_id\" IS NULL\n  )"
+        },
+        "birth_giving_events_removed_check": {
+          "name": "birth_giving_events_removed_check",
+          "value": "(\"birth_giving_events\".\"removed_at\" IS NULL) = (\"birth_giving_events\".\"removed_by_profile_id\" IS NULL)"
+        }
+      },
+      "isRLSEnabled": true
+    },
+    "public.birth_giving_team_members": {
+      "name": "birth_giving_team_members",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "event_id": {
+          "name": "event_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "profile_id": {
+          "name": "profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "confirmed_at": {
+          "name": "confirmed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "reflection_contribution": {
+          "name": "reflection_contribution",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reflection_learning": {
+          "name": "reflection_learning",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reflection_submitted_at": {
+          "name": "reflection_submitted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_by_profile_id": {
+          "name": "created_by_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_by_profile_id": {
+          "name": "updated_by_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "birth_giving_team_members_team_idx": {
+          "name": "birth_giving_team_members_team_idx",
+          "columns": [
+            {
+              "expression": "event_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "team_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "birth_giving_team_members_profile_idx": {
+          "name": "birth_giving_team_members_profile_idx",
+          "columns": [
+            {
+              "expression": "profile_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "birth_giving_team_members_event_team_fkey": {
+          "name": "birth_giving_team_members_event_team_fkey",
+          "tableFrom": "birth_giving_team_members",
+          "tableTo": "birth_giving_teams",
+          "columnsFrom": [
+            "event_id",
+            "team_id"
+          ],
+          "columnsTo": [
+            "event_id",
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "birth_giving_team_members_profile_id_fkey": {
+          "name": "birth_giving_team_members_profile_id_fkey",
+          "tableFrom": "birth_giving_team_members",
+          "tableTo": "profiles",
+          "columnsFrom": [
+            "profile_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "birth_giving_team_members_created_by_profile_id_fkey": {
+          "name": "birth_giving_team_members_created_by_profile_id_fkey",
+          "tableFrom": "birth_giving_team_members",
+          "tableTo": "profiles",
+          "columnsFrom": [
+            "created_by_profile_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "birth_giving_team_members_updated_by_profile_id_fkey": {
+          "name": "birth_giving_team_members_updated_by_profile_id_fkey",
+          "tableFrom": "birth_giving_team_members",
+          "tableTo": "profiles",
+          "columnsFrom": [
+            "updated_by_profile_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "birth_giving_team_members_event_profile_key": {
+          "name": "birth_giving_team_members_event_profile_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "event_id",
+            "profile_id"
+          ]
+        },
+        "birth_giving_team_members_event_team_profile_key": {
+          "name": "birth_giving_team_members_event_team_profile_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "event_id",
+            "team_id",
+            "profile_id"
+          ]
+        }
+      },
+      "policies": {
+        "Community can view BG memberships for accessible events": {
+          "name": "Community can view BG memberships for accessible events",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": [
+            "authenticated"
+          ],
+          "using": "EXISTS (\n  SELECT 1\n  FROM profiles caller_profile\n  JOIN users caller_user ON caller_user.id = caller_profile.user_id\n  WHERE caller_profile.id = current_profile_id()\n    AND caller_profile.access_removed_at IS NULL\n    AND caller_profile.beta_access_granted_at IS NOT NULL\n    AND caller_user.verified_work_email IS NOT NULL\n) AND EXISTS (\n      SELECT 1 FROM birth_giving_events event\n      WHERE event.id = \"birth_giving_team_members\".\"event_id\"\n        AND event.removed_at IS NULL\n        AND (event.status = 'published' OR current_profile_id() = ANY(event.organizer_profile_ids))\n    )"
+        }
+      },
+      "checkConstraints": {
+        "birth_giving_team_members_reflection_check": {
+          "name": "birth_giving_team_members_reflection_check",
+          "value": "(\n    \"birth_giving_team_members\".\"reflection_contribution\" IS NULL\n    AND \"birth_giving_team_members\".\"reflection_learning\" IS NULL\n    AND \"birth_giving_team_members\".\"reflection_submitted_at\" IS NULL\n  ) OR (\n    \"birth_giving_team_members\".\"reflection_contribution\" IS NOT NULL\n    AND length(trim(\"birth_giving_team_members\".\"reflection_contribution\")) > 0\n    AND \"birth_giving_team_members\".\"reflection_learning\" IS NOT NULL\n    AND length(trim(\"birth_giving_team_members\".\"reflection_learning\")) > 0\n    AND \"birth_giving_team_members\".\"reflection_submitted_at\" IS NOT NULL\n  )"
+        }
+      },
+      "isRLSEnabled": true
+    },
+    "public.birth_giving_teams": {
+      "name": "birth_giving_teams",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "event_id": {
+          "name": "event_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_winner": {
+          "name": "is_winner",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "result_state": {
+          "name": "result_state",
+          "type": "birth_giving_team_result_state",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "result_files": {
+          "name": "result_files",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "cancelled_at": {
+          "name": "cancelled_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cancellation_reason": {
+          "name": "cancellation_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_by_profile_id": {
+          "name": "created_by_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_by_profile_id": {
+          "name": "updated_by_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "birth_giving_teams_event_winner_idx": {
+          "name": "birth_giving_teams_event_winner_idx",
+          "columns": [
+            {
+              "expression": "event_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"birth_giving_teams\".\"is_winner\" AND \"birth_giving_teams\".\"cancelled_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "birth_giving_teams_event_idx": {
+          "name": "birth_giving_teams_event_idx",
+          "columns": [
+            {
+              "expression": "event_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "birth_giving_teams_event_id_fkey": {
+          "name": "birth_giving_teams_event_id_fkey",
+          "tableFrom": "birth_giving_teams",
+          "tableTo": "birth_giving_events",
+          "columnsFrom": [
+            "event_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "birth_giving_teams_created_by_profile_id_fkey": {
+          "name": "birth_giving_teams_created_by_profile_id_fkey",
+          "tableFrom": "birth_giving_teams",
+          "tableTo": "profiles",
+          "columnsFrom": [
+            "created_by_profile_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "birth_giving_teams_updated_by_profile_id_fkey": {
+          "name": "birth_giving_teams_updated_by_profile_id_fkey",
+          "tableFrom": "birth_giving_teams",
+          "tableTo": "profiles",
+          "columnsFrom": [
+            "updated_by_profile_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "birth_giving_teams_event_id_id_key": {
+          "name": "birth_giving_teams_event_id_id_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "event_id",
+            "id"
+          ]
+        }
+      },
+      "policies": {
+        "Community can view BG teams for accessible events": {
+          "name": "Community can view BG teams for accessible events",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": [
+            "authenticated"
+          ],
+          "using": "EXISTS (\n  SELECT 1\n  FROM profiles caller_profile\n  JOIN users caller_user ON caller_user.id = caller_profile.user_id\n  WHERE caller_profile.id = current_profile_id()\n    AND caller_profile.access_removed_at IS NULL\n    AND caller_profile.beta_access_granted_at IS NOT NULL\n    AND caller_user.verified_work_email IS NOT NULL\n) AND EXISTS (\n      SELECT 1 FROM birth_giving_events event\n      WHERE event.id = \"birth_giving_teams\".\"event_id\"\n        AND event.removed_at IS NULL\n        AND (event.status = 'published' OR current_profile_id() = ANY(event.organizer_profile_ids))\n    )"
+        }
+      },
+      "checkConstraints": {
+        "birth_giving_teams_name_check": {
+          "name": "birth_giving_teams_name_check",
+          "value": "length(trim(\"birth_giving_teams\".\"name\")) > 0"
+        },
+        "birth_giving_teams_cancellation_check": {
+          "name": "birth_giving_teams_cancellation_check",
+          "value": "(\n    \"birth_giving_teams\".\"cancelled_at\" IS NULL AND \"birth_giving_teams\".\"cancellation_reason\" IS NULL\n  ) OR (\n    \"birth_giving_teams\".\"cancelled_at\" IS NOT NULL\n    AND \"birth_giving_teams\".\"cancellation_reason\" IS NOT NULL\n    AND length(trim(\"birth_giving_teams\".\"cancellation_reason\")) > 0\n  )"
+        },
+        "birth_giving_teams_result_check": {
+          "name": "birth_giving_teams_result_check",
+          "value": "jsonb_typeof(\"birth_giving_teams\".\"result_files\") = 'array' AND (\n    (\"birth_giving_teams\".\"result_state\" = 'present' AND jsonb_array_length(\"birth_giving_teams\".\"result_files\") > 0)\n    OR (\"birth_giving_teams\".\"result_state\" IN ('pending', 'missing') AND jsonb_array_length(\"birth_giving_teams\".\"result_files\") = 0)\n  )"
+        }
+      },
+      "isRLSEnabled": true
+    },
+    "public.book_loans": {
+      "name": "book_loans",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "library_book_id": {
+          "name": "library_book_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "borrower_id": {
+          "name": "borrower_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "borrowed_at": {
+          "name": "borrowed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "due_at": {
+          "name": "due_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "returned_at": {
+          "name": "returned_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "book_loans_library_book_id_idx": {
+          "name": "book_loans_library_book_id_idx",
+          "columns": [
+            {
+              "expression": "library_book_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "uuid_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "book_loans_borrower_id_idx": {
+          "name": "book_loans_borrower_id_idx",
+          "columns": [
+            {
+              "expression": "borrower_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "uuid_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "book_loans_active_idx": {
+          "name": "book_loans_active_idx",
+          "columns": [
+            {
+              "expression": "library_book_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "uuid_ops"
+            }
+          ],
+          "isUnique": false,
+          "where": "(returned_at IS NULL)",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "book_loans_library_book_id_fkey": {
+          "name": "book_loans_library_book_id_fkey",
+          "tableFrom": "book_loans",
+          "tableTo": "library_books",
+          "columnsFrom": [
+            "library_book_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "book_loans_borrower_id_fkey": {
+          "name": "book_loans_borrower_id_fkey",
+          "tableFrom": "book_loans",
+          "tableTo": "profiles",
+          "columnsFrom": [
+            "borrower_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {
+        "Authenticated users can view loans": {
+          "name": "Authenticated users can view loans",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": [
+            "authenticated"
+          ],
+          "using": "true"
+        },
+        "Users can borrow for themselves": {
+          "name": "Users can borrow for themselves",
+          "as": "PERMISSIVE",
+          "for": "INSERT",
+          "to": [
+            "authenticated"
+          ],
+          "withCheck": "(borrower_id = current_profile_id())"
+        },
+        "Borrower can return their own loan": {
+          "name": "Borrower can return their own loan",
+          "as": "PERMISSIVE",
+          "for": "UPDATE",
+          "to": [
+            "authenticated"
+          ],
+          "using": "(borrower_id = current_profile_id())",
+          "withCheck": "(borrower_id = current_profile_id())"
+        }
+      },
+      "checkConstraints": {},
+      "isRLSEnabled": true
+    },
+    "public.book_tags": {
+      "name": "book_tags",
+      "schema": "",
+      "columns": {
+        "book_id": {
+          "name": "book_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tag_id": {
+          "name": "tag_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_by_profile_id": {
+          "name": "created_by_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_by_profile_id": {
+          "name": "updated_by_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "book_tags_tag_idx": {
+          "name": "book_tags_tag_idx",
+          "columns": [
+            {
+              "expression": "tag_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "uuid_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "book_tags_book_id_fkey": {
+          "name": "book_tags_book_id_fkey",
+          "tableFrom": "book_tags",
+          "tableTo": "books",
+          "columnsFrom": [
+            "book_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "book_tags_tag_id_fkey": {
+          "name": "book_tags_tag_id_fkey",
+          "tableFrom": "book_tags",
+          "tableTo": "tags",
+          "columnsFrom": [
+            "tag_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "book_tags_created_by_profile_id_fkey": {
+          "name": "book_tags_created_by_profile_id_fkey",
+          "tableFrom": "book_tags",
+          "tableTo": "profiles",
+          "columnsFrom": [
+            "created_by_profile_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "book_tags_updated_by_profile_id_fkey": {
+          "name": "book_tags_updated_by_profile_id_fkey",
+          "tableFrom": "book_tags",
+          "tableTo": "profiles",
+          "columnsFrom": [
+            "updated_by_profile_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "book_tags_pkey": {
+          "name": "book_tags_pkey",
+          "columns": [
+            "book_id",
+            "tag_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {
+        "Authenticated users can view book tags": {
+          "name": "Authenticated users can view book tags",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": [
+            "authenticated"
+          ],
+          "using": "true"
+        },
+        "Authenticated users can assign book tags": {
+          "name": "Authenticated users can assign book tags",
+          "as": "PERMISSIVE",
+          "for": "INSERT",
+          "to": [
+            "authenticated"
+          ],
+          "withCheck": "(created_by_profile_id = current_profile_id())"
+        },
+        "Coaches and admins can update book tags": {
+          "name": "Coaches and admins can update book tags",
+          "as": "PERMISSIVE",
+          "for": "UPDATE",
+          "to": [
+            "authenticated"
+          ],
+          "using": "is_coach_or_admin()",
+          "withCheck": "is_coach_or_admin()"
+        },
+        "Coaches and admins can remove book tags": {
+          "name": "Coaches and admins can remove book tags",
+          "as": "PERMISSIVE",
+          "for": "DELETE",
+          "to": [
+            "authenticated"
+          ],
+          "using": "is_coach_or_admin()"
+        }
+      },
+      "checkConstraints": {},
+      "isRLSEnabled": true
+    },
+    "public.books": {
+      "name": "books",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "title_cs": {
+          "name": "title_cs",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title_en": {
+          "name": "title_en",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "author": {
+          "name": "author",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "isbn_13": {
+          "name": "isbn_13",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "google_books_cover_url": {
+          "name": "google_books_cover_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "book_points": {
+          "name": "book_points",
+          "type": "numeric(3, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "page_count": {
+          "name": "page_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "preview_link": {
+          "name": "preview_link",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source": {
+          "name": "source",
+          "type": "book_source",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'manual'"
+        },
+        "external_id": {
+          "name": "external_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "list_status": {
+          "name": "list_status",
+          "type": "book_list_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'processing'"
+        },
+        "list_status_changed_at": {
+          "name": "list_status_changed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "list_status_changed_by_profile_id": {
+          "name": "list_status_changed_by_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "list_status_reason": {
+          "name": "list_status_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "highlight_category_id": {
+          "name": "highlight_category_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_rocket_model": {
+          "name": "is_rocket_model",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_by_profile_id": {
+          "name": "created_by_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_by_profile_id": {
+          "name": "updated_by_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "books_created_by_idx": {
+          "name": "books_created_by_idx",
+          "columns": [
+            {
+              "expression": "created_by_profile_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "uuid_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "books_author_trgm_idx": {
+          "name": "books_author_trgm_idx",
+          "columns": [
+            {
+              "expression": "author",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "gin_trgm_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        },
+        "books_created_desc_idx": {
+          "name": "books_created_desc_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "first",
+              "opclass": "timestamptz_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "books_isbn_13_idx": {
+          "name": "books_isbn_13_idx",
+          "columns": [
+            {
+              "expression": "isbn_13",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "text_ops"
+            }
+          ],
+          "isUnique": false,
+          "where": "(isbn_13 IS NOT NULL)",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "books_list_status_idx": {
+          "name": "books_list_status_idx",
+          "columns": [
+            {
+              "expression": "list_status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "enum_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "books_title_cs_trgm_idx": {
+          "name": "books_title_cs_trgm_idx",
+          "columns": [
+            {
+              "expression": "title_cs",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "gin_trgm_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "books_created_by_profile_id_fkey": {
+          "name": "books_created_by_profile_id_fkey",
+          "tableFrom": "books",
+          "tableTo": "profiles",
+          "columnsFrom": [
+            "created_by_profile_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "books_updated_by_profile_id_fkey": {
+          "name": "books_updated_by_profile_id_fkey",
+          "tableFrom": "books",
+          "tableTo": "profiles",
+          "columnsFrom": [
+            "updated_by_profile_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "books_list_status_changed_by_profile_id_fkey": {
+          "name": "books_list_status_changed_by_profile_id_fkey",
+          "tableFrom": "books",
+          "tableTo": "profiles",
+          "columnsFrom": [
+            "list_status_changed_by_profile_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "books_highlight_category_id_fkey": {
+          "name": "books_highlight_category_id_fkey",
+          "tableFrom": "books",
+          "tableTo": "highlight_categories",
+          "columnsFrom": [
+            "highlight_category_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {
+        "Coaches and admins can delete books": {
+          "name": "Coaches and admins can delete books",
+          "as": "PERMISSIVE",
+          "for": "DELETE",
+          "to": [
+            "public"
+          ],
+          "using": "is_coach_or_admin()"
+        },
+        "Coaches and admins can update books": {
+          "name": "Coaches and admins can update books",
+          "as": "PERMISSIVE",
+          "for": "UPDATE",
+          "to": [
+            "authenticated"
+          ],
+          "using": "is_coach_or_admin()",
+          "withCheck": "is_coach_or_admin()"
+        },
+        "Authenticated users can add books": {
+          "name": "Authenticated users can add books",
+          "as": "PERMISSIVE",
+          "for": "INSERT",
+          "to": [
+            "authenticated"
+          ],
+          "withCheck": "(created_by_profile_id = current_profile_id())"
+        },
+        "Authenticated users can view all books": {
+          "name": "Authenticated users can view all books",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": [
+            "authenticated"
+          ],
+          "using": "true"
+        }
+      },
+      "checkConstraints": {
+        "books_book_points_check": {
+          "name": "books_book_points_check",
+          "value": "(book_points IS NULL) OR ((book_points >= (0)::numeric) AND (book_points <= (3)::numeric))"
+        },
+        "books_archived_points_check": {
+          "name": "books_archived_points_check",
+          "value": "(list_status <> 'archived') OR (book_points = (0)::numeric)"
+        }
+      },
+      "isRLSEnabled": true
+    },
+    "public.highlight_categories": {
+      "name": "highlight_categories",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_by_profile_id": {
+          "name": "created_by_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_by_profile_id": {
+          "name": "updated_by_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "highlight_categories_created_by_profile_id_fkey": {
+          "name": "highlight_categories_created_by_profile_id_fkey",
+          "tableFrom": "highlight_categories",
+          "tableTo": "profiles",
+          "columnsFrom": [
+            "created_by_profile_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "highlight_categories_updated_by_profile_id_fkey": {
+          "name": "highlight_categories_updated_by_profile_id_fkey",
+          "tableFrom": "highlight_categories",
+          "tableTo": "profiles",
+          "columnsFrom": [
+            "updated_by_profile_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {
+        "Authenticated users can view highlight categories": {
+          "name": "Authenticated users can view highlight categories",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": [
+            "authenticated"
+          ],
+          "using": "true"
+        },
+        "Coaches and admins can add highlight categories": {
+          "name": "Coaches and admins can add highlight categories",
+          "as": "PERMISSIVE",
+          "for": "INSERT",
+          "to": [
+            "authenticated"
+          ],
+          "withCheck": "is_coach_or_admin()"
+        },
+        "Coaches and admins can update highlight categories": {
+          "name": "Coaches and admins can update highlight categories",
+          "as": "PERMISSIVE",
+          "for": "UPDATE",
+          "to": [
+            "authenticated"
+          ],
+          "using": "is_coach_or_admin()",
+          "withCheck": "is_coach_or_admin()"
+        },
+        "Coaches and admins can delete highlight categories": {
+          "name": "Coaches and admins can delete highlight categories",
+          "as": "PERMISSIVE",
+          "for": "DELETE",
+          "to": [
+            "authenticated"
+          ],
+          "using": "is_coach_or_admin()"
+        }
+      },
+      "checkConstraints": {},
+      "isRLSEnabled": true
+    },
+    "public.library_books": {
+      "name": "library_books",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "book_id": {
+          "name": "book_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "label_code": {
+          "name": "label_code",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_by_profile_id": {
+          "name": "created_by_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_by_profile_id": {
+          "name": "updated_by_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "library_books_book_id_idx": {
+          "name": "library_books_book_id_idx",
+          "columns": [
+            {
+              "expression": "book_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "uuid_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "library_books_book_id_fkey": {
+          "name": "library_books_book_id_fkey",
+          "tableFrom": "library_books",
+          "tableTo": "books",
+          "columnsFrom": [
+            "book_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "library_books_created_by_profile_id_fkey": {
+          "name": "library_books_created_by_profile_id_fkey",
+          "tableFrom": "library_books",
+          "tableTo": "profiles",
+          "columnsFrom": [
+            "created_by_profile_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "library_books_updated_by_profile_id_fkey": {
+          "name": "library_books_updated_by_profile_id_fkey",
+          "tableFrom": "library_books",
+          "tableTo": "profiles",
+          "columnsFrom": [
+            "updated_by_profile_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "library_books_label_code_key": {
+          "name": "library_books_label_code_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "label_code"
+          ]
+        }
+      },
+      "policies": {
+        "Authenticated users can view library books": {
+          "name": "Authenticated users can view library books",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": [
+            "authenticated"
+          ],
+          "using": "true"
+        },
+        "Coaches and admins can add library books": {
+          "name": "Coaches and admins can add library books",
+          "as": "PERMISSIVE",
+          "for": "INSERT",
+          "to": [
+            "authenticated"
+          ],
+          "withCheck": "is_coach_or_admin()"
+        },
+        "Coaches and admins can update library books": {
+          "name": "Coaches and admins can update library books",
+          "as": "PERMISSIVE",
+          "for": "UPDATE",
+          "to": [
+            "authenticated"
+          ],
+          "using": "is_coach_or_admin()",
+          "withCheck": "is_coach_or_admin()"
+        },
+        "Coaches and admins can delete library books": {
+          "name": "Coaches and admins can delete library books",
+          "as": "PERMISSIVE",
+          "for": "DELETE",
+          "to": [
+            "authenticated"
+          ],
+          "using": "is_coach_or_admin()"
+        }
+      },
+      "checkConstraints": {
+        "library_books_label_code_check": {
+          "name": "library_books_label_code_check",
+          "value": "(label_code IS NULL) OR (label_code > 0)"
+        }
+      },
+      "isRLSEnabled": true
+    },
+    "public.tags": {
+      "name": "tags",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_by_profile_id": {
+          "name": "created_by_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_by_profile_id": {
+          "name": "updated_by_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "tags_created_by_profile_id_fkey": {
+          "name": "tags_created_by_profile_id_fkey",
+          "tableFrom": "tags",
+          "tableTo": "profiles",
+          "columnsFrom": [
+            "created_by_profile_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "tags_updated_by_profile_id_fkey": {
+          "name": "tags_updated_by_profile_id_fkey",
+          "tableFrom": "tags",
+          "tableTo": "profiles",
+          "columnsFrom": [
+            "updated_by_profile_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "tags_name_key": {
+          "name": "tags_name_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "name"
+          ]
+        }
+      },
+      "policies": {
+        "Authenticated users can view tags": {
+          "name": "Authenticated users can view tags",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": [
+            "authenticated"
+          ],
+          "using": "true"
+        },
+        "Coaches and admins can add tags": {
+          "name": "Coaches and admins can add tags",
+          "as": "PERMISSIVE",
+          "for": "INSERT",
+          "to": [
+            "authenticated"
+          ],
+          "withCheck": "is_coach_or_admin()"
+        },
+        "Coaches and admins can update tags": {
+          "name": "Coaches and admins can update tags",
+          "as": "PERMISSIVE",
+          "for": "UPDATE",
+          "to": [
+            "authenticated"
+          ],
+          "using": "is_coach_or_admin()",
+          "withCheck": "is_coach_or_admin()"
+        },
+        "Coaches and admins can delete tags": {
+          "name": "Coaches and admins can delete tags",
+          "as": "PERMISSIVE",
+          "for": "DELETE",
+          "to": [
+            "authenticated"
+          ],
+          "using": "is_coach_or_admin()"
+        }
+      },
+      "checkConstraints": {},
+      "isRLSEnabled": true
+    },
+    "public.content_sources": {
+      "name": "content_sources",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "kind": {
+          "name": "kind",
+          "type": "content_source_kind",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "creator": {
+          "name": "creator",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "external_url": {
+          "name": "external_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "points": {
+          "name": "points",
+          "type": "numeric(3, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "content_source_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending_review'"
+        },
+        "status_changed_at": {
+          "name": "status_changed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status_changed_by_profile_id": {
+          "name": "status_changed_by_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_by_profile_id": {
+          "name": "created_by_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_by_profile_id": {
+          "name": "updated_by_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "content_sources_created_by_idx": {
+          "name": "content_sources_created_by_idx",
+          "columns": [
+            {
+              "expression": "created_by_profile_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "uuid_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "content_sources_status_idx": {
+          "name": "content_sources_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "enum_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "content_sources_title_trgm_idx": {
+          "name": "content_sources_title_trgm_idx",
+          "columns": [
+            {
+              "expression": "title",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "gin_trgm_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        },
+        "content_sources_creator_trgm_idx": {
+          "name": "content_sources_creator_trgm_idx",
+          "columns": [
+            {
+              "expression": "creator",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "gin_trgm_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "content_sources_created_by_profile_id_fkey": {
+          "name": "content_sources_created_by_profile_id_fkey",
+          "tableFrom": "content_sources",
+          "tableTo": "profiles",
+          "columnsFrom": [
+            "created_by_profile_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "content_sources_updated_by_profile_id_fkey": {
+          "name": "content_sources_updated_by_profile_id_fkey",
+          "tableFrom": "content_sources",
+          "tableTo": "profiles",
+          "columnsFrom": [
+            "updated_by_profile_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "content_sources_status_changed_by_profile_id_fkey": {
+          "name": "content_sources_status_changed_by_profile_id_fkey",
+          "tableFrom": "content_sources",
+          "tableTo": "profiles",
+          "columnsFrom": [
+            "status_changed_by_profile_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {
+        "Authenticated users can view all content sources": {
+          "name": "Authenticated users can view all content sources",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": [
+            "authenticated"
+          ],
+          "using": "true"
+        },
+        "Authenticated users can add content sources": {
+          "name": "Authenticated users can add content sources",
+          "as": "PERMISSIVE",
+          "for": "INSERT",
+          "to": [
+            "authenticated"
+          ],
+          "withCheck": "((created_by_profile_id = current_profile_id()) AND (status = 'pending_review'::content_source_status))"
+        },
+        "Coaches and admins can update content sources": {
+          "name": "Coaches and admins can update content sources",
+          "as": "PERMISSIVE",
+          "for": "UPDATE",
+          "to": [
+            "authenticated"
+          ],
+          "using": "is_coach_or_admin()",
+          "withCheck": "is_coach_or_admin()"
+        },
+        "Coaches and admins can delete content sources": {
+          "name": "Coaches and admins can delete content sources",
+          "as": "PERMISSIVE",
+          "for": "DELETE",
+          "to": [
+            "authenticated"
+          ],
+          "using": "is_coach_or_admin()"
+        }
+      },
+      "checkConstraints": {
+        "content_sources_points_check": {
+          "name": "content_sources_points_check",
+          "value": "(points IS NULL) OR ((points >= (0)::numeric) AND (points <= (3)::numeric))"
+        }
+      },
+      "isRLSEnabled": true
+    },
+    "public.customer_meetings": {
+      "name": "customer_meetings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "profile_id": {
+          "name": "profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "meeting_at": {
+          "name": "meeting_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "company": {
+          "name": "company",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "contact_person": {
+          "name": "contact_person",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "position": {
+          "name": "position",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "objective": {
+          "name": "objective",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "post_mortem": {
+          "name": "post_mortem",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "team_share": {
+          "name": "team_share",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "removed_at": {
+          "name": "removed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_by_profile_id": {
+          "name": "created_by_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_by_profile_id": {
+          "name": "updated_by_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "customer_meetings_profile_idx": {
+          "name": "customer_meetings_profile_idx",
+          "columns": [
+            {
+              "expression": "profile_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "uuid_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "customer_meetings_created_desc_idx": {
+          "name": "customer_meetings_created_desc_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "first",
+              "opclass": "timestamptz_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "customer_meetings_profile_id_fkey": {
+          "name": "customer_meetings_profile_id_fkey",
+          "tableFrom": "customer_meetings",
+          "tableTo": "profiles",
+          "columnsFrom": [
+            "profile_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "customer_meetings_created_by_profile_id_fkey": {
+          "name": "customer_meetings_created_by_profile_id_fkey",
+          "tableFrom": "customer_meetings",
+          "tableTo": "profiles",
+          "columnsFrom": [
+            "created_by_profile_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "customer_meetings_updated_by_profile_id_fkey": {
+          "name": "customer_meetings_updated_by_profile_id_fkey",
+          "tableFrom": "customer_meetings",
+          "tableTo": "profiles",
+          "columnsFrom": [
+            "updated_by_profile_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {
+        "Users can view their own customer meetings": {
+          "name": "Users can view their own customer meetings",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": [
+            "authenticated"
+          ],
+          "using": "(profile_id = current_profile_id())"
+        },
+        "Users can create their own customer meetings": {
+          "name": "Users can create their own customer meetings",
+          "as": "PERMISSIVE",
+          "for": "INSERT",
+          "to": [
+            "authenticated"
+          ],
+          "withCheck": "(profile_id = current_profile_id())"
+        },
+        "Users can update their own customer meetings": {
+          "name": "Users can update their own customer meetings",
+          "as": "PERMISSIVE",
+          "for": "UPDATE",
+          "to": [
+            "authenticated"
+          ],
+          "using": "(profile_id = current_profile_id())",
+          "withCheck": "(profile_id = current_profile_id())"
+        },
+        "Users can delete their own customer meetings": {
+          "name": "Users can delete their own customer meetings",
+          "as": "PERMISSIVE",
+          "for": "DELETE",
+          "to": [
+            "authenticated"
+          ],
+          "using": "(profile_id = current_profile_id())"
+        }
+      },
+      "checkConstraints": {},
+      "isRLSEnabled": true
+    },
+    "public.dashboard_layouts": {
+      "name": "dashboard_layouts",
+      "schema": "",
+      "columns": {
+        "profile_id": {
+          "name": "profile_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "widgets": {
+          "name": "widgets",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_by_profile_id": {
+          "name": "created_by_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_by_profile_id": {
+          "name": "updated_by_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "dashboard_layouts_profile_id_fkey": {
+          "name": "dashboard_layouts_profile_id_fkey",
+          "tableFrom": "dashboard_layouts",
+          "tableTo": "profiles",
+          "columnsFrom": [
+            "profile_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "dashboard_layouts_created_by_profile_id_fkey": {
+          "name": "dashboard_layouts_created_by_profile_id_fkey",
+          "tableFrom": "dashboard_layouts",
+          "tableTo": "profiles",
+          "columnsFrom": [
+            "created_by_profile_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "dashboard_layouts_updated_by_profile_id_fkey": {
+          "name": "dashboard_layouts_updated_by_profile_id_fkey",
+          "tableFrom": "dashboard_layouts",
+          "tableTo": "profiles",
+          "columnsFrom": [
+            "updated_by_profile_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {
+        "Users can delete their own dashboard layout": {
+          "name": "Users can delete their own dashboard layout",
+          "as": "PERMISSIVE",
+          "for": "DELETE",
+          "to": [
+            "public"
+          ],
+          "using": "(profile_id = current_profile_id())"
+        },
+        "Users can update their own dashboard layout": {
+          "name": "Users can update their own dashboard layout",
+          "as": "PERMISSIVE",
+          "for": "UPDATE",
+          "to": [
+            "public"
+          ],
+          "using": "(profile_id = current_profile_id())",
+          "withCheck": "(profile_id = current_profile_id())"
+        },
+        "Users can insert their own dashboard layout": {
+          "name": "Users can insert their own dashboard layout",
+          "as": "PERMISSIVE",
+          "for": "INSERT",
+          "to": [
+            "public"
+          ],
+          "withCheck": "(profile_id = current_profile_id())"
+        },
+        "Users can view their own dashboard layout": {
+          "name": "Users can view their own dashboard layout",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": [
+            "public"
+          ],
+          "using": "(profile_id = current_profile_id())"
+        }
+      },
+      "checkConstraints": {},
+      "isRLSEnabled": true
+    },
+    "public.essay_coach_reads": {
+      "name": "essay_coach_reads",
+      "schema": "",
+      "columns": {
+        "essay_id": {
+          "name": "essay_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "coach_profile_id": {
+          "name": "coach_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "read_at": {
+          "name": "read_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_by_profile_id": {
+          "name": "created_by_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_by_profile_id": {
+          "name": "updated_by_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "essay_coach_reads_coach_idx": {
+          "name": "essay_coach_reads_coach_idx",
+          "columns": [
+            {
+              "expression": "coach_profile_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "uuid_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "essay_coach_reads_essay_id_fkey": {
+          "name": "essay_coach_reads_essay_id_fkey",
+          "tableFrom": "essay_coach_reads",
+          "tableTo": "essays",
+          "columnsFrom": [
+            "essay_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "essay_coach_reads_coach_profile_id_fkey": {
+          "name": "essay_coach_reads_coach_profile_id_fkey",
+          "tableFrom": "essay_coach_reads",
+          "tableTo": "profiles",
+          "columnsFrom": [
+            "coach_profile_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "essay_coach_reads_created_by_profile_id_fkey": {
+          "name": "essay_coach_reads_created_by_profile_id_fkey",
+          "tableFrom": "essay_coach_reads",
+          "tableTo": "profiles",
+          "columnsFrom": [
+            "created_by_profile_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "essay_coach_reads_updated_by_profile_id_fkey": {
+          "name": "essay_coach_reads_updated_by_profile_id_fkey",
+          "tableFrom": "essay_coach_reads",
+          "tableTo": "profiles",
+          "columnsFrom": [
+            "updated_by_profile_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "essay_coach_reads_pkey": {
+          "name": "essay_coach_reads_pkey",
+          "columns": [
+            "essay_id",
+            "coach_profile_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {
+        "Coaches remove own reads": {
+          "name": "Coaches remove own reads",
+          "as": "PERMISSIVE",
+          "for": "DELETE",
+          "to": [
+            "authenticated"
+          ],
+          "using": "(coach_profile_id = current_profile_id())"
+        },
+        "Coaches mark own reads within their team": {
+          "name": "Coaches mark own reads within their team",
+          "as": "PERMISSIVE",
+          "for": "INSERT",
+          "to": [
+            "authenticated"
+          ],
+          "withCheck": "((coach_profile_id = current_profile_id()) AND coach_can_review_essay(essay_id))"
+        },
+        "Coach sees own reads; author sees reads of own essays": {
+          "name": "Coach sees own reads; author sees reads of own essays",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": [
+            "authenticated"
+          ],
+          "using": "((coach_profile_id = current_profile_id()) OR (EXISTS ( SELECT 1\n   FROM essays e\n  WHERE ((e.id = essay_coach_reads.essay_id) AND (e.author_profile_id = current_profile_id())))))"
+        }
+      },
+      "checkConstraints": {},
+      "isRLSEnabled": true
+    },
+    "public.essay_comments": {
+      "name": "essay_comments",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "essay_id": {
+          "name": "essay_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "author_profile_id": {
+          "name": "author_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "parent_id": {
+          "name": "parent_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "removed_at": {
+          "name": "removed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_by_profile_id": {
+          "name": "created_by_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_by_profile_id": {
+          "name": "updated_by_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "essay_comments_author_idx": {
+          "name": "essay_comments_author_idx",
+          "columns": [
+            {
+              "expression": "author_profile_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "uuid_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "essay_comments_essay_idx": {
+          "name": "essay_comments_essay_idx",
+          "columns": [
+            {
+              "expression": "essay_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "uuid_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "essay_comments_essay_id_fkey": {
+          "name": "essay_comments_essay_id_fkey",
+          "tableFrom": "essay_comments",
+          "tableTo": "essays",
+          "columnsFrom": [
+            "essay_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "essay_comments_author_profile_id_fkey": {
+          "name": "essay_comments_author_profile_id_fkey",
+          "tableFrom": "essay_comments",
+          "tableTo": "profiles",
+          "columnsFrom": [
+            "author_profile_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "essay_comments_created_by_profile_id_fkey": {
+          "name": "essay_comments_created_by_profile_id_fkey",
+          "tableFrom": "essay_comments",
+          "tableTo": "profiles",
+          "columnsFrom": [
+            "created_by_profile_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "essay_comments_updated_by_profile_id_fkey": {
+          "name": "essay_comments_updated_by_profile_id_fkey",
+          "tableFrom": "essay_comments",
+          "tableTo": "profiles",
+          "columnsFrom": [
+            "updated_by_profile_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "essay_comments_parent_id_fkey": {
+          "name": "essay_comments_parent_id_fkey",
+          "tableFrom": "essay_comments",
+          "tableTo": "essay_comments",
+          "columnsFrom": [
+            "parent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {
+        "Authors and admins can delete essay comments": {
+          "name": "Authors and admins can delete essay comments",
+          "as": "PERMISSIVE",
+          "for": "DELETE",
+          "to": [
+            "authenticated"
+          ],
+          "using": "((author_profile_id = current_profile_id()) OR is_admin())"
+        },
+        "Authors can update their own essay comments": {
+          "name": "Authors can update their own essay comments",
+          "as": "PERMISSIVE",
+          "for": "UPDATE",
+          "to": [
+            "authenticated"
+          ],
+          "using": "(author_profile_id = current_profile_id())",
+          "withCheck": "(author_profile_id = current_profile_id())"
+        },
+        "Authenticated users can add essay comments": {
+          "name": "Authenticated users can add essay comments",
+          "as": "PERMISSIVE",
+          "for": "INSERT",
+          "to": [
+            "authenticated"
+          ],
+          "withCheck": "(author_profile_id = current_profile_id())"
+        },
+        "Authenticated users can view essay comments": {
+          "name": "Authenticated users can view essay comments",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": [
+            "authenticated"
+          ],
+          "using": "true"
+        }
+      },
+      "checkConstraints": {
+        "essay_comments_body_check": {
+          "name": "essay_comments_body_check",
+          "value": "(char_length(body) >= 1) AND (char_length(body) <= 4000)"
+        }
+      },
+      "isRLSEnabled": true
+    },
+    "public.essay_revisions": {
+      "name": "essay_revisions",
+      "schema": "",
+      "columns": {
+        "essay_id": {
+          "name": "essay_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "revision_no": {
+          "name": "revision_no",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content_json": {
+          "name": "content_json",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "invalid_since": {
+          "name": "invalid_since",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_by_profile_id": {
+          "name": "created_by_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_by_profile_id": {
+          "name": "updated_by_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "essay_revisions_essay_id_fkey": {
+          "name": "essay_revisions_essay_id_fkey",
+          "tableFrom": "essay_revisions",
+          "tableTo": "essays",
+          "columnsFrom": [
+            "essay_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "essay_revisions_created_by_profile_id_fkey": {
+          "name": "essay_revisions_created_by_profile_id_fkey",
+          "tableFrom": "essay_revisions",
+          "tableTo": "profiles",
+          "columnsFrom": [
+            "created_by_profile_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "essay_revisions_updated_by_profile_id_fkey": {
+          "name": "essay_revisions_updated_by_profile_id_fkey",
+          "tableFrom": "essay_revisions",
+          "tableTo": "profiles",
+          "columnsFrom": [
+            "updated_by_profile_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "essay_revisions_pkey": {
+          "name": "essay_revisions_pkey",
+          "columns": [
+            "essay_id",
+            "revision_no"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {
+        "Authenticated users can view essay revisions": {
+          "name": "Authenticated users can view essay revisions",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": [
+            "authenticated"
+          ],
+          "using": "(EXISTS ( SELECT 1\n   FROM essays e\n  WHERE ((e.id = essay_revisions.essay_id) AND ((e.published_at IS NOT NULL) OR (e.author_profile_id = ( SELECT current_profile_id())) OR ( SELECT is_admin())))))"
+        },
+        "Authors can create essay revisions": {
+          "name": "Authors can create essay revisions",
+          "as": "PERMISSIVE",
+          "for": "INSERT",
+          "to": [
+            "authenticated"
+          ],
+          "withCheck": "(created_by_profile_id = current_profile_id())"
+        },
+        "Authors can update their newest recent essay revision": {
+          "name": "Authors can update their newest recent essay revision",
+          "as": "PERMISSIVE",
+          "for": "UPDATE",
+          "to": [
+            "authenticated"
+          ],
+          "using": "((created_by_profile_id = ( SELECT current_profile_id())) AND (created_at > (now() - '00:30:00'::interval)))",
+          "withCheck": "(created_by_profile_id = ( SELECT current_profile_id()))"
+        },
+        "Essay revisions cannot be deleted": {
+          "name": "Essay revisions cannot be deleted",
+          "as": "PERMISSIVE",
+          "for": "DELETE",
+          "to": [
+            "authenticated"
+          ],
+          "using": "false"
+        }
+      },
+      "checkConstraints": {},
+      "isRLSEnabled": true
+    },
+    "public.essay_views": {
+      "name": "essay_views",
+      "schema": "",
+      "columns": {
+        "essay_id": {
+          "name": "essay_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "viewer_profile_id": {
+          "name": "viewer_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "first_viewed_at": {
+          "name": "first_viewed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_viewed_at": {
+          "name": "last_viewed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_by_profile_id": {
+          "name": "created_by_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_by_profile_id": {
+          "name": "updated_by_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "essay_views_viewer_idx": {
+          "name": "essay_views_viewer_idx",
+          "columns": [
+            {
+              "expression": "viewer_profile_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "uuid_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "essay_views_essay_id_fkey": {
+          "name": "essay_views_essay_id_fkey",
+          "tableFrom": "essay_views",
+          "tableTo": "essays",
+          "columnsFrom": [
+            "essay_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "essay_views_viewer_profile_id_fkey": {
+          "name": "essay_views_viewer_profile_id_fkey",
+          "tableFrom": "essay_views",
+          "tableTo": "profiles",
+          "columnsFrom": [
+            "viewer_profile_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "essay_views_created_by_profile_id_fkey": {
+          "name": "essay_views_created_by_profile_id_fkey",
+          "tableFrom": "essay_views",
+          "tableTo": "profiles",
+          "columnsFrom": [
+            "created_by_profile_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "essay_views_updated_by_profile_id_fkey": {
+          "name": "essay_views_updated_by_profile_id_fkey",
+          "tableFrom": "essay_views",
+          "tableTo": "profiles",
+          "columnsFrom": [
+            "updated_by_profile_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "essay_views_pkey": {
+          "name": "essay_views_pkey",
+          "columns": [
+            "essay_id",
+            "viewer_profile_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {
+        "No direct inserts to essay_views": {
+          "name": "No direct inserts to essay_views",
+          "as": "PERMISSIVE",
+          "for": "INSERT",
+          "to": [
+            "authenticated"
+          ],
+          "withCheck": "false"
+        },
+        "Authors see all viewers; others see own row": {
+          "name": "Authors see all viewers; others see own row",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": [
+            "authenticated"
+          ],
+          "using": "((viewer_profile_id = current_profile_id()) OR (EXISTS ( SELECT 1\n   FROM essays e\n  WHERE ((e.id = essay_views.essay_id) AND (e.author_profile_id = current_profile_id())))))"
+        }
+      },
+      "checkConstraints": {},
+      "isRLSEnabled": true
+    },
+    "public.essay_votes": {
+      "name": "essay_votes",
+      "schema": "",
+      "columns": {
+        "essay_id": {
+          "name": "essay_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "voter_profile_id": {
+          "name": "voter_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_by_profile_id": {
+          "name": "created_by_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_by_profile_id": {
+          "name": "updated_by_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "essay_votes_voter_idx": {
+          "name": "essay_votes_voter_idx",
+          "columns": [
+            {
+              "expression": "voter_profile_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "uuid_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "essay_votes_essay_id_fkey": {
+          "name": "essay_votes_essay_id_fkey",
+          "tableFrom": "essay_votes",
+          "tableTo": "essays",
+          "columnsFrom": [
+            "essay_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "essay_votes_voter_profile_id_fkey": {
+          "name": "essay_votes_voter_profile_id_fkey",
+          "tableFrom": "essay_votes",
+          "tableTo": "profiles",
+          "columnsFrom": [
+            "voter_profile_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "essay_votes_created_by_profile_id_fkey": {
+          "name": "essay_votes_created_by_profile_id_fkey",
+          "tableFrom": "essay_votes",
+          "tableTo": "profiles",
+          "columnsFrom": [
+            "created_by_profile_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "essay_votes_updated_by_profile_id_fkey": {
+          "name": "essay_votes_updated_by_profile_id_fkey",
+          "tableFrom": "essay_votes",
+          "tableTo": "profiles",
+          "columnsFrom": [
+            "updated_by_profile_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "essay_votes_pkey": {
+          "name": "essay_votes_pkey",
+          "columns": [
+            "essay_id",
+            "voter_profile_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {
+        "Users can vote (not own essays)": {
+          "name": "Users can vote (not own essays)",
+          "as": "PERMISSIVE",
+          "for": "INSERT",
+          "to": [
+            "authenticated"
+          ],
+          "withCheck": "((voter_profile_id = current_profile_id()) AND (NOT (essay_id IN ( SELECT essays.id\n   FROM essays\n  WHERE (essays.author_profile_id = current_profile_id())))))"
+        },
+        "Authenticated users can view votes": {
+          "name": "Authenticated users can view votes",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": [
+            "authenticated"
+          ],
+          "using": "true"
+        },
+        "Users can remove own votes": {
+          "name": "Users can remove own votes",
+          "as": "PERMISSIVE",
+          "for": "DELETE",
+          "to": [
+            "authenticated"
+          ],
+          "using": "(voter_profile_id = current_profile_id())"
+        }
+      },
+      "checkConstraints": {},
+      "isRLSEnabled": true
+    },
+    "public.essays": {
+      "name": "essays",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "external_id": {
+          "name": "external_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "author_profile_id": {
+          "name": "author_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "book_id": {
+          "name": "book_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "frozen_book_points": {
+          "name": "frozen_book_points",
+          "type": "numeric(3, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "content_source_id": {
+          "name": "content_source_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "published_at": {
+          "name": "published_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pinned_at": {
+          "name": "pinned_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pinned_by_profile_id": {
+          "name": "pinned_by_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "removed_at": {
+          "name": "removed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_by_profile_id": {
+          "name": "created_by_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_by_profile_id": {
+          "name": "updated_by_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "essays_author_idx": {
+          "name": "essays_author_idx",
+          "columns": [
+            {
+              "expression": "author_profile_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "uuid_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "essays_book_idx": {
+          "name": "essays_book_idx",
+          "columns": [
+            {
+              "expression": "book_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "uuid_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "essays_content_source_idx": {
+          "name": "essays_content_source_idx",
+          "columns": [
+            {
+              "expression": "content_source_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "uuid_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "essays_created_desc_idx": {
+          "name": "essays_created_desc_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "first",
+              "opclass": "timestamptz_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "essays_author_profile_id_fkey": {
+          "name": "essays_author_profile_id_fkey",
+          "tableFrom": "essays",
+          "tableTo": "profiles",
+          "columnsFrom": [
+            "author_profile_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "essays_book_id_fkey": {
+          "name": "essays_book_id_fkey",
+          "tableFrom": "essays",
+          "tableTo": "books",
+          "columnsFrom": [
+            "book_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "essays_content_source_id_fkey": {
+          "name": "essays_content_source_id_fkey",
+          "tableFrom": "essays",
+          "tableTo": "content_sources",
+          "columnsFrom": [
+            "content_source_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "essays_pinned_by_profile_id_fkey": {
+          "name": "essays_pinned_by_profile_id_fkey",
+          "tableFrom": "essays",
+          "tableTo": "profiles",
+          "columnsFrom": [
+            "pinned_by_profile_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "essays_created_by_profile_id_fkey": {
+          "name": "essays_created_by_profile_id_fkey",
+          "tableFrom": "essays",
+          "tableTo": "profiles",
+          "columnsFrom": [
+            "created_by_profile_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "essays_updated_by_profile_id_fkey": {
+          "name": "essays_updated_by_profile_id_fkey",
+          "tableFrom": "essays",
+          "tableTo": "profiles",
+          "columnsFrom": [
+            "updated_by_profile_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {
+        "Authors can create their own essays": {
+          "name": "Authors can create their own essays",
+          "as": "PERMISSIVE",
+          "for": "INSERT",
+          "to": [
+            "authenticated"
+          ],
+          "withCheck": "(author_profile_id = current_profile_id())"
+        },
+        "Authenticated users can view all essays": {
+          "name": "Authenticated users can view all essays",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": [
+            "authenticated"
+          ],
+          "using": "((published_at IS NOT NULL) OR (author_profile_id = ( SELECT current_profile_id())) OR ( SELECT is_admin()))"
+        },
+        "Authors and admins can delete essays": {
+          "name": "Authors and admins can delete essays",
+          "as": "PERMISSIVE",
+          "for": "DELETE",
+          "to": [
+            "authenticated"
+          ],
+          "using": "((author_profile_id = current_profile_id()) OR is_admin())"
+        },
+        "Authors can update their own essays": {
+          "name": "Authors can update their own essays",
+          "as": "PERMISSIVE",
+          "for": "UPDATE",
+          "to": [
+            "authenticated"
+          ],
+          "using": "(author_profile_id = current_profile_id())",
+          "withCheck": "(author_profile_id = current_profile_id())"
+        }
+      },
+      "checkConstraints": {
+        "essays_source_exclusive_check": {
+          "name": "essays_source_exclusive_check",
+          "value": "NOT ((book_id IS NOT NULL) AND (content_source_id IS NOT NULL))"
+        },
+        "essays_frozen_book_points_check": {
+          "name": "essays_frozen_book_points_check",
+          "value": "(frozen_book_points IS NULL) OR ((frozen_book_points >= (0)::numeric) AND (frozen_book_points <= (3)::numeric))"
+        }
+      },
+      "isRLSEnabled": true
+    },
+    "public.feedback": {
+      "name": "feedback",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "author_profile_id": {
+          "name": "author_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "resolved_at": {
+          "name": "resolved_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_by_profile_id": {
+          "name": "created_by_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_by_profile_id": {
+          "name": "updated_by_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "feedback_active_created_idx": {
+          "name": "feedback_active_created_idx",
+          "columns": [
+            {
+              "expression": "resolved_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "timestamptz_ops"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "first",
+              "opclass": "timestamptz_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "feedback_author_idx": {
+          "name": "feedback_author_idx",
+          "columns": [
+            {
+              "expression": "author_profile_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "uuid_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "feedback_author_profile_id_fkey": {
+          "name": "feedback_author_profile_id_fkey",
+          "tableFrom": "feedback",
+          "tableTo": "profiles",
+          "columnsFrom": [
+            "author_profile_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "feedback_created_by_profile_id_fkey": {
+          "name": "feedback_created_by_profile_id_fkey",
+          "tableFrom": "feedback",
+          "tableTo": "profiles",
+          "columnsFrom": [
+            "created_by_profile_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "feedback_updated_by_profile_id_fkey": {
+          "name": "feedback_updated_by_profile_id_fkey",
+          "tableFrom": "feedback",
+          "tableTo": "profiles",
+          "columnsFrom": [
+            "updated_by_profile_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {
+        "Authenticated users can view feedback": {
+          "name": "Authenticated users can view feedback",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": [
+            "authenticated"
+          ],
+          "using": "true"
+        },
+        "Authenticated users can create feedback": {
+          "name": "Authenticated users can create feedback",
+          "as": "PERMISSIVE",
+          "for": "INSERT",
+          "to": [
+            "authenticated"
+          ],
+          "withCheck": "(author_profile_id = current_profile_id())"
+        },
+        "Admins can update feedback": {
+          "name": "Admins can update feedback",
+          "as": "PERMISSIVE",
+          "for": "UPDATE",
+          "to": [
+            "authenticated"
+          ],
+          "using": "is_admin()",
+          "withCheck": "is_admin()"
+        },
+        "Authors and admins can delete feedback": {
+          "name": "Authors and admins can delete feedback",
+          "as": "PERMISSIVE",
+          "for": "DELETE",
+          "to": [
+            "authenticated"
+          ],
+          "using": "((author_profile_id = current_profile_id()) OR is_admin())"
+        }
+      },
+      "checkConstraints": {
+        "feedback_body_check": {
+          "name": "feedback_body_check",
+          "value": "(char_length(body) >= 1) AND (char_length(body) <= 4000)"
+        }
+      },
+      "isRLSEnabled": true
+    },
+    "public.individual_coaching_sessions": {
+      "name": "individual_coaching_sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "profile_id": {
+          "name": "profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "session_at": {
+          "name": "session_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "coach_profile_id": {
+          "name": "coach_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "external_coach_name": {
+          "name": "external_coach_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "key_takeaways": {
+          "name": "key_takeaways",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "action_steps": {
+          "name": "action_steps",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "removed_at": {
+          "name": "removed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_by_profile_id": {
+          "name": "created_by_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_by_profile_id": {
+          "name": "updated_by_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "individual_coaching_sessions_profile_idx": {
+          "name": "individual_coaching_sessions_profile_idx",
+          "columns": [
+            {
+              "expression": "profile_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "uuid_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "individual_coaching_sessions_coach_idx": {
+          "name": "individual_coaching_sessions_coach_idx",
+          "columns": [
+            {
+              "expression": "coach_profile_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "uuid_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "individual_coaching_sessions_created_desc_idx": {
+          "name": "individual_coaching_sessions_created_desc_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "first",
+              "opclass": "timestamptz_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "individual_coaching_sessions_profile_id_fkey": {
+          "name": "individual_coaching_sessions_profile_id_fkey",
+          "tableFrom": "individual_coaching_sessions",
+          "tableTo": "profiles",
+          "columnsFrom": [
+            "profile_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "individual_coaching_sessions_coach_profile_id_fkey": {
+          "name": "individual_coaching_sessions_coach_profile_id_fkey",
+          "tableFrom": "individual_coaching_sessions",
+          "tableTo": "profiles",
+          "columnsFrom": [
+            "coach_profile_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "individual_coaching_sessions_created_by_profile_id_fkey": {
+          "name": "individual_coaching_sessions_created_by_profile_id_fkey",
+          "tableFrom": "individual_coaching_sessions",
+          "tableTo": "profiles",
+          "columnsFrom": [
+            "created_by_profile_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "individual_coaching_sessions_updated_by_profile_id_fkey": {
+          "name": "individual_coaching_sessions_updated_by_profile_id_fkey",
+          "tableFrom": "individual_coaching_sessions",
+          "tableTo": "profiles",
+          "columnsFrom": [
+            "updated_by_profile_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {
+        "Users can view their own coaching sessions": {
+          "name": "Users can view their own coaching sessions",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": [
+            "authenticated"
+          ],
+          "using": "(profile_id = current_profile_id())"
+        },
+        "Users can create their own coaching sessions": {
+          "name": "Users can create their own coaching sessions",
+          "as": "PERMISSIVE",
+          "for": "INSERT",
+          "to": [
+            "authenticated"
+          ],
+          "withCheck": "(profile_id = current_profile_id())"
+        },
+        "Users can update their own coaching sessions": {
+          "name": "Users can update their own coaching sessions",
+          "as": "PERMISSIVE",
+          "for": "UPDATE",
+          "to": [
+            "authenticated"
+          ],
+          "using": "(profile_id = current_profile_id())",
+          "withCheck": "(profile_id = current_profile_id())"
+        },
+        "Users can delete their own coaching sessions": {
+          "name": "Users can delete their own coaching sessions",
+          "as": "PERMISSIVE",
+          "for": "DELETE",
+          "to": [
+            "authenticated"
+          ],
+          "using": "(profile_id = current_profile_id())"
+        }
+      },
+      "checkConstraints": {
+        "individual_coaching_sessions_coach_xor": {
+          "name": "individual_coaching_sessions_coach_xor",
+          "value": "(coach_profile_id IS NOT NULL) <> (external_coach_name IS NOT NULL)"
+        }
+      },
+      "isRLSEnabled": true
+    },
+    "public.notification_preferences": {
+      "name": "notification_preferences",
+      "schema": "",
+      "columns": {
+        "profile_id": {
+          "name": "profile_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "essay_coach_read_email": {
+          "name": "essay_coach_read_email",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "essay_comment_email": {
+          "name": "essay_comment_email",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "essay_vote_email": {
+          "name": "essay_vote_email",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "book_submitted_email": {
+          "name": "book_submitted_email",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_by_profile_id": {
+          "name": "created_by_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_by_profile_id": {
+          "name": "updated_by_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "notification_preferences_profile_id_fkey": {
+          "name": "notification_preferences_profile_id_fkey",
+          "tableFrom": "notification_preferences",
+          "tableTo": "profiles",
+          "columnsFrom": [
+            "profile_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "notification_preferences_created_by_profile_id_fkey": {
+          "name": "notification_preferences_created_by_profile_id_fkey",
+          "tableFrom": "notification_preferences",
+          "tableTo": "profiles",
+          "columnsFrom": [
+            "created_by_profile_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "notification_preferences_updated_by_profile_id_fkey": {
+          "name": "notification_preferences_updated_by_profile_id_fkey",
+          "tableFrom": "notification_preferences",
+          "tableTo": "profiles",
+          "columnsFrom": [
+            "updated_by_profile_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {
+        "Users can view their own notification preferences": {
+          "name": "Users can view their own notification preferences",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": [
+            "authenticated"
+          ],
+          "using": "(profile_id = current_profile_id())"
+        },
+        "Users can insert their own notification preferences": {
+          "name": "Users can insert their own notification preferences",
+          "as": "PERMISSIVE",
+          "for": "INSERT",
+          "to": [
+            "authenticated"
+          ],
+          "withCheck": "(profile_id = current_profile_id())"
+        },
+        "Users can update their own notification preferences": {
+          "name": "Users can update their own notification preferences",
+          "as": "PERMISSIVE",
+          "for": "UPDATE",
+          "to": [
+            "authenticated"
+          ],
+          "using": "(profile_id = current_profile_id())",
+          "withCheck": "(profile_id = current_profile_id())"
+        }
+      },
+      "checkConstraints": {},
+      "isRLSEnabled": true
+    },
+    "public.personality_tests": {
+      "name": "personality_tests",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "profile_id": {
+          "name": "profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "test_type": {
+          "name": "test_type",
+          "type": "personality_test_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "test_type_other": {
+          "name": "test_type_other",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tested_on": {
+          "name": "tested_on",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "file_path": {
+          "name": "file_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "file_name": {
+          "name": "file_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "file_size": {
+          "name": "file_size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "removed_at": {
+          "name": "removed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_by_profile_id": {
+          "name": "created_by_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_by_profile_id": {
+          "name": "updated_by_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "personality_tests_profile_tested_on_idx": {
+          "name": "personality_tests_profile_tested_on_idx",
+          "columns": [
+            {
+              "expression": "profile_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "uuid_ops"
+            },
+            {
+              "expression": "tested_on",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "date_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "personality_tests_profile_id_fkey": {
+          "name": "personality_tests_profile_id_fkey",
+          "tableFrom": "personality_tests",
+          "tableTo": "profiles",
+          "columnsFrom": [
+            "profile_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "personality_tests_created_by_profile_id_fkey": {
+          "name": "personality_tests_created_by_profile_id_fkey",
+          "tableFrom": "personality_tests",
+          "tableTo": "profiles",
+          "columnsFrom": [
+            "created_by_profile_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "personality_tests_updated_by_profile_id_fkey": {
+          "name": "personality_tests_updated_by_profile_id_fkey",
+          "tableFrom": "personality_tests",
+          "tableTo": "profiles",
+          "columnsFrom": [
+            "updated_by_profile_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {
+        "Verified users can view personality tests": {
+          "name": "Verified users can view personality tests",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": [
+            "authenticated"
+          ],
+          "using": "(EXISTS (SELECT 1 FROM users WHERE (users.auth_user_id = (SELECT auth.uid()) AND users.verified_work_email IS NOT NULL)))"
+        },
+        "Users can create their own personality tests": {
+          "name": "Users can create their own personality tests",
+          "as": "PERMISSIVE",
+          "for": "INSERT",
+          "to": [
+            "authenticated"
+          ],
+          "withCheck": "(profile_id = current_profile_id())"
+        },
+        "Users can update their own personality tests": {
+          "name": "Users can update their own personality tests",
+          "as": "PERMISSIVE",
+          "for": "UPDATE",
+          "to": [
+            "authenticated"
+          ],
+          "using": "(profile_id = current_profile_id())",
+          "withCheck": "(profile_id = current_profile_id())"
+        },
+        "Users can delete their own personality tests": {
+          "name": "Users can delete their own personality tests",
+          "as": "PERMISSIVE",
+          "for": "DELETE",
+          "to": [
+            "authenticated"
+          ],
+          "using": "(profile_id = current_profile_id())"
+        }
+      },
+      "checkConstraints": {
+        "personality_tests_other_type_required": {
+          "name": "personality_tests_other_type_required",
+          "value": "(test_type <> 'other' OR (test_type_other IS NOT NULL AND length(trim(test_type_other)) > 0))"
+        }
+      },
+      "isRLSEnabled": true
+    },
+    "public.profiles": {
+      "name": "profiles",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "picture": {
+          "name": "picture",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "work_email": {
+          "name": "work_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "profile_role",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'student'"
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "phone_number": {
+          "name": "phone_number",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "personal_email": {
+          "name": "personal_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "date_of_birth": {
+          "name": "date_of_birth",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_removed_at": {
+          "name": "access_removed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_removed_by_profile_id": {
+          "name": "access_removed_by_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "beta_access_granted_at": {
+          "name": "beta_access_granted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "beta_cohort": {
+          "name": "beta_cohort",
+          "type": "beta_cohort",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'A'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_by_profile_id": {
+          "name": "created_by_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_by_profile_id": {
+          "name": "updated_by_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "profiles_team_id_idx": {
+          "name": "profiles_team_id_idx",
+          "columns": [
+            {
+              "expression": "team_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "uuid_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "profiles_team_id_user_id_idx": {
+          "name": "profiles_team_id_user_id_idx",
+          "columns": [
+            {
+              "expression": "team_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "uuid_ops"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "uuid_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "profiles_user_id_idx": {
+          "name": "profiles_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "uuid_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "profiles_work_email_idx": {
+          "name": "profiles_work_email_idx",
+          "columns": [
+            {
+              "expression": "work_email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "text_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "profiles_user_id_fkey": {
+          "name": "profiles_user_id_fkey",
+          "tableFrom": "profiles",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "profiles_team_id_fkey": {
+          "name": "profiles_team_id_fkey",
+          "tableFrom": "profiles",
+          "tableTo": "teams",
+          "columnsFrom": [
+            "team_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "profiles_access_removed_by_profile_id_fkey": {
+          "name": "profiles_access_removed_by_profile_id_fkey",
+          "tableFrom": "profiles",
+          "tableTo": "profiles",
+          "columnsFrom": [
+            "access_removed_by_profile_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "profiles_created_by_profile_id_fkey": {
+          "name": "profiles_created_by_profile_id_fkey",
+          "tableFrom": "profiles",
+          "tableTo": "profiles",
+          "columnsFrom": [
+            "created_by_profile_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "profiles_updated_by_profile_id_fkey": {
+          "name": "profiles_updated_by_profile_id_fkey",
+          "tableFrom": "profiles",
+          "tableTo": "profiles",
+          "columnsFrom": [
+            "updated_by_profile_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "profiles_user_id_key": {
+          "name": "profiles_user_id_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id"
+          ]
+        },
+        "profiles_work_email_key": {
+          "name": "profiles_work_email_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "work_email"
+          ]
+        }
+      },
+      "policies": {
+        "Verified users can view all profiles": {
+          "name": "Verified users can view all profiles",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": [
+            "authenticated"
+          ],
+          "using": "((access_removed_at IS NULL) AND (EXISTS ( SELECT 1\n   FROM users\n  WHERE ((users.auth_user_id = ( SELECT auth.uid() AS uid)) AND (users.verified_work_email IS NOT NULL)))))"
+        },
+        "Users can update their own profile picture": {
+          "name": "Users can update their own profile picture",
+          "as": "PERMISSIVE",
+          "for": "UPDATE",
+          "to": [
+            "authenticated"
+          ],
+          "using": "(user_id IN ( SELECT users.id\n   FROM users\n  WHERE (users.auth_user_id = ( SELECT auth.uid() AS uid))))",
+          "withCheck": "(user_id IN ( SELECT users.id\n   FROM users\n  WHERE (users.auth_user_id = ( SELECT auth.uid() AS uid))))"
+        }
+      },
+      "checkConstraints": {
+        "valid_czu_domain": {
+          "name": "valid_czu_domain",
+          "value": "(lower(split_part(work_email, '@'::text, 2)) = ANY (ARRAY['pef.czu.cz'::text, 'studenti.czu.cz'::text, 'rektorat.czu.cz'::text]))"
+        }
+      },
+      "isRLSEnabled": true
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "auth_user_id": {
+          "name": "auth_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "google_email": {
+          "name": "google_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "suggested_work_email": {
+          "name": "suggested_work_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "verified_work_email": {
+          "name": "verified_work_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "verified_work_email_at": {
+          "name": "verified_work_email_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_otp_sent_at": {
+          "name": "last_otp_sent_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "users_google_email_idx": {
+          "name": "users_google_email_idx",
+          "columns": [
+            {
+              "expression": "google_email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "text_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "users_suggested_work_email_idx": {
+          "name": "users_suggested_work_email_idx",
+          "columns": [
+            {
+              "expression": "suggested_work_email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "text_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "users_auth_user_id_fkey": {
+          "name": "users_auth_user_id_fkey",
+          "tableFrom": "users",
+          "tableTo": "users",
+          "schemaTo": "auth",
+          "columnsFrom": [
+            "auth_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_auth_user_id_key": {
+          "name": "users_auth_user_id_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "auth_user_id"
+          ]
+        },
+        "users_google_email_key": {
+          "name": "users_google_email_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "google_email"
+          ]
+        }
+      },
+      "policies": {
+        "Users can update only suggested_work_email": {
+          "name": "Users can update only suggested_work_email",
+          "as": "PERMISSIVE",
+          "for": "UPDATE",
+          "to": [
+            "authenticated"
+          ],
+          "using": "(( SELECT auth.uid() AS uid) = auth_user_id)",
+          "withCheck": "(( SELECT auth.uid() AS uid) = auth_user_id)"
+        },
+        "Users can insert their own user record": {
+          "name": "Users can insert their own user record",
+          "as": "PERMISSIVE",
+          "for": "INSERT",
+          "to": [
+            "authenticated"
+          ],
+          "withCheck": "(( SELECT auth.uid() AS uid) = auth_user_id)"
+        },
+        "Users can view their own user record": {
+          "name": "Users can view their own user record",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": [
+            "authenticated"
+          ],
+          "using": "(( SELECT auth.uid() AS uid) = auth_user_id)"
+        }
+      },
+      "checkConstraints": {},
+      "isRLSEnabled": true
+    },
+    "public.recurring_schedules": {
+      "name": "recurring_schedules",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "room_id": {
+          "name": "room_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "schedule_type": {
+          "name": "schedule_type",
+          "type": "schedule_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "day_of_week": {
+          "name": "day_of_week",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "start_time": {
+          "name": "start_time",
+          "type": "time",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "end_time": {
+          "name": "end_time",
+          "type": "time",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "valid_from": {
+          "name": "valid_from",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "valid_until": {
+          "name": "valid_until",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "removed_at": {
+          "name": "removed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_by_profile_id": {
+          "name": "created_by_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_by_profile_id": {
+          "name": "updated_by_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "idx_recurring_schedules_day": {
+          "name": "idx_recurring_schedules_day",
+          "columns": [
+            {
+              "expression": "day_of_week",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "int2_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_recurring_schedules_room": {
+          "name": "idx_recurring_schedules_room",
+          "columns": [
+            {
+              "expression": "room_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "uuid_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_recurring_schedules_team": {
+          "name": "idx_recurring_schedules_team",
+          "columns": [
+            {
+              "expression": "team_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "uuid_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_recurring_schedules_type": {
+          "name": "idx_recurring_schedules_type",
+          "columns": [
+            {
+              "expression": "schedule_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "enum_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_recurring_schedules_valid": {
+          "name": "idx_recurring_schedules_valid",
+          "columns": [
+            {
+              "expression": "valid_from",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "date_ops"
+            },
+            {
+              "expression": "valid_until",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "date_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "recurring_schedules_room_id_fkey": {
+          "name": "recurring_schedules_room_id_fkey",
+          "tableFrom": "recurring_schedules",
+          "tableTo": "rooms",
+          "columnsFrom": [
+            "room_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "recurring_schedules_team_id_fkey": {
+          "name": "recurring_schedules_team_id_fkey",
+          "tableFrom": "recurring_schedules",
+          "tableTo": "teams",
+          "columnsFrom": [
+            "team_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "recurring_schedules_created_by_profile_id_fkey": {
+          "name": "recurring_schedules_created_by_profile_id_fkey",
+          "tableFrom": "recurring_schedules",
+          "tableTo": "profiles",
+          "columnsFrom": [
+            "created_by_profile_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "recurring_schedules_updated_by_profile_id_fkey": {
+          "name": "recurring_schedules_updated_by_profile_id_fkey",
+          "tableFrom": "recurring_schedules",
+          "tableTo": "profiles",
+          "columnsFrom": [
+            "updated_by_profile_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {
+        "Coaches can manage recurring_schedules": {
+          "name": "Coaches can manage recurring_schedules",
+          "as": "PERMISSIVE",
+          "for": "ALL",
+          "to": [
+            "authenticated"
+          ],
+          "using": "(EXISTS ( SELECT 1\n   FROM profiles\n  WHERE ((profiles.user_id IN ( SELECT users.id\n           FROM users\n          WHERE (users.auth_user_id = ( SELECT auth.uid() AS uid)))) AND (profiles.role = ANY (ARRAY['coach'::profile_role, 'admin'::profile_role])))))",
+          "withCheck": "(EXISTS ( SELECT 1\n   FROM profiles\n  WHERE ((profiles.user_id IN ( SELECT users.id\n           FROM users\n          WHERE (users.auth_user_id = ( SELECT auth.uid() AS uid)))) AND (profiles.role = ANY (ARRAY['coach'::profile_role, 'admin'::profile_role])))))"
+        },
+        "Authenticated can read recurring_schedules": {
+          "name": "Authenticated can read recurring_schedules",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": [
+            "authenticated"
+          ],
+          "using": "true"
+        }
+      },
+      "checkConstraints": {
+        "recurring_schedules_day_of_week_check": {
+          "name": "recurring_schedules_day_of_week_check",
+          "value": "(day_of_week >= 0) AND (day_of_week <= 6)"
+        },
+        "valid_time_range": {
+          "name": "valid_time_range",
+          "value": "end_time > start_time"
+        },
+        "valid_schedule_dates": {
+          "name": "valid_schedule_dates",
+          "value": "(valid_until IS NULL) OR (valid_until >= valid_from)"
+        },
+        "recurring_schedules_team_for_ts": {
+          "name": "recurring_schedules_team_for_ts",
+          "value": "(schedule_type <> 'training_session'::schedule_type) OR (team_id IS NOT NULL)"
+        }
+      },
+      "isRLSEnabled": true
+    },
+    "public.reservations": {
+      "name": "reservations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "room_id": {
+          "name": "room_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "owner_profile_id": {
+          "name": "owner_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "person_count": {
+          "name": "person_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "start_at": {
+          "name": "start_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "end_at": {
+          "name": "end_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cancelled_at": {
+          "name": "cancelled_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cancelled_by_profile_id": {
+          "name": "cancelled_by_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_by_profile_id": {
+          "name": "created_by_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_by_profile_id": {
+          "name": "updated_by_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "idx_reservations_room_time": {
+          "name": "idx_reservations_room_time",
+          "columns": [
+            {
+              "expression": "room_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "uuid_ops"
+            },
+            {
+              "expression": "start_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "timestamptz_ops"
+            },
+            {
+              "expression": "end_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "timestamptz_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_reservations_start": {
+          "name": "idx_reservations_start",
+          "columns": [
+            {
+              "expression": "start_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "timestamptz_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_reservations_owner": {
+          "name": "idx_reservations_owner",
+          "columns": [
+            {
+              "expression": "owner_profile_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "uuid_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "reservations_room_id_fkey": {
+          "name": "reservations_room_id_fkey",
+          "tableFrom": "reservations",
+          "tableTo": "rooms",
+          "columnsFrom": [
+            "room_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "reservations_owner_profile_id_fkey": {
+          "name": "reservations_owner_profile_id_fkey",
+          "tableFrom": "reservations",
+          "tableTo": "profiles",
+          "columnsFrom": [
+            "owner_profile_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "reservations_cancelled_by_profile_id_fkey": {
+          "name": "reservations_cancelled_by_profile_id_fkey",
+          "tableFrom": "reservations",
+          "tableTo": "profiles",
+          "columnsFrom": [
+            "cancelled_by_profile_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "reservations_created_by_profile_id_fkey": {
+          "name": "reservations_created_by_profile_id_fkey",
+          "tableFrom": "reservations",
+          "tableTo": "profiles",
+          "columnsFrom": [
+            "created_by_profile_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "reservations_updated_by_profile_id_fkey": {
+          "name": "reservations_updated_by_profile_id_fkey",
+          "tableFrom": "reservations",
+          "tableTo": "profiles",
+          "columnsFrom": [
+            "updated_by_profile_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {
+        "Authenticated can read reservations": {
+          "name": "Authenticated can read reservations",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": [
+            "authenticated"
+          ],
+          "using": "true"
+        },
+        "Users can delete own reservations": {
+          "name": "Users can delete own reservations",
+          "as": "PERMISSIVE",
+          "for": "DELETE",
+          "to": [
+            "authenticated"
+          ],
+          "using": "(owner_profile_id IN ( SELECT profiles.id\n   FROM profiles\n  WHERE (profiles.user_id IN ( SELECT users.id\n           FROM users\n          WHERE (users.auth_user_id = ( SELECT auth.uid() AS uid))))))"
+        },
+        "Users can update own reservations": {
+          "name": "Users can update own reservations",
+          "as": "PERMISSIVE",
+          "for": "UPDATE",
+          "to": [
+            "authenticated"
+          ],
+          "using": "(owner_profile_id IN ( SELECT profiles.id\n   FROM profiles\n  WHERE (profiles.user_id IN ( SELECT users.id\n           FROM users\n          WHERE (users.auth_user_id = ( SELECT auth.uid() AS uid))))))",
+          "withCheck": "(owner_profile_id IN ( SELECT profiles.id\n   FROM profiles\n  WHERE (profiles.user_id IN ( SELECT users.id\n           FROM users\n          WHERE (users.auth_user_id = ( SELECT auth.uid() AS uid))))))"
+        },
+        "Users can create own reservations": {
+          "name": "Users can create own reservations",
+          "as": "PERMISSIVE",
+          "for": "INSERT",
+          "to": [
+            "authenticated"
+          ],
+          "withCheck": "(owner_profile_id IN ( SELECT profiles.id\n   FROM profiles\n  WHERE (profiles.user_id IN ( SELECT users.id\n           FROM users\n          WHERE (users.auth_user_id = ( SELECT auth.uid() AS uid))))))"
+        }
+      },
+      "checkConstraints": {
+        "valid_reservation_time": {
+          "name": "valid_reservation_time",
+          "value": "end_at > start_at"
+        }
+      },
+      "isRLSEnabled": true
+    },
+    "public.rooms": {
+      "name": "rooms",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "code": {
+          "name": "code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "available_days": {
+          "name": "available_days",
+          "type": "integer[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "can_have_ts": {
+          "name": "can_have_ts",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "removed_at": {
+          "name": "removed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_by_profile_id": {
+          "name": "created_by_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_by_profile_id": {
+          "name": "updated_by_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "idx_rooms_code": {
+          "name": "idx_rooms_code",
+          "columns": [
+            {
+              "expression": "code",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "text_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "rooms_created_by_profile_id_fkey": {
+          "name": "rooms_created_by_profile_id_fkey",
+          "tableFrom": "rooms",
+          "tableTo": "profiles",
+          "columnsFrom": [
+            "created_by_profile_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "rooms_updated_by_profile_id_fkey": {
+          "name": "rooms_updated_by_profile_id_fkey",
+          "tableFrom": "rooms",
+          "tableTo": "profiles",
+          "columnsFrom": [
+            "updated_by_profile_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "rooms_code_key": {
+          "name": "rooms_code_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "code"
+          ]
+        }
+      },
+      "policies": {
+        "Admins can manage rooms": {
+          "name": "Admins can manage rooms",
+          "as": "PERMISSIVE",
+          "for": "ALL",
+          "to": [
+            "authenticated"
+          ],
+          "using": "(EXISTS ( SELECT 1\n   FROM profiles\n  WHERE ((profiles.user_id IN ( SELECT users.id\n           FROM users\n          WHERE (users.auth_user_id = ( SELECT auth.uid() AS uid)))) AND (profiles.role = 'admin'::profile_role))))",
+          "withCheck": "(EXISTS ( SELECT 1\n   FROM profiles\n  WHERE ((profiles.user_id IN ( SELECT users.id\n           FROM users\n          WHERE (users.auth_user_id = ( SELECT auth.uid() AS uid)))) AND (profiles.role = 'admin'::profile_role))))"
+        },
+        "Authenticated can read rooms": {
+          "name": "Authenticated can read rooms",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": [
+            "authenticated"
+          ],
+          "using": "true"
+        }
+      },
+      "checkConstraints": {},
+      "isRLSEnabled": true
+    },
+    "public.schedule_breaks": {
+      "name": "schedule_breaks",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "start_date": {
+          "name": "start_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "end_date": {
+          "name": "end_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_by_profile_id": {
+          "name": "created_by_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_by_profile_id": {
+          "name": "updated_by_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "idx_schedule_breaks_dates": {
+          "name": "idx_schedule_breaks_dates",
+          "columns": [
+            {
+              "expression": "start_date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "date_ops"
+            },
+            {
+              "expression": "end_date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "date_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "schedule_breaks_created_by_profile_id_fkey": {
+          "name": "schedule_breaks_created_by_profile_id_fkey",
+          "tableFrom": "schedule_breaks",
+          "tableTo": "profiles",
+          "columnsFrom": [
+            "created_by_profile_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "schedule_breaks_updated_by_profile_id_fkey": {
+          "name": "schedule_breaks_updated_by_profile_id_fkey",
+          "tableFrom": "schedule_breaks",
+          "tableTo": "profiles",
+          "columnsFrom": [
+            "updated_by_profile_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {
+        "Coaches can manage schedule_breaks": {
+          "name": "Coaches can manage schedule_breaks",
+          "as": "PERMISSIVE",
+          "for": "ALL",
+          "to": [
+            "authenticated"
+          ],
+          "using": "(EXISTS ( SELECT 1\n   FROM profiles\n  WHERE ((profiles.user_id IN ( SELECT users.id\n           FROM users\n          WHERE (users.auth_user_id = ( SELECT auth.uid() AS uid)))) AND (profiles.role = ANY (ARRAY['coach'::profile_role, 'admin'::profile_role])))))",
+          "withCheck": "(EXISTS ( SELECT 1\n   FROM profiles\n  WHERE ((profiles.user_id IN ( SELECT users.id\n           FROM users\n          WHERE (users.auth_user_id = ( SELECT auth.uid() AS uid)))) AND (profiles.role = ANY (ARRAY['coach'::profile_role, 'admin'::profile_role])))))"
+        },
+        "Authenticated can read schedule_breaks": {
+          "name": "Authenticated can read schedule_breaks",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": [
+            "authenticated"
+          ],
+          "using": "true"
+        }
+      },
+      "checkConstraints": {
+        "valid_break_date_range": {
+          "name": "valid_break_date_range",
+          "value": "end_date >= start_date"
+        }
+      },
+      "isRLSEnabled": true
+    },
+    "public.team_activities": {
+      "name": "team_activities",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "occurred_at": {
+          "name": "occurred_at",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "activity_type": {
+          "name": "activity_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "participants": {
+          "name": "participants",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reflection": {
+          "name": "reflection",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "image_path": {
+          "name": "image_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "removed_at": {
+          "name": "removed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_by_profile_id": {
+          "name": "created_by_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_by_profile_id": {
+          "name": "updated_by_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "team_activities_team_occurred_at_idx": {
+          "name": "team_activities_team_occurred_at_idx",
+          "columns": [
+            {
+              "expression": "team_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "uuid_ops"
+            },
+            {
+              "expression": "occurred_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "date_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "team_activities_team_id_fkey": {
+          "name": "team_activities_team_id_fkey",
+          "tableFrom": "team_activities",
+          "tableTo": "teams",
+          "columnsFrom": [
+            "team_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "team_activities_created_by_profile_id_fkey": {
+          "name": "team_activities_created_by_profile_id_fkey",
+          "tableFrom": "team_activities",
+          "tableTo": "profiles",
+          "columnsFrom": [
+            "created_by_profile_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "team_activities_updated_by_profile_id_fkey": {
+          "name": "team_activities_updated_by_profile_id_fkey",
+          "tableFrom": "team_activities",
+          "tableTo": "profiles",
+          "columnsFrom": [
+            "updated_by_profile_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {
+        "Team members can view activities": {
+          "name": "Team members can view activities",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": [
+            "authenticated"
+          ],
+          "using": "team_id IN (SELECT team_id FROM profiles WHERE id = current_profile_id() AND access_removed_at IS NULL)"
+        },
+        "Team members can create activities": {
+          "name": "Team members can create activities",
+          "as": "PERMISSIVE",
+          "for": "INSERT",
+          "to": [
+            "authenticated"
+          ],
+          "withCheck": "team_id IN (SELECT team_id FROM profiles WHERE id = current_profile_id() AND access_removed_at IS NULL)"
+        },
+        "Team members can update activities": {
+          "name": "Team members can update activities",
+          "as": "PERMISSIVE",
+          "for": "UPDATE",
+          "to": [
+            "authenticated"
+          ],
+          "using": "team_id IN (SELECT team_id FROM profiles WHERE id = current_profile_id() AND access_removed_at IS NULL)",
+          "withCheck": "team_id IN (SELECT team_id FROM profiles WHERE id = current_profile_id() AND access_removed_at IS NULL)"
+        },
+        "Team members can delete activities": {
+          "name": "Team members can delete activities",
+          "as": "PERMISSIVE",
+          "for": "DELETE",
+          "to": [
+            "authenticated"
+          ],
+          "using": "team_id IN (SELECT team_id FROM profiles WHERE id = current_profile_id() AND access_removed_at IS NULL)"
+        }
+      },
+      "checkConstraints": {},
+      "isRLSEnabled": true
+    },
+    "public.team_activity_attendees": {
+      "name": "team_activity_attendees",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "activity_id": {
+          "name": "activity_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "profile_id": {
+          "name": "profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "attendance_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'present'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_by_profile_id": {
+          "name": "created_by_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_by_profile_id": {
+          "name": "updated_by_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "team_activity_attendees_activity_idx": {
+          "name": "team_activity_attendees_activity_idx",
+          "columns": [
+            {
+              "expression": "activity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "uuid_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "team_activity_attendees_profile_idx": {
+          "name": "team_activity_attendees_profile_idx",
+          "columns": [
+            {
+              "expression": "profile_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "uuid_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "team_activity_attendees_activity_id_fkey": {
+          "name": "team_activity_attendees_activity_id_fkey",
+          "tableFrom": "team_activity_attendees",
+          "tableTo": "team_activities",
+          "columnsFrom": [
+            "activity_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "team_activity_attendees_profile_id_fkey": {
+          "name": "team_activity_attendees_profile_id_fkey",
+          "tableFrom": "team_activity_attendees",
+          "tableTo": "profiles",
+          "columnsFrom": [
+            "profile_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "team_activity_attendees_created_by_profile_id_fkey": {
+          "name": "team_activity_attendees_created_by_profile_id_fkey",
+          "tableFrom": "team_activity_attendees",
+          "tableTo": "profiles",
+          "columnsFrom": [
+            "created_by_profile_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "team_activity_attendees_updated_by_profile_id_fkey": {
+          "name": "team_activity_attendees_updated_by_profile_id_fkey",
+          "tableFrom": "team_activity_attendees",
+          "tableTo": "profiles",
+          "columnsFrom": [
+            "updated_by_profile_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "team_activity_attendees_activity_profile_key": {
+          "name": "team_activity_attendees_activity_profile_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "activity_id",
+            "profile_id"
+          ]
+        }
+      },
+      "policies": {
+        "Team members can view activity attendees": {
+          "name": "Team members can view activity attendees",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": [
+            "authenticated"
+          ],
+          "using": "activity_id IN (SELECT id FROM team_activities WHERE team_id IN (SELECT team_id FROM profiles WHERE id = current_profile_id() AND access_removed_at IS NULL))"
+        },
+        "Team members can create activity attendees": {
+          "name": "Team members can create activity attendees",
+          "as": "PERMISSIVE",
+          "for": "INSERT",
+          "to": [
+            "authenticated"
+          ],
+          "withCheck": "activity_id IN (SELECT id FROM team_activities WHERE team_id IN (SELECT team_id FROM profiles WHERE id = current_profile_id() AND access_removed_at IS NULL))"
+        },
+        "Team members can update activity attendees": {
+          "name": "Team members can update activity attendees",
+          "as": "PERMISSIVE",
+          "for": "UPDATE",
+          "to": [
+            "authenticated"
+          ],
+          "using": "activity_id IN (SELECT id FROM team_activities WHERE team_id IN (SELECT team_id FROM profiles WHERE id = current_profile_id() AND access_removed_at IS NULL))",
+          "withCheck": "activity_id IN (SELECT id FROM team_activities WHERE team_id IN (SELECT team_id FROM profiles WHERE id = current_profile_id() AND access_removed_at IS NULL))"
+        },
+        "Team members can delete activity attendees": {
+          "name": "Team members can delete activity attendees",
+          "as": "PERMISSIVE",
+          "for": "DELETE",
+          "to": [
+            "authenticated"
+          ],
+          "using": "activity_id IN (SELECT id FROM team_activities WHERE team_id IN (SELECT team_id FROM profiles WHERE id = current_profile_id() AND access_removed_at IS NULL))"
+        }
+      },
+      "checkConstraints": {},
+      "isRLSEnabled": true
+    },
+    "public.team_annual_reflection_entries": {
+      "name": "team_annual_reflection_entries",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "annual_reflection_id": {
+          "name": "annual_reflection_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "topic": {
+          "name": "topic",
+          "type": "annual_reflection_topic",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "what_went_well": {
+          "name": "what_went_well",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "what_didnt_go_well": {
+          "name": "what_didnt_go_well",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "what_next_time": {
+          "name": "what_next_time",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_by_profile_id": {
+          "name": "updated_by_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "team_annual_reflection_entries_reflection_topic_idx": {
+          "name": "team_annual_reflection_entries_reflection_topic_idx",
+          "columns": [
+            {
+              "expression": "annual_reflection_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "uuid_ops"
+            },
+            {
+              "expression": "topic",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "enum_ops"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "team_annual_reflection_entries_reflection_idx": {
+          "name": "team_annual_reflection_entries_reflection_idx",
+          "columns": [
+            {
+              "expression": "annual_reflection_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "uuid_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "team_annual_reflection_entries_annual_reflection_id_fkey": {
+          "name": "team_annual_reflection_entries_annual_reflection_id_fkey",
+          "tableFrom": "team_annual_reflection_entries",
+          "tableTo": "team_annual_reflections",
+          "columnsFrom": [
+            "annual_reflection_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "team_annual_reflection_entries_updated_by_profile_id_fkey": {
+          "name": "team_annual_reflection_entries_updated_by_profile_id_fkey",
+          "tableFrom": "team_annual_reflection_entries",
+          "tableTo": "profiles",
+          "columnsFrom": [
+            "updated_by_profile_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {
+        "Team members can view annual reflection entries": {
+          "name": "Team members can view annual reflection entries",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": [
+            "authenticated"
+          ],
+          "using": "annual_reflection_id IN (SELECT id FROM team_annual_reflections WHERE team_id IN (SELECT team_id FROM profiles WHERE id = current_profile_id() AND access_removed_at IS NULL))"
+        },
+        "Team members can create annual reflection entries": {
+          "name": "Team members can create annual reflection entries",
+          "as": "PERMISSIVE",
+          "for": "INSERT",
+          "to": [
+            "authenticated"
+          ],
+          "withCheck": "annual_reflection_id IN (SELECT id FROM team_annual_reflections WHERE team_id IN (SELECT team_id FROM profiles WHERE id = current_profile_id() AND access_removed_at IS NULL))"
+        },
+        "Team members can update annual reflection entries": {
+          "name": "Team members can update annual reflection entries",
+          "as": "PERMISSIVE",
+          "for": "UPDATE",
+          "to": [
+            "authenticated"
+          ],
+          "using": "annual_reflection_id IN (SELECT id FROM team_annual_reflections WHERE team_id IN (SELECT team_id FROM profiles WHERE id = current_profile_id() AND access_removed_at IS NULL))",
+          "withCheck": "annual_reflection_id IN (SELECT id FROM team_annual_reflections WHERE team_id IN (SELECT team_id FROM profiles WHERE id = current_profile_id() AND access_removed_at IS NULL))"
+        },
+        "Team members can delete annual reflection entries": {
+          "name": "Team members can delete annual reflection entries",
+          "as": "PERMISSIVE",
+          "for": "DELETE",
+          "to": [
+            "authenticated"
+          ],
+          "using": "annual_reflection_id IN (SELECT id FROM team_annual_reflections WHERE team_id IN (SELECT team_id FROM profiles WHERE id = current_profile_id() AND access_removed_at IS NULL))"
+        }
+      },
+      "checkConstraints": {},
+      "isRLSEnabled": true
+    },
+    "public.team_annual_reflections": {
+      "name": "team_annual_reflections",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reflection_month": {
+          "name": "reflection_month",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "removed_at": {
+          "name": "removed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_by_profile_id": {
+          "name": "created_by_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_by_profile_id": {
+          "name": "updated_by_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "team_annual_reflections_team_month_idx": {
+          "name": "team_annual_reflections_team_month_idx",
+          "columns": [
+            {
+              "expression": "team_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "uuid_ops"
+            },
+            {
+              "expression": "reflection_month",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "date_ops"
+            }
+          ],
+          "isUnique": true,
+          "where": "(removed_at IS NULL)",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "team_annual_reflections_team_id_fkey": {
+          "name": "team_annual_reflections_team_id_fkey",
+          "tableFrom": "team_annual_reflections",
+          "tableTo": "teams",
+          "columnsFrom": [
+            "team_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "team_annual_reflections_created_by_profile_id_fkey": {
+          "name": "team_annual_reflections_created_by_profile_id_fkey",
+          "tableFrom": "team_annual_reflections",
+          "tableTo": "profiles",
+          "columnsFrom": [
+            "created_by_profile_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "team_annual_reflections_updated_by_profile_id_fkey": {
+          "name": "team_annual_reflections_updated_by_profile_id_fkey",
+          "tableFrom": "team_annual_reflections",
+          "tableTo": "profiles",
+          "columnsFrom": [
+            "updated_by_profile_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {
+        "Team members can view annual reflections": {
+          "name": "Team members can view annual reflections",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": [
+            "authenticated"
+          ],
+          "using": "team_id IN (SELECT team_id FROM profiles WHERE id = current_profile_id() AND access_removed_at IS NULL)"
+        },
+        "Team members can create annual reflections": {
+          "name": "Team members can create annual reflections",
+          "as": "PERMISSIVE",
+          "for": "INSERT",
+          "to": [
+            "authenticated"
+          ],
+          "withCheck": "team_id IN (SELECT team_id FROM profiles WHERE id = current_profile_id() AND access_removed_at IS NULL)"
+        },
+        "Team members can update annual reflections": {
+          "name": "Team members can update annual reflections",
+          "as": "PERMISSIVE",
+          "for": "UPDATE",
+          "to": [
+            "authenticated"
+          ],
+          "using": "team_id IN (SELECT team_id FROM profiles WHERE id = current_profile_id() AND access_removed_at IS NULL)",
+          "withCheck": "team_id IN (SELECT team_id FROM profiles WHERE id = current_profile_id() AND access_removed_at IS NULL)"
+        },
+        "Team members can delete annual reflections": {
+          "name": "Team members can delete annual reflections",
+          "as": "PERMISSIVE",
+          "for": "DELETE",
+          "to": [
+            "authenticated"
+          ],
+          "using": "team_id IN (SELECT team_id FROM profiles WHERE id = current_profile_id() AND access_removed_at IS NULL)"
+        }
+      },
+      "checkConstraints": {
+        "team_annual_reflections_month_check": {
+          "name": "team_annual_reflections_month_check",
+          "value": "EXTRACT(MONTH FROM reflection_month) = 5"
+        }
+      },
+      "isRLSEnabled": true
+    },
+    "public.team_document_versions": {
+      "name": "team_document_versions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "document_id": {
+          "name": "document_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "version_no": {
+          "name": "version_no",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "file_path": {
+          "name": "file_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "file_name": {
+          "name": "file_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "file_size": {
+          "name": "file_size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "effective_from": {
+          "name": "effective_from",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "change_note": {
+          "name": "change_note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_by_profile_id": {
+          "name": "created_by_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "team_document_versions_document_version_idx": {
+          "name": "team_document_versions_document_version_idx",
+          "columns": [
+            {
+              "expression": "document_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "uuid_ops"
+            },
+            {
+              "expression": "version_no",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "int4_ops"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "team_document_versions_document_id_fkey": {
+          "name": "team_document_versions_document_id_fkey",
+          "tableFrom": "team_document_versions",
+          "tableTo": "team_documents",
+          "columnsFrom": [
+            "document_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "team_document_versions_created_by_profile_id_fkey": {
+          "name": "team_document_versions_created_by_profile_id_fkey",
+          "tableFrom": "team_document_versions",
+          "tableTo": "profiles",
+          "columnsFrom": [
+            "created_by_profile_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {
+        "Team members can view document versions": {
+          "name": "Team members can view document versions",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": [
+            "authenticated"
+          ],
+          "using": "document_id IN (\n\t\t\tSELECT team_documents.id\n\t\t\tFROM team_documents\n\t\t\tWHERE team_documents.team_id IN (\n\t\t\t\tSELECT team_id FROM profiles WHERE id = current_profile_id() AND access_removed_at IS NULL\n\t\t\t)\n\t\t)"
+        },
+        "Team members can create document versions": {
+          "name": "Team members can create document versions",
+          "as": "PERMISSIVE",
+          "for": "INSERT",
+          "to": [
+            "authenticated"
+          ],
+          "withCheck": "created_by_profile_id = current_profile_id() AND document_id IN (\n\t\t\tSELECT team_documents.id\n\t\t\tFROM team_documents\n\t\t\tWHERE team_documents.removed_at IS NULL\n\t\t\t\tAND team_documents.team_id IN (\n\t\t\t\t\tSELECT team_id FROM profiles WHERE id = current_profile_id() AND access_removed_at IS NULL\n\t\t\t\t)\n\t\t)"
+        }
+      },
+      "checkConstraints": {
+        "team_document_versions_version_positive": {
+          "name": "team_document_versions_version_positive",
+          "value": "version_no > 0"
+        },
+        "team_document_versions_file_size_positive": {
+          "name": "team_document_versions_file_size_positive",
+          "value": "file_size > 0"
+        }
+      },
+      "isRLSEnabled": true
+    },
+    "public.team_documents": {
+      "name": "team_documents",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "doc_type": {
+          "name": "doc_type",
+          "type": "team_document_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "removed_at": {
+          "name": "removed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_by_profile_id": {
+          "name": "created_by_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_by_profile_id": {
+          "name": "updated_by_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "team_documents_featured_team_type_idx": {
+          "name": "team_documents_featured_team_type_idx",
+          "columns": [
+            {
+              "expression": "team_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "uuid_ops"
+            },
+            {
+              "expression": "doc_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "enum_ops"
+            }
+          ],
+          "isUnique": true,
+          "where": "doc_type IN ('team_contract', 'financial_policy') AND removed_at IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "team_documents_team_id_fkey": {
+          "name": "team_documents_team_id_fkey",
+          "tableFrom": "team_documents",
+          "tableTo": "teams",
+          "columnsFrom": [
+            "team_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "team_documents_created_by_profile_id_fkey": {
+          "name": "team_documents_created_by_profile_id_fkey",
+          "tableFrom": "team_documents",
+          "tableTo": "profiles",
+          "columnsFrom": [
+            "created_by_profile_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "team_documents_updated_by_profile_id_fkey": {
+          "name": "team_documents_updated_by_profile_id_fkey",
+          "tableFrom": "team_documents",
+          "tableTo": "profiles",
+          "columnsFrom": [
+            "updated_by_profile_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {
+        "Team members can view documents": {
+          "name": "Team members can view documents",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": [
+            "authenticated"
+          ],
+          "using": "team_id IN (SELECT team_id FROM profiles WHERE id = current_profile_id() AND access_removed_at IS NULL)"
+        },
+        "Team members can create documents": {
+          "name": "Team members can create documents",
+          "as": "PERMISSIVE",
+          "for": "INSERT",
+          "to": [
+            "authenticated"
+          ],
+          "withCheck": "team_id IN (SELECT team_id FROM profiles WHERE id = current_profile_id() AND access_removed_at IS NULL) AND created_by_profile_id = current_profile_id() AND updated_by_profile_id = current_profile_id()"
+        },
+        "Team members can update custom documents": {
+          "name": "Team members can update custom documents",
+          "as": "PERMISSIVE",
+          "for": "UPDATE",
+          "to": [
+            "authenticated"
+          ],
+          "using": "doc_type = 'other' AND team_id IN (SELECT team_id FROM profiles WHERE id = current_profile_id() AND access_removed_at IS NULL)",
+          "withCheck": "doc_type = 'other' AND team_id IN (SELECT team_id FROM profiles WHERE id = current_profile_id() AND access_removed_at IS NULL) AND updated_by_profile_id = current_profile_id()"
+        }
+      },
+      "checkConstraints": {
+        "team_documents_title_matches_type": {
+          "name": "team_documents_title_matches_type",
+          "value": "(\n\t\t(doc_type = 'other' AND title IS NOT NULL AND length(trim(title)) > 0)\n\t\tOR (doc_type <> 'other' AND title IS NULL)\n\t)"
+        }
+      },
+      "isRLSEnabled": true
+    },
+    "public.team_reflection_action_steps": {
+      "name": "team_reflection_action_steps",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "team_reflection_id": {
+          "name": "team_reflection_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "assignee_profile_id": {
+          "name": "assignee_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "custom_assignee": {
+          "name": "custom_assignee",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "order_index": {
+          "name": "order_index",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "removed_at": {
+          "name": "removed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_by_profile_id": {
+          "name": "created_by_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "team_reflection_action_steps_reflection_idx": {
+          "name": "team_reflection_action_steps_reflection_idx",
+          "columns": [
+            {
+              "expression": "team_reflection_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "uuid_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "team_reflection_action_steps_team_reflection_id_fkey": {
+          "name": "team_reflection_action_steps_team_reflection_id_fkey",
+          "tableFrom": "team_reflection_action_steps",
+          "tableTo": "team_reflections",
+          "columnsFrom": [
+            "team_reflection_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "team_reflection_action_steps_assignee_profile_id_fkey": {
+          "name": "team_reflection_action_steps_assignee_profile_id_fkey",
+          "tableFrom": "team_reflection_action_steps",
+          "tableTo": "profiles",
+          "columnsFrom": [
+            "assignee_profile_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "team_reflection_action_steps_created_by_profile_id_fkey": {
+          "name": "team_reflection_action_steps_created_by_profile_id_fkey",
+          "tableFrom": "team_reflection_action_steps",
+          "tableTo": "profiles",
+          "columnsFrom": [
+            "created_by_profile_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {
+        "Team members can view action steps": {
+          "name": "Team members can view action steps",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": [
+            "authenticated"
+          ],
+          "using": "team_reflection_id IN (SELECT id FROM team_reflections WHERE team_id IN (SELECT team_id FROM profiles WHERE id = current_profile_id() AND access_removed_at IS NULL))"
+        },
+        "Team members can create action steps": {
+          "name": "Team members can create action steps",
+          "as": "PERMISSIVE",
+          "for": "INSERT",
+          "to": [
+            "authenticated"
+          ],
+          "withCheck": "team_reflection_id IN (SELECT id FROM team_reflections WHERE team_id IN (SELECT team_id FROM profiles WHERE id = current_profile_id() AND access_removed_at IS NULL))"
+        },
+        "Team members can update action steps": {
+          "name": "Team members can update action steps",
+          "as": "PERMISSIVE",
+          "for": "UPDATE",
+          "to": [
+            "authenticated"
+          ],
+          "using": "team_reflection_id IN (SELECT id FROM team_reflections WHERE team_id IN (SELECT team_id FROM profiles WHERE id = current_profile_id() AND access_removed_at IS NULL))",
+          "withCheck": "team_reflection_id IN (SELECT id FROM team_reflections WHERE team_id IN (SELECT team_id FROM profiles WHERE id = current_profile_id() AND access_removed_at IS NULL))"
+        },
+        "Team members can delete action steps": {
+          "name": "Team members can delete action steps",
+          "as": "PERMISSIVE",
+          "for": "DELETE",
+          "to": [
+            "authenticated"
+          ],
+          "using": "team_reflection_id IN (SELECT id FROM team_reflections WHERE team_id IN (SELECT team_id FROM profiles WHERE id = current_profile_id() AND access_removed_at IS NULL))"
+        }
+      },
+      "checkConstraints": {},
+      "isRLSEnabled": true
+    },
+    "public.team_reflections": {
+      "name": "team_reflections",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "month": {
+          "name": "month",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "what_went_well": {
+          "name": "what_went_well",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "what_didnt_go_well": {
+          "name": "what_didnt_go_well",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "what_we_do_differently": {
+          "name": "what_we_do_differently",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "planned_action_steps": {
+          "name": "planned_action_steps",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "responsible_person": {
+          "name": "responsible_person",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "removed_at": {
+          "name": "removed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_by_profile_id": {
+          "name": "created_by_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_by_profile_id": {
+          "name": "updated_by_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "team_reflections_team_month_idx": {
+          "name": "team_reflections_team_month_idx",
+          "columns": [
+            {
+              "expression": "team_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "uuid_ops"
+            },
+            {
+              "expression": "month",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "date_ops"
+            }
+          ],
+          "isUnique": true,
+          "where": "(removed_at IS NULL)",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "team_reflections_team_id_fkey": {
+          "name": "team_reflections_team_id_fkey",
+          "tableFrom": "team_reflections",
+          "tableTo": "teams",
+          "columnsFrom": [
+            "team_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "team_reflections_created_by_profile_id_fkey": {
+          "name": "team_reflections_created_by_profile_id_fkey",
+          "tableFrom": "team_reflections",
+          "tableTo": "profiles",
+          "columnsFrom": [
+            "created_by_profile_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "team_reflections_updated_by_profile_id_fkey": {
+          "name": "team_reflections_updated_by_profile_id_fkey",
+          "tableFrom": "team_reflections",
+          "tableTo": "profiles",
+          "columnsFrom": [
+            "updated_by_profile_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {
+        "Team members can view reflections": {
+          "name": "Team members can view reflections",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": [
+            "authenticated"
+          ],
+          "using": "team_id IN (SELECT team_id FROM profiles WHERE id = current_profile_id() AND access_removed_at IS NULL)"
+        },
+        "Team members can create reflections": {
+          "name": "Team members can create reflections",
+          "as": "PERMISSIVE",
+          "for": "INSERT",
+          "to": [
+            "authenticated"
+          ],
+          "withCheck": "team_id IN (SELECT team_id FROM profiles WHERE id = current_profile_id() AND access_removed_at IS NULL)"
+        },
+        "Team members can update reflections": {
+          "name": "Team members can update reflections",
+          "as": "PERMISSIVE",
+          "for": "UPDATE",
+          "to": [
+            "authenticated"
+          ],
+          "using": "team_id IN (SELECT team_id FROM profiles WHERE id = current_profile_id() AND access_removed_at IS NULL)",
+          "withCheck": "team_id IN (SELECT team_id FROM profiles WHERE id = current_profile_id() AND access_removed_at IS NULL)"
+        },
+        "Team members can delete reflections": {
+          "name": "Team members can delete reflections",
+          "as": "PERMISSIVE",
+          "for": "DELETE",
+          "to": [
+            "authenticated"
+          ],
+          "using": "team_id IN (SELECT team_id FROM profiles WHERE id = current_profile_id() AND access_removed_at IS NULL)"
+        }
+      },
+      "checkConstraints": {},
+      "isRLSEnabled": true
+    },
+    "public.teams": {
+      "name": "teams",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "picture": {
+          "name": "picture",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "color": {
+          "name": "color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "onboardingYear": {
+          "name": "onboardingYear",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "removed_at": {
+          "name": "removed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_by_profile_id": {
+          "name": "created_by_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_by_profile_id": {
+          "name": "updated_by_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {
+        "Authenticated users can read teams": {
+          "name": "Authenticated users can read teams",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": [
+            "authenticated"
+          ],
+          "using": "true"
+        }
+      },
+      "checkConstraints": {},
+      "isRLSEnabled": true
+    },
+    "public.tools_techniques": {
+      "name": "tools_techniques",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "profile_id": {
+          "name": "profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tool_type": {
+          "name": "tool_type",
+          "type": "tool_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reflection": {
+          "name": "reflection",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "removed_at": {
+          "name": "removed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_by_profile_id": {
+          "name": "created_by_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_by_profile_id": {
+          "name": "updated_by_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "tools_techniques_profile_idx": {
+          "name": "tools_techniques_profile_idx",
+          "columns": [
+            {
+              "expression": "profile_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "uuid_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "tools_techniques_profile_id_fkey": {
+          "name": "tools_techniques_profile_id_fkey",
+          "tableFrom": "tools_techniques",
+          "tableTo": "profiles",
+          "columnsFrom": [
+            "profile_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "tools_techniques_created_by_profile_id_fkey": {
+          "name": "tools_techniques_created_by_profile_id_fkey",
+          "tableFrom": "tools_techniques",
+          "tableTo": "profiles",
+          "columnsFrom": [
+            "created_by_profile_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "tools_techniques_updated_by_profile_id_fkey": {
+          "name": "tools_techniques_updated_by_profile_id_fkey",
+          "tableFrom": "tools_techniques",
+          "tableTo": "profiles",
+          "columnsFrom": [
+            "updated_by_profile_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {
+        "Users can view their own tools and techniques": {
+          "name": "Users can view their own tools and techniques",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": [
+            "authenticated"
+          ],
+          "using": "(profile_id = current_profile_id())"
+        },
+        "Users can create their own tools and techniques": {
+          "name": "Users can create their own tools and techniques",
+          "as": "PERMISSIVE",
+          "for": "INSERT",
+          "to": [
+            "authenticated"
+          ],
+          "withCheck": "(profile_id = current_profile_id())"
+        },
+        "Users can update their own tools and techniques": {
+          "name": "Users can update their own tools and techniques",
+          "as": "PERMISSIVE",
+          "for": "UPDATE",
+          "to": [
+            "authenticated"
+          ],
+          "using": "(profile_id = current_profile_id())",
+          "withCheck": "(profile_id = current_profile_id())"
+        },
+        "Users can delete their own tools and techniques": {
+          "name": "Users can delete their own tools and techniques",
+          "as": "PERMISSIVE",
+          "for": "DELETE",
+          "to": [
+            "authenticated"
+          ],
+          "using": "(profile_id = current_profile_id())"
+        }
+      },
+      "checkConstraints": {},
+      "isRLSEnabled": true
+    }
+  },
+  "enums": {
+    "public.birth_giving_assignment_state": {
+      "name": "birth_giving_assignment_state",
+      "schema": "public",
+      "values": [
+        "present",
+        "missing",
+        "none"
+      ]
+    },
+    "public.birth_giving_duration": {
+      "name": "birth_giving_duration",
+      "schema": "public",
+      "values": [
+        "8h",
+        "24h"
+      ]
+    },
+    "public.birth_giving_event_status": {
+      "name": "birth_giving_event_status",
+      "schema": "public",
+      "values": [
+        "draft",
+        "published"
+      ]
+    },
+    "public.birth_giving_team_result_state": {
+      "name": "birth_giving_team_result_state",
+      "schema": "public",
+      "values": [
+        "pending",
+        "present",
+        "missing"
+      ]
+    },
+    "public.book_list_status": {
+      "name": "book_list_status",
+      "schema": "public",
+      "values": [
+        "processing",
+        "shortlist",
+        "longlist",
+        "archived"
+      ]
+    },
+    "public.book_source": {
+      "name": "book_source",
+      "schema": "public",
+      "values": [
+        "manual",
+        "google_books",
+        "open_library"
+      ]
+    },
+    "public.content_source_kind": {
+      "name": "content_source_kind",
+      "schema": "public",
+      "values": [
+        "podcast",
+        "conference",
+        "program",
+        "other"
+      ]
+    },
+    "public.content_source_status": {
+      "name": "content_source_status",
+      "schema": "public",
+      "values": [
+        "pending_review",
+        "approved",
+        "archived"
+      ]
+    },
+    "public.personality_test_type": {
+      "name": "personality_test_type",
+      "schema": "public",
+      "values": [
+        "gallup",
+        "mbti",
+        "disc",
+        "big_five",
+        "enneagram",
+        "belbin",
+        "other"
+      ]
+    },
+    "public.beta_cohort": {
+      "name": "beta_cohort",
+      "schema": "public",
+      "values": [
+        "A",
+        "B"
+      ]
+    },
+    "public.profile_role": {
+      "name": "profile_role",
+      "schema": "public",
+      "values": [
+        "student",
+        "mentor",
+        "coach",
+        "admin"
+      ]
+    },
+    "public.schedule_type": {
+      "name": "schedule_type",
+      "schema": "public",
+      "values": [
+        "training_session",
+        "houston_calling"
+      ]
+    },
+    "public.attendance_status": {
+      "name": "attendance_status",
+      "schema": "public",
+      "values": [
+        "present",
+        "absent",
+        "excused",
+        "late"
+      ]
+    },
+    "public.annual_reflection_topic": {
+      "name": "annual_reflection_topic",
+      "schema": "public",
+      "values": [
+        "predmety_zkousky_vyucujici",
+        "metodika_a_metriky",
+        "kouci_a_mentori",
+        "tymy_a_tymove_spolecnosti",
+        "individualni_prinos",
+        "komunita",
+        "komunitni_role",
+        "komunitni_akce",
+        "komunitni_a_cross_projekty",
+        "zacleneni_tucnaku",
+        "dalsi"
+      ]
+    },
+    "public.team_document_type": {
+      "name": "team_document_type",
+      "schema": "public",
+      "values": [
+        "team_contract",
+        "financial_policy",
+        "other"
+      ]
+    },
+    "public.tool_type": {
+      "name": "tool_type",
+      "schema": "public",
+      "values": [
+        "model",
+        "technique",
+        "tool"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {
+    "public.books_with_essay_count": {
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "title_cs": {
+          "name": "title_cs",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "title_en": {
+          "name": "title_en",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "author": {
+          "name": "author",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "isbn_13": {
+          "name": "isbn_13",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "google_books_cover_url": {
+          "name": "google_books_cover_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "book_points": {
+          "name": "book_points",
+          "type": "numeric(3, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "page_count": {
+          "name": "page_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "preview_link": {
+          "name": "preview_link",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source": {
+          "name": "source",
+          "type": "book_source",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "external_id": {
+          "name": "external_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "list_status": {
+          "name": "list_status",
+          "type": "book_list_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "list_status_changed_at": {
+          "name": "list_status_changed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "list_status_changed_by_profile_id": {
+          "name": "list_status_changed_by_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "list_status_reason": {
+          "name": "list_status_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "highlight_category_id": {
+          "name": "highlight_category_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_rocket_model": {
+          "name": "is_rocket_model",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by_profile_id": {
+          "name": "created_by_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_by_profile_id": {
+          "name": "updated_by_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "essay_count": {
+          "name": "essay_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "definition": "SELECT b.id, b.title_cs, b.title_en, b.author, b.isbn_13, b.description, b.google_books_cover_url, b.book_points, b.page_count, b.preview_link, b.source, b.external_id, b.list_status, b.list_status_changed_at, b.list_status_changed_by_profile_id, b.list_status_reason, b.highlight_category_id, b.is_rocket_model, b.created_at, b.updated_at, b.created_by_profile_id, b.updated_by_profile_id, COALESCE(ec.essay_count, 0) AS essay_count FROM books b LEFT JOIN ( SELECT essays.book_id, count(*)::integer AS essay_count FROM essays WHERE essays.book_id IS NOT NULL AND essays.published_at IS NOT NULL AND essays.removed_at IS NULL GROUP BY essays.book_id) ec ON ec.book_id = b.id",
+      "name": "books_with_essay_count",
+      "schema": "public",
+      "isExisting": false,
+      "materialized": false
+    }
+  },
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/supabase/migrations/meta/_journal.json
+++ b/supabase/migrations/meta/_journal.json
@@ -764,6 +764,13 @@
       "when": 1788379482531,
       "tag": "20260902200442_giant_bloodaxe",
       "breakpoints": true
+    },
+    {
+      "idx": 109,
+      "version": "7",
+      "when": 1788391573490,
+      "tag": "20260902232613_library_copy_label_codes",
+      "breakpoints": true
     }
   ]
 }

--- a/tests/e2e/essay-save.spec.ts
+++ b/tests/e2e/essay-save.spec.ts
@@ -79,6 +79,22 @@ test.describe("essay manual save and auto-publish", () => {
 
     const essayId = new URL(page.url()).pathname.split("/").at(-2);
 
+    // Asserted on the row itself, not just on the list: everything that shows
+    // an essay or counts its book points keys off published_at, so the very
+    // first save of a titled essay has to stamp it.
+    const rows = await fetch(
+      `${process.env.NEXT_PUBLIC_SUPABASE_URL}/rest/v1/essays` +
+        `?id=eq.${essayId}&select=id,published_at`,
+      {
+        headers: {
+          apikey: process.env.SUPABASE_SERVICE_ROLE_KEY!,
+          Authorization: `Bearer ${process.env.SUPABASE_SERVICE_ROLE_KEY}`,
+        },
+      },
+    ).then((res) => res.json());
+    expect(rows).toHaveLength(1);
+    expect(rows[0].published_at).not.toBeNull();
+
     await page.goto("/cteni/prehled");
     await expect(page.getByRole("link", { name: new RegExp(VISIBILITY_TITLE) })).toBeVisible();
     // Reading it directly (not via "continue editing") confirms it's a normal,

--- a/tests/integration/library-book-labels.int.test.ts
+++ b/tests/integration/library-book-labels.int.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it } from 'vitest';
+
+import { insertVerifiedProfile } from '@/tests/setup/factories';
+import { withRollback } from '@/tests/setup/tx';
+
+async function seedBook(client: import('pg').PoolClient): Promise<{
+  bookId: string;
+  profileId: string;
+}> {
+  const { profileId } = await insertVerifiedProfile(client);
+  const { rows } = await client.query(
+    `insert into public.books
+       (title_cs, author, created_by_profile_id, updated_by_profile_id)
+     values ('Testovací kniha', 'Testující autor:ka', $1, $1)
+     returning id`,
+    [profileId],
+  );
+
+  return { bookId: rows[0].id as string, profileId };
+}
+
+describe('library book label codes', () => {
+  it('requires label codes to be unique across physical copies', async () => {
+    await withRollback(async (client) => {
+      const { bookId, profileId } = await seedBook(client);
+      const insertCopy = (labelCode: number) => client.query(
+        `insert into public.library_books
+           (book_id, label_code, created_by_profile_id, updated_by_profile_id)
+         values ($1, $2, $3, $3)`,
+        [bookId, labelCode, profileId],
+      );
+
+      await insertCopy(1);
+
+      await expect(insertCopy(1)).rejects.toThrow(/library_books_label_code_key/);
+    });
+  });
+
+  it('requires label codes to be positive', async () => {
+    await withRollback(async (client) => {
+      const { bookId, profileId } = await seedBook(client);
+
+      await expect(client.query(
+        `insert into public.library_books
+           (book_id, label_code, created_by_profile_id, updated_by_profile_id)
+         values ($1, 0, $2, $2)`,
+        [bookId, profileId],
+      )).rejects.toThrow(/library_books_label_code_check/);
+    });
+  });
+
+  it('keeps existing unlabelled copies valid during the rollout', async () => {
+    await withRollback(async (client) => {
+      const { bookId, profileId } = await seedBook(client);
+      const { rows } = await client.query(
+        `insert into public.library_books
+           (book_id, created_by_profile_id, updated_by_profile_id)
+         values ($1, $2, $2)
+         returning label_code`,
+        [bookId, profileId],
+      );
+
+      expect(rows[0].label_code).toBeNull();
+    });
+  });
+});


### PR DESCRIPTION
Next batch on `feat/beta-cohort-feature-access` since #126 merged — 8 commits.

## ⚠️ Destructive migration — review before merging

`supabase/migrations/20260902232613_library_copy_label_codes.sql` drops a column:

```sql
DROP INDEX "library_books_isbn_13_idx";
ALTER TABLE "library_books" ADD COLUMN "label_code" integer;
ALTER TABLE "library_books" DROP COLUMN "isbn_13";
```

`library_books.isbn_13` and its index go away, replaced by a unique `label_code`. **Any ISBN data in that column on preview/production is lost on apply and is not recoverable from the migration.** Confirm the column is genuinely unused (or back it up) before this lands. The other two new migrations — `20260902190609_curious_matthew_murdock.sql` and `20260902200442_giant_bloodaxe.sql` — contain no drops.

## Library

- **QR labels for library copies** (`3639255`) — printable labels per copy, keyed off the new `label_code`.
- **Streamlined label→book assignment** (`6c4c18e`).

## Books & reading

- **Visual identity + category switcher on book category subpages** (`ed9e3a3`).
- **Long book titles** are structured and truncated in the feed and connection cards (`8b233d0`).
- **Mobile semester progress** display and carry-over handling in `MetricProgress` (`28e6e3b`).
- **Legacy points badge** unified with score and hidden on public feeds (`6567213`).
- **Cursor pointer** on category and feature cards in search (`52c2065`).

## Essay fix: a new essay was invisible until its second save (`f9e60e4`)

`POST /api/essays` hardcoded `published_at: null`, and `PATCH` was the only route that ever stamped it. That was the autosave-era contract — create an empty row, publish on the next keystroke's PATCH — but since manual save replaced autosave in `1b88f4b`, one click is one POST with no PATCH behind it. A newly created essay stayed unpublished until the author happened to save a second time.

`published_at` gates both visible symptoms: `getEssays()` filters on it even for the `moje` view behind **Moje čtení**, and `getUserBookPointsStats()` requires it to credit book points. So the essay was missing from its own author's overview *and* from their points total.

POST now mirrors PATCH's rule — a title publishes the essay whenever it first arrives; title-less essays stay private drafts.

The E2E test covering exactly this (`"becomes visible in Moje eseje as soon as it gets a title saved"`) was already failing on `preview`; it now passes and asserts `published_at` on the row, so a regression points at the cause instead of a downstream symptom.

### Existing rows need a manual repair

Essays created between 2026-08-29 (when manual save shipped) and this fix are still stuck unpublished on production. The code fix does not backfill them — @ondrej-kulhavy is repairing those by hand; the diagnostic query keys off `published_at IS NULL AND btrim(title) <> ''`, and the repair sets `published_at = created_at` (not `now()`, since point credit is earliest-wins per book and gated on the semester start).

## Verification

- `pnpm test` — 1119/1119 passed (183 files)
- `npx tsc --noEmit` — clean
- `tests/e2e/essay-save.spec.ts` — the visibility and delete tests pass. Two tests in that spec fail, **both confirmed pre-existing on `preview`** (verified by stashing this change): `"history lists at least the current version"` looks for a `Historie verzí` menuitem that has since moved out of the "Další akce" dropdown into its own icon button, and `"warns before leaving with unsaved changes"` lands on `about:blank` because the test opens `/nova` directly, leaving `router.back()` no history entry. Not fixed here — flagging as separate cleanup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)