### PR TITLE
feat(analytics): PostHog improvements, GDPR consent & privacy, dark mode contrast

### DIFF
--- a/docs/plans/2026-09-04-posthog-improvements.md
+++ b/docs/plans/2026-09-04-posthog-improvements.md
@@ -18,6 +18,11 @@ No code. Owner: maintainer + Spirit of TAP, z.s. (IČO 23152036, L 80354 u Měst
 
 Controller for GDPR is Spirit of TAP, z.s. (not ČZU). PostHog = processor.
 
+Data model (two strictly separated worlds):
+- **App data ↔ school:** account + content (essays, reservations, loans) replaces school Excel files; PEF ČZU sees this data for study agenda, as it saw the spreadsheets. Access to the app: only active students/employees; čtení + rezervace visible to all app members. School copies/backups are the school's responsibility under its own rules.
+- **Analytics (PostHog EU): never shared with the school.** Not for checking whether/how often anyone opens the app. Clicks/views/errors/session recordings serve only bug reproduction and fixes, only with consent. No essay/message/document content is ever read.
+- **Hosting:** operational DB in Switzerland (EU adequacy decision); analytics in PostHog EU.
+
 - [ ] Decide host: use **EU Cloud** `https://eu.i.posthog.com` + `https://eu-assets.i.posthog.com`. If `NEXT_PUBLIC_POSTHOG_HOST` currently points to `us.*`, migrate project to EU before prod rollout.
 - [ ] Sign PostHog DPA in org settings (PostHog = processor, Spirit of TAP, z.s. = controller). Record date + signer (statutory: Tuuli Co. Družstvo, zastoupena Julie Holá).
 - [ ] Update privacy notice (Czech, gender-neutral per `DESIGN.md`): what is collected (pageview, clicks, errors, replay if enabled), purpose (improve app), retention (e.g. 90d events / 30d replay), how to withdraw (banner + `Nastavení → Soukromí`), contact for erasure.

--- a/docs/plans/2026-09-04-posthog-improvements.md
+++ b/docs/plans/2026-09-04-posthog-improvements.md
@@ -1,0 +1,464 @@
+# PostHog Improvements Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Turn PostHog from pageview-only into GDPR-compliant product + error analytics for the two generally-available features: rezervace and čtení.
+
+**Architecture:** Reverse-proxy ingest (`/ingest`) + opt-in consent banner + typed client/server `track()` wrapper + enriched identify/groups + curated rezervace/čtení events + hardened error tracking. No authorization ever depends on PostHog. Other modules stay untracked until they leave beta.
+
+**Tech Stack:** Next.js 16 App Router, TypeScript strict, `posthog-js@1.418.1`, `posthog-node@5.26.1` (or `@posthog/next` wrapper), shadcn/ui + sonner, Vitest unit/component, Playwright E2E.
+
+**Branch:** `feat/posthog-improvements` (already cut from `preview`).
+
+---
+
+## 0. Legal groundwork (do first, blocks enabling replay/surveys in prod)
+
+No code. Owner: maintainer + Spirit of TAP, z.s. (IČO 23152036, L 80354 u Městského soudu v Praze, sídlo Blatenská 4018, 430 03 Chomutov).
+
+Controller for GDPR is Spirit of TAP, z.s. (not ČZU). PostHog = processor.
+
+- [ ] Decide host: use **EU Cloud** `https://eu.i.posthog.com` + `https://eu-assets.i.posthog.com`. If `NEXT_PUBLIC_POSTHOG_HOST` currently points to `us.*`, migrate project to EU before prod rollout.
+- [ ] Sign PostHog DPA in org settings (PostHog = processor, Spirit of TAP, z.s. = controller). Record date + signer (statutory: Tuuli Co. Družstvo, zastoupena Julie Holá).
+- [ ] Update privacy notice (Czech, gender-neutral per `DESIGN.md`): what is collected (pageview, clicks, errors, replay if enabled), purpose (improve app), retention (e.g. 90d events / 30d replay), how to withdraw (banner + `Nastavení → Soukromí`), contact for erasure.
+- [x] Privacy page created: `src/app/ochrana-soukromi/page.tsx` (controller Spirit of TAP, purposes, 90d/30d retention, cookie inventory, rights via in-app feedback or spolek seat). Banner links to it; footer link on `/about`.
+- [ ] Data minimization rule: never send `name`, `email`, essay/reflection text, document contents as event props. Only `user_id`, `role`, `beta_cohort`, `team_id`, `feature`, `action`.
+- [ ] Erasure runbook: Supabase row delete + PostHog person delete (`POST /api/projects/:id/persons/:distinct_id/delete` or dashboard) within 30d. Document in `docs/runbooks/privacy-erasure.md`.
+- [ ] Cookie inventory: `ph_*_posthog` (consent + identity). Needed for banner text.
+
+Gate: do not enable session replay/heatmaps in production until 0 is done. Analytics events with opt-in can proceed to preview.
+
+---
+
+### Task 1: Reverse-proxy ingest (stop adblock loss)
+
+**Files:**
+- Modify: `next.config.ts:1-42`
+- Modify: `src/instrumentation-client.ts:1-10`
+- Modify: `src/lib/posthog-server.ts:1-17`
+- Test: manual `curl` + network tab (no unit test; verify no 404)
+
+**Step 1: Add rewrites**
+
+In `next.config.ts`, add:
+
+```ts
+async rewrites() {
+  return [
+    { source: "/ingest/static/:path*", destination: "https://eu-assets.i.posthog.com/static/:path*" },
+    { source: "/ingest/:path*", destination: "https://eu.i.posthog.com/:path*" },
+  ];
+},
+skipTrailingSlashRedirect: true,
+```
+
+If US host is required, swap `eu` → `us` + `us-assets`. Keep EU default.
+
+**Step 2: Point clients at proxy**
+
+In `src/instrumentation-client.ts`:
+
+```ts
+posthog.init(process.env.NEXT_PUBLIC_POSTHOG_KEY!, {
+  api_host: "/ingest",
+  defaults: "2026-01-30",
+  capture_pageview: false,
+  capture_pageleave: true,
+  capture_heatmaps: true,
+  enable_recording_console_log: false, // enable in Task 7 only after legal gate
+  autocapture: {
+    css_selector_ignorelist: ["[data-ph-no-capture]", ".ph-no-capture", "[data-sensitive]"],
+  },
+  mask_all_element_attributes: false,
+  mask_all_text: false,
+});
+```
+
+In `src/lib/posthog-server.ts` keep direct `https://eu.i.posthog.com` host (server-to-server, no proxy needed).
+
+**Step 3: Verify**
+
+Run: `pnpm dev`, open network tab, confirm requests to `/ingest/array/*` return 200, no direct `*.i.posthog.com` from browser.
+
+**Step 4: Commit**
+
+```bash
+git add next.config.ts src/instrumentation-client.ts
+git commit -m "feat: proxy PostHog ingest to avoid adblockers"
+```
+
+---
+
+### Task 2: Consent banner (GDPR opt-in, Czech inclusive copy)
+
+**Files:**
+- Create: `src/components/posthog/consent-banner.tsx`
+- Create: `src/components/posthog/consent-banner.test.tsx`
+- Modify: `src/app/layout.tsx:106-132`
+- Modify: `src/instrumentation-client.ts:1-10`
+
+**Step 1: Write failing component test**
+
+Create `src/components/posthog/consent-banner.test.tsx`:
+
+```tsx
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { ConsentBanner } from "./consent-banner";
+
+it("calls opt_in on accept", async () => {
+  render(<ConsentBanner />);
+  await userEvent.click(screen.getByRole("button", { name: /přijmout/i }));
+  // assert posthog.opt_in_capturing called (mock posthog-js)
+});
+```
+
+Run: `pnpm test:component -- consent-banner`
+Expected: FAIL (file missing)
+
+**Step 2: Harden init to opt-out by default**
+
+```ts
+opt_out_capturing_by_default: true,
+opt_out_capturing_persistence_type: "localStorage",
+```
+
+**Step 3: Implement banner**
+
+Create `src/components/posthog/consent-banner.tsx` (client):
+
+```tsx
+"use client";
+import { useEffect, useState } from "react";
+import posthog from "posthog-js";
+import { Button } from "@/components/ui/button";
+
+export function ConsentBanner() {
+  const [visible, setVisible] = useState(false);
+  useEffect(() => {
+    if (posthog.get_explicit_consent_status() === "pending") setVisible(true);
+  }, []);
+  if (!visible) return null;
+  return (
+    <div role="dialog" aria-label="Souhlas s analytikou" className="fixed bottom-4 ...">
+      <p>Pomozte nám zlepšit Tappku. Měříme anonymizované používání a chyby.</p>
+      <Button onClick={() => { posthog.opt_in_capturing(); setVisible(false); }}>Přijmout</Button>
+      <Button variant="outline" onClick={() => { posthog.opt_out_capturing(); setVisible(false); }}>Odmítnout</Button>
+    </div>
+  );
+}
+```
+
+Copy must be gender-neutral, present tense. Link to privacy notice.
+
+Mount in `src/app/layout.tsx` inside `<PostHogProvider>` after `<Toaster />`.
+
+**Step 4: Run tests**
+
+Run: `pnpm test:component -- consent-banner` + `pnpm typecheck`
+Expected: PASS
+
+**Step 5: Commit**
+
+```bash
+git add src/components/posthog/consent-banner.tsx src/components/posthog/consent-banner.test.tsx src/app/layout.tsx src/instrumentation-client.ts
+git commit -m "feat: add GDPR consent banner with opt-out default"
+```
+
+---
+
+### Task 3: Typed analytics wrapper (single entry point)
+
+**Files:**
+- Create: `src/lib/analytics.ts`
+- Create: `src/lib/analytics.test.ts`
+
+**Step 1: Write failing unit test**
+
+Create `src/lib/analytics.test.ts`:
+
+```ts
+import { describe, it, expect, vi } from "vitest";
+import posthog from "posthog-js";
+import { trackFeature } from "./analytics";
+
+describe("trackFeature", () => {
+  it("captures feature_interaction with allowlisted props", () => {
+    const spy = vi.spyOn(posthog, "capture").mockImplementation(() => {});
+    trackFeature("reservations", "created");
+    expect(spy).toHaveBeenCalledWith("feature_interaction", expect.objectContaining({ feature: "reservations", action: "created" }));
+  });
+});
+```
+
+Run: `pnpm test:unit -- analytics`
+Expected: FAIL
+
+**Step 2: Implement minimal wrapper**
+
+Create `src/lib/analytics.ts`:
+
+```ts
+import posthog from "posthog-js";
+
+// Pilot scope: only GA features. Add others when they leave beta.
+export const FEATURES = ["reservations", "cteni"] as const;
+export type FeatureKey = (typeof FEATURES)[number];
+
+export function trackFeature(feature: FeatureKey, action: string, props: Record<string, string | number | boolean> = {}) {
+  try {
+    posthog.capture("feature_interaction", { feature, action, ...props });
+  } catch { /* ignore */ }
+}
+
+export function trackView(feature: FeatureKey, props: Record<string, string | number | boolean> = {}) {
+  try {
+    posthog.capture("feature_view", { feature, ...props });
+  } catch { /* ignore */ }
+}
+```
+
+Rules: never pass PII/content bodies. Only ids + enums.
+
+**Step 3: Run tests**
+
+Run: `pnpm test:unit -- analytics`
+Expected: PASS
+
+**Step 4: Commit**
+
+```bash
+git add src/lib/analytics.ts src/lib/analytics.test.ts
+git commit -m "feat: add typed PostHog analytics wrapper"
+```
+
+---
+
+### Task 4: Enriched identify + groups
+
+**Files:**
+- Modify: `src/components/posthog/posthog-identify.tsx:1-21`
+- Modify: `src/app/(main)/layout.tsx:35-51`
+- Test: `src/components/posthog/posthog-identify.test.tsx` (new)
+
+**Step 1: Write failing test**
+
+Assert `identify` called with `{ role, beta_access, beta_cohort }` and `group("team", teamId)` when `teamId` present, and `setPersonProperties` used for updates without re-identify churn.
+
+Run: `pnpm test:component -- posthog-identify`
+Expected: FAIL
+
+**Step 2: Implement**
+
+```tsx
+"use client";
+import { useEffect } from "react";
+import { usePostHog } from "posthog-js/react";
+
+export function PostHogIdentify({ distinctId, role, betaAccess, betaCohort, teamId }: {
+  distinctId: string; role: string; betaAccess: boolean; betaCohort: "A"|"B"; teamId?: string | null;
+}) {
+  const posthog = usePostHog();
+  useEffect(() => {
+    if (!posthog) return;
+    posthog.identify(distinctId, { role, beta_access: betaAccess, beta_cohort: betaCohort });
+    if (teamId) posthog.group("team", teamId);
+  }, [posthog, distinctId, role, betaAccess, betaCohort, teamId]);
+  return null;
+}
+```
+
+Pass `role` + `team_id` from `getSessionProfile()` in `(main)/layout.tsx`. Keep `posthog.reset()` on logout as-is.
+
+**Step 3: Verify**
+
+Run: `pnpm test:component -- posthog-identify` + `pnpm typecheck`
+Expected: PASS
+
+**Step 4: Commit**
+
+```bash
+git add src/components/posthog/posthog-identify.tsx src/app/\(main\)/layout.tsx
+git commit -m "feat: enrich PostHog identify with role and team group"
+```
+
+---
+
+### Task 5: Server-side capture helper
+
+**Files:**
+- Create: `src/lib/analytics-server.ts`
+- Create: `src/lib/analytics-server.test.ts`
+
+**Step 1: Write failing test**
+
+Mock `getPostHogServer` to return `{ capture: vi.fn() }`, assert `trackServer({distinctId, event: "feature_interaction", properties})` forwards allowlisted props only.
+
+Run: `pnpm test:unit -- analytics-server`
+Expected: FAIL
+
+**Step 2: Implement**
+
+```ts
+import { getPostHogServer } from "./posthog-server";
+
+export async function trackServer(event: string, distinctId: string, properties: Record<string, string | number | boolean> = {}) {
+  const client = getPostHogServer();
+  if (!client) return;
+  try {
+    await client.captureImmediate({ distinctId, event, properties });
+  } catch { /* ignore */ }
+}
+```
+
+Use in route handlers / server actions for completed actions (e.g. reservation created) where client may have navigated away.
+
+**Step 3: Run + commit**
+
+Run: `pnpm test:unit -- analytics-server`
+```bash
+git add src/lib/analytics-server.ts src/lib/analytics-server.test.ts
+git commit -m "feat: add server-side PostHog capture helper"
+```
+
+---
+
+### Task 6: Pilot feature events (rezervace + čtení only)
+
+**Files (pilot, nothing else):**
+- Modify: reservation flows (`src/app/(main)/reservations/*` + `src/app/rezervace/*`)
+- Modify: reading flows (`src/app/(main)/cteni/*`)
+
+Out of scope: `tymovy-denik`, `zpetna-vazba`, and all other beta modules — not available to most people, do not instrument yet.
+
+**Step 1: Add `trackView` on pilot pages**
+
+In each pilot `page.tsx`, add client tracker or call `trackView("reservations" | "cteni")` on mount. Keep server render pure; put tracking in existing client component.
+
+**Step 2: Add `trackFeature(feature, "created"|"submitted"|"completed")` on success paths**
+
+Example (reservation):
+
+```ts
+import { trackFeature } from "@/lib/analytics";
+trackFeature("reservations", "created", { has_team: !!teamId });
+```
+
+Example (čtení):
+
+```ts
+trackFeature("cteni", "completed", { source: "prehled" });
+```
+
+Never send free text (no book notes, titles, or feedback bodies).
+
+**Step 3: Verify in PostHog**
+
+Preview env: trigger both flows, confirm `feature_view` + `feature_interaction` appear with `feature in ["reservations","cteni"]`. Build Insight: `feature_interaction` count grouped by `feature` + `action`.
+
+**Step 4: Commit per feature**
+
+```bash
+git add src/app/\(main\)/reservations src/lib/analytics.ts
+git commit -m "feat: track reservation usage events"
+```
+
+```bash
+git add src/app/\(main\)/cteni src/lib/analytics.ts
+git commit -m "feat: track cteni usage events"
+```
+
+YAGNI: do not instrument other modules in this plan.
+
+---
+
+### Task 7: Error tracking hardening
+
+**Files:**
+- Modify: `src/instrumentation.ts:1-40`
+- Modify: `src/app/global-error.tsx:1-31`, `src/app/(main)/error.tsx:1-28`
+- Modify: `src/instrumentation-client.ts:1-10`
+
+**Step 1: Prefer official server hook**
+
+If `@posthog/next` is available for Next 16, replace hand-rolled cookie regex in `src/instrumentation.ts` with:
+
+```ts
+export { onRequestError } from "@posthog/next";
+```
+
+If not compatible, keep current `captureExceptionImmediate` but add `$session_id` forwarding and a comment citing docs. Add `before_send` fingerprint skip for `ChunkLoadError`.
+
+**Step 2: Add context to client boundaries**
+
+```ts
+posthog.captureException(error, { feature: "global", digest: error.digest });
+```
+
+**Step 3: Enable console-log replay only after Task 0 gate**
+
+```ts
+enable_recording_console_log: true,
+session_recording: { maskAllInputs: true },
+```
+
+Default stays OFF until DPA + notice live.
+
+**Step 4: Verify**
+
+Run: `pnpm test` + `pnpm build`. Trigger test error in preview, confirm `$exception` with session link + replay (if enabled).
+
+**Step 5: Commit**
+
+```bash
+git add src/instrumentation.ts src/app/global-error.tsx src/app/\(main\)/error.tsx src/instrumentation-client.ts
+git commit -m "feat: harden PostHog error tracking"
+```
+
+---
+
+### Task 8: Flags + micro-surveys (defer until rezervace/cteni events flow)
+
+- Migrate one beta gate (e.g. `portfolio`) to PostHog flag to get `$feature_flag_called` analytics only if needed. Never use flag for authz — keep `canAccessFeature` as source of truth, flag is analytics-only.
+- Add one PostHog survey tied to GA scope only (e.g. post-reservation 1-question) instead of building custom UI. No surveys for beta modules in this plan.
+
+Separate commit. Skip if pilot shows no need.
+
+---
+
+### Task 9: Verification + rollout
+
+**Step 1: Fast suite**
+
+Run: `pnpm test`
+Expected: PASS (unit + component)
+
+**Step 2: Static + build**
+
+Run:
+```bash
+pnpm typecheck
+pnpm lint
+pnpm build
+```
+Expected: exit 0
+
+**Step 3: Preview checklist**
+
+- [ ] `/ingest/*` 200, no direct browser calls to `*.i.posthog.com`
+- [ ] Banner shows on first visit, accept/decline persists
+- [ ] `$pageview`, `feature_view`, `feature_interaction`, `$exception` visible in PostHog EU project
+- [ ] Persons show `role`, `beta_cohort`, `team` group
+- [ ] Light + dark themes for banner (per `DESIGN.md`)
+
+**Step 4: Prod gate**
+
+Do not merge to `production` until Task 0 legal items are signed. Merge to `preview` freely.
+
+---
+
+## References
+
+- Context7 `/posthog/posthog-js` (defaults, autocapture, `capture_pageview: 'history_change'` vs manual)
+- Context7 `/posthog/posthog.com` (Next.js `onRequestError`, proxy `rewrites`, GDPR consent `opt_out_capturing_by_default` + `opt_in/opt_out`, EU Cloud + DPA as processor)
+- Repo: `src/instrumentation-client.ts`, `src/instrumentation.ts`, `src/lib/posthog-server.ts`, `src/app/posthog-provider.tsx`, `src/app/posthog-pageview.tsx`, `src/components/posthog/posthog-identify.tsx`, `next.config.ts`

--- a/next.config.ts
+++ b/next.config.ts
@@ -37,6 +37,19 @@ const nextConfig: NextConfig = {
       },
     ],
   },
+  async rewrites() {
+    return [
+      {
+        source: "/ingest/static/:path*",
+        destination: "https://eu-assets.i.posthog.com/static/:path*",
+      },
+      {
+        source: "/ingest/:path*",
+        destination: "https://eu.i.posthog.com/:path*",
+      },
+    ];
+  },
+  skipTrailingSlashRedirect: true,
 };
 
 export default nextConfig;

--- a/src/app/(main)/cteni/prehled/page.tsx
+++ b/src/app/(main)/cteni/prehled/page.tsx
@@ -4,6 +4,7 @@ import { getCurrentUserProfile } from '@/lib/auth-helpers';
 import { getUserBookPointsStats, getTeamBookPointsStats, getEssays } from '@/lib/essays/queries';
 import { getMyLoans } from '@/lib/library/queries';
 import { PrehledContent } from '@/components/essays/prehled-content';
+import { CteniViewTracker } from '@/components/cteni/cteni-view-tracker';
 import { HelpDialog } from '@/components/help-dialog';
 import { InfoCard } from '@/components/essays/info-card';
 import { PageHeader } from '@/components/ui/page-header';
@@ -34,6 +35,7 @@ export default async function PrehledPage() {
 
   return (
     <PageShell size="full">
+      <CteniViewTracker />
       <PageHeader
         title="Moje čtení"
         description="Tvůj pokrok, eseje a srovnání s týmem"

--- a/src/app/(main)/error.tsx
+++ b/src/app/(main)/error.tsx
@@ -11,7 +11,10 @@ export default function Error({
   reset: () => void;
 }) {
   useEffect(() => {
-    posthog.captureException(error);
+    posthog.captureException(error, {
+      feature: "main",
+      digest: error.digest,
+    });
   }, [error]);
 
   return (

--- a/src/app/(main)/layout.tsx
+++ b/src/app/(main)/layout.tsx
@@ -46,8 +46,10 @@ export default async function DashboardLayout({
     <SpotlightProvider user={sidebarUser}>
       <PostHogIdentify
         distinctId={profile.id}
+        role={profile.role}
         betaAccess={profile.beta_access_granted_at != null}
         betaCohort={sidebarUser.beta_cohort}
+        teamId={profile.team_id}
       />
       <SidebarProvider>
         <AppSidebar user={sidebarUser} />

--- a/src/app/(main)/reservations/page.tsx
+++ b/src/app/(main)/reservations/page.tsx
@@ -1,6 +1,7 @@
 import { createClient } from "@/lib/supabase/server";
 import { RoomsWithFilter } from "@/components/reservations/rooms-with-filter";
 import { ReservationsTabs } from "@/components/reservations/reservations-tabs";
+import { ReservationsViewTracker } from "@/components/reservations/reservations-view-tracker";
 import { getNextAvailableTime } from "@/lib/reservations/utils";
 import { getCurrentUserProfile } from "@/lib/auth-helpers";
 import { PageHeader } from "@/components/ui/page-header";
@@ -86,6 +87,7 @@ export default async function ReservationsPage() {
 
   return (
     <PageShell>
+      <ReservationsViewTracker />
       <PageHeader
         title="Rezervace"
         description="Vyber si místnost a zarezervuj si ji"

--- a/src/app/(main)/settings/notifikace/page.tsx
+++ b/src/app/(main)/settings/notifikace/page.tsx
@@ -3,6 +3,7 @@ import { redirect } from 'next/navigation';
 import { createClient } from '@/lib/supabase/server';
 import { getCurrentUserProfile } from '@/lib/auth-helpers';
 import { NotificationPreferencesForm } from '@/components/settings/notification-preferences-form';
+import { ConsentSettings } from '@/components/posthog/consent-settings';
 import { PageHeader } from '@/components/ui/page-header';
 
 export const metadata = {
@@ -36,6 +37,9 @@ export default async function NotificationSettingsPage() {
         initialVoteEmail={preferences?.essay_vote_email ?? true}
         initialBookSubmittedEmail={preferences?.book_submitted_email ?? false}
       />
+      <div className="rounded-xl border bg-card p-4 sm:p-6">
+        <ConsentSettings />
+      </div>
     </div>
   );
 }

--- a/src/app/about/page.tsx
+++ b/src/app/about/page.tsx
@@ -249,6 +249,12 @@ export default async function AboutPage() {
               GitHub
             </a>
             <Link
+              href="/ochrana-soukromi"
+              className="hover:text-foreground transition-colors underline underline-offset-4"
+            >
+              Ochrana soukromí
+            </Link>
+            <Link
               href="/auth/login"
               className="hover:text-foreground transition-colors underline underline-offset-4"
             >

--- a/src/app/api/essays/route.ts
+++ b/src/app/api/essays/route.ts
@@ -1,8 +1,9 @@
-import { NextRequest, NextResponse } from 'next/server';
+import { NextRequest, NextResponse, after } from 'next/server';
 import type { SupabaseClient } from '@supabase/supabase-js';
 
 import { createClient } from '@/lib/supabase/server';
 import { getCurrentUserProfile } from '@/lib/auth-helpers';
+import { trackServer } from '@/lib/analytics-server';
 import { getEssays, getEssaysByTeam } from '@/lib/essays/queries';
 import { contentTextFromJson } from '@/lib/essays/content-text';
 import { validateEssaySourceIds } from '@/lib/essays/validate-source';
@@ -127,6 +128,13 @@ export async function POST(request: NextRequest) {
       });
 
     if (revisionError) throw revisionError;
+
+    after(() => {
+      trackServer('feature_interaction', profile.id, {
+        feature: 'cteni',
+        action: 'essay_created',
+      });
+    });
 
     return NextResponse.json({ data: { id: essay.id } }, { status: 201 });
   } catch (error) {

--- a/src/app/api/library/books/[bookId]/borrow/route.ts
+++ b/src/app/api/library/books/[bookId]/borrow/route.ts
@@ -2,6 +2,7 @@ import { NextRequest, NextResponse, after } from 'next/server';
 
 import { createClient } from '@/lib/supabase/server';
 import { getCurrentUserProfile } from '@/lib/auth-helpers';
+import { trackServer } from '@/lib/analytics-server';
 import { parseLibraryLabelCode } from '@/lib/library/label-code';
 import { getAvailableCopyByLabelCode, getAvailableCopyForBook } from '@/lib/library/queries';
 import { notifyBookBorrowed } from '@/lib/notifications/library-notifications';
@@ -54,6 +55,10 @@ export async function POST(request: NextRequest, { params }: RouteContext) {
     if (error) throw error;
 
     after(() => {
+      trackServer('feature_interaction', profile.id, {
+        feature: 'cteni',
+        action: 'book_borrowed',
+      });
       notifyBookBorrowed(supabase, {
         bookId,
         borrowerProfileId: profile.id,

--- a/src/app/api/reservations/route.ts
+++ b/src/app/api/reservations/route.ts
@@ -1,11 +1,12 @@
 import { createClient } from "@/lib/supabase/server";
-import { NextRequest, NextResponse } from "next/server";
+import { NextRequest, NextResponse, after } from "next/server";
 import {
   OPERATING_HOURS,
   type CreateReservationInput,
 } from "@/lib/reservations/types";
 import { ALLOWED_PAST_MS, isRoomAvailableOnDay } from "@/lib/reservations/utils";
 import { getCurrentUserProfile } from "@/lib/auth-helpers";
+import { trackServer } from "@/lib/analytics-server";
 
 const PRAGUE_TZ = "Europe/Prague";
 
@@ -252,6 +253,13 @@ export async function POST(request: NextRequest) {
         { status: 500 }
       );
     }
+
+    after(() => {
+      trackServer("feature_interaction", profile.id, {
+        feature: "reservations",
+        action: "created",
+      });
+    });
 
     return NextResponse.json({
       success: true,

--- a/src/app/global-error.tsx
+++ b/src/app/global-error.tsx
@@ -12,7 +12,10 @@ export default function GlobalError({
   reset: () => void;
 }) {
   useEffect(() => {
-    posthog.captureException(error);
+    posthog.captureException(error, {
+      feature: "global",
+      digest: error.digest,
+    });
   }, [error]);
 
   return (

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -5,6 +5,7 @@ import NextTopLoader from "nextjs-toploader";
 import { Toaster } from "@/components/ui/sonner";
 import { PostHogProvider } from "./posthog-provider";
 import { PostHogPageView } from "./posthog-pageview";
+import { ConsentBanner } from "@/components/posthog/consent-banner";
 import "./globals.css";
 
 const defaultUrl = process.env.VERCEL_URL
@@ -124,6 +125,7 @@ export default function RootLayout({
             <PostHogPageView />
             {children}
             <Toaster />
+            <ConsentBanner />
           </ThemeProvider>
         </PostHogProvider>
       </body>

--- a/src/app/ochrana-soukromi/page.tsx
+++ b/src/app/ochrana-soukromi/page.tsx
@@ -122,9 +122,8 @@ export default function PrivacyPage() {
               vidět, co se stalo: kde se klikalo, jaká chyba nastala a případně
               záznam relace, abychom chybu uměli zopakovat a opravit. Proto —
               a pouze se souhlasem v dialogu při první návštěvě — měříme, jak
-              se používají rezervace a čtení, a zaznamenáváme chyby. Samotné
-              měření obsah esejí, zpráv ani dokumentů nesbírá — ten vidí pouze
-              lidé s přístupem podle pravidel výše. Bez souhlasu se neměří nic
+              se používají rezervace a čtení, a zaznamenáváme chyby.
+              Bez souhlasu se neměří nic
               a souhlas lze kdykoli odvolat.
             </p>
             <ul className="list-disc pl-6 space-y-2 text-base text-foreground/80">

--- a/src/app/ochrana-soukromi/page.tsx
+++ b/src/app/ochrana-soukromi/page.tsx
@@ -8,7 +8,7 @@ import { ArrowRight } from "lucide-react";
 export const metadata: Metadata = {
   title: "Ochrana soukromí",
   description:
-    "Jak Tappka zpracovává osobní údaje: správce, účely, uchovávání, práva a soubory cookies.",
+    "Jak Tappka zpracovává osobní údaje: správce, co se sdílí se školou, k čemu slouží měření používání a jaká máte práva.",
 };
 
 export default function PrivacyPage() {
@@ -54,8 +54,8 @@ export default function PrivacyPage() {
               Ochrana soukromí
             </h1>
             <p className="text-sm sm:text-base text-muted-foreground">
-              Jak Tappka nakládá s osobními údaji a co znamená souhlas
-              s měřením používání.
+              Dvě věci držíme přísně odděleně: data aplikace, která patří
+              studiu, a měření používání, které slouží jen k opravám.
             </p>
           </header>
 
@@ -69,73 +69,69 @@ export default function PrivacyPage() {
               Správcem osobních údajů je spolek{" "}
               <strong>Spirit of TAP, z.s.</strong>, IČO 23152036, se sídlem
               Blatenská 4018, 430 03 Chomutov, zapsaný ve spolkovém rejstříku
-              vedeném Městským soudem v Praze, spisová značka L 80354.
+              vedeném Městským soudem v Praze, spisová značka L 80354. Spolek
+              provozuje Tappku proto, aby pomáhal studujícím s jejich studiem.
             </p>
           </section>
 
           <section className="space-y-4">
             <h2 className="font-heading text-xl sm:text-2xl font-bold tracking-tight text-foreground">
-              Jaké údaje zpracováváme
-            </h2>
-            <ul className="list-disc pl-6 space-y-2 text-base text-foreground/80">
-              <li>
-                <strong>Účet:</strong> jméno, e-mail a zařazení do týmu — bez
-                nich se nelze přihlásit a používat aplikaci.
-              </li>
-              <li>
-                <strong>Obsah, který vytváříte:</strong> rezervace, eseje,
-                výpůjčky a další záznamy podle toho, které části aplikace
-                používáte.
-              </li>
-              <li>
-                <strong>Měření používání (pouze se souhlasem):</strong> jak se
-                používají rezervace a čtení a kdy nastane chyba. Neměříme obsah
-                esejí, zpráv ani dokumentů — pouze to, která část aplikace se
-                otevřela a jaká akce proběhla.
-              </li>
-            </ul>
-          </section>
-
-          <section className="space-y-4">
-            <h2 className="font-heading text-xl sm:text-2xl font-bold tracking-tight text-foreground">
-              Proč a na jakém základě
-            </h2>
-            <ul className="list-disc pl-6 space-y-2 text-base text-foreground/80">
-              <li>
-                <strong>Provoz aplikace</strong> (účet a obsah): plnění účelu
-                spolku — podpora studujících Inovativního podnikání na PEF ČZU.
-              </li>
-              <li>
-                <strong>Měření používání a chyb</strong>: výhradně váš souhlas
-                v dialogu při první návštěvě. Souhlas kdykoli odvoláte
-                odmítnutím v tomto dialogu nebo zprávou přes Zpětnou vazbu
-                v aplikaci. Bez souhlasu se neměří nic.
-              </li>
-            </ul>
-          </section>
-
-          <section className="space-y-4">
-            <h2 className="font-heading text-xl sm:text-2xl font-bold tracking-tight text-foreground">
-              Jak dlouho údaje držíme
-            </h2>
-            <ul className="list-disc pl-6 space-y-2 text-base text-foreground/80">
-              <li>Účet a obsah: po dobu studia a členství ve spolku.</li>
-              <li>Události měření používání: nejdéle 90 dní.</li>
-              <li>Chybové záznamy: nejdéle 30 dní.</li>
-            </ul>
-          </section>
-
-          <section className="space-y-4">
-            <h2 className="font-heading text-xl sm:text-2xl font-bold tracking-tight text-foreground">
-              Komu údaje předáváme
+              Kdo má do aplikace přístup
             </h2>
             <p>
-              Data neběží přes žádné reklamní sítě. Měření používání zajišťuje
-              zpracovatel <strong>PostHog</strong> s uložením v EU. Bezpečnostní
-              a provozní zázemí aplikace běží u poskytovatele hostingu databáze.
-              Se zpracovateli má spolek uzavřené smlouvy o zpracování osobních
+              Přístup mají pouze aktivně studující a zaměstnanci:ky školy.
+              Přístup neschvalujeme nikomu mimo školu. Čtení a rezervace jsou
+              viditelné pro všechny, kdo do aplikace patří — nic z toho není
+              veřejné na internetu.
+            </p>
+          </section>
+
+          <section className="space-y-4">
+            <h2 className="font-heading text-xl sm:text-2xl font-bold tracking-tight text-foreground">
+              Data aplikace a škola
+            </h2>
+            <p>
+              Účet (jméno, e-mail, tým) a obsah, který vytváříte — eseje,
+              rezervace, výpůjčky a další studijní záznamy — postupně nahrazují
+              excelové tabulky, které dnes vede škola. Tato data proto škola
+              (PEF ČZU) vidí a používá pro studijní agendu, stejně jako dřív
+              viděla tabulky.
+            </p>
+            <p>
+              Co škola se svými kopiemi a zálohami dělá dál, je mimo naše ruce:
+              za jejich další nakládání odpovídá škola podle vlastních pravidel.
+              Provozní data aplikace běží v databázi hostované ve Švýcarsku —
+              zemi, kterou EU uznává jako poskytující odpovídající ochranu
               údajů.
             </p>
+          </section>
+
+          <section className="space-y-4">
+            <h2 className="font-heading text-xl sm:text-2xl font-bold tracking-tight text-foreground">
+              Měření používání: jen k opravám, nikdy ke kontrole
+            </h2>
+            <p>
+              <strong>
+                Údaje z měření používání škole nikdy nepředáváme.
+              </strong>{" "}
+              Neslouží k tomu, aby škola zjišťovala, zda a jak často aplikaci
+              otevíráte — na takový dotaz škole data neposkytneme.
+            </p>
+            <p>
+              K čemu tedy slouží? Když nahlásíte, že se něco rozbilo, potřebujeme
+              vidět, co se stalo: kde se klikalo, jaká chyba nastala a případně
+              záznam relace, abychom chybu uměli zopakovat a opravit. Proto —
+              a pouze se souhlasem v dialogu při první návštěvě — měříme, jak
+              se používají rezervace a čtení, a zaznamenáváme chyby. Nečteme
+              obsah esejí, zpráv ani dokumentů. Bez souhlasu se neměří nic
+              a souhlas lze kdykoli odvolat.
+            </p>
+            <ul className="list-disc pl-6 space-y-2 text-base text-foreground/80">
+              <li>Události měření používání: nejdéle 90 dní.</li>
+              <li>Chybové záznamy a záznamy relací: nejdéle 30 dní.</li>
+              <li>Uložení v EU u zpracovatele PostHog, se kterým má spolek
+                smlouvu o zpracování osobních údajů.</li>
+            </ul>
           </section>
 
           <section className="space-y-4">

--- a/src/app/ochrana-soukromi/page.tsx
+++ b/src/app/ochrana-soukromi/page.tsx
@@ -122,8 +122,9 @@ export default function PrivacyPage() {
               vidět, co se stalo: kde se klikalo, jaká chyba nastala a případně
               záznam relace, abychom chybu uměli zopakovat a opravit. Proto —
               a pouze se souhlasem v dialogu při první návštěvě — měříme, jak
-              se používají rezervace a čtení, a zaznamenáváme chyby. Nečteme
-              obsah esejí, zpráv ani dokumentů. Bez souhlasu se neměří nic
+              se používají rezervace a čtení, a zaznamenáváme chyby. Samotné
+              měření obsah esejí, zpráv ani dokumentů nesbírá — ten vidí pouze
+              lidé s přístupem podle pravidel výše. Bez souhlasu se neměří nic
               a souhlas lze kdykoli odvolat.
             </p>
             <ul className="list-disc pl-6 space-y-2 text-base text-foreground/80">

--- a/src/app/ochrana-soukromi/page.tsx
+++ b/src/app/ochrana-soukromi/page.tsx
@@ -123,8 +123,8 @@ export default function PrivacyPage() {
               záznam relace, abychom chybu uměli zopakovat a opravit. Proto —
               a pouze se souhlasem v dialogu při první návštěvě — měříme, jak
               se používají rezervace a čtení, a zaznamenáváme chyby.
-              Bez souhlasu se neměří nic
-              a souhlas lze kdykoli odvolat.
+              Bez souhlasu se neměří nic a souhlas lze kdykoli odvolat
+              v Nastavení → Notifikace.
             </p>
             <ul className="list-disc pl-6 space-y-2 text-base text-foreground/80">
               <li>Události měření používání: nejdéle 90 dní.</li>
@@ -151,7 +151,8 @@ export default function PrivacyPage() {
             </h2>
             <p>
               Máte právo na přístup k údajům, jejich opravu a výmaz, omezení
-              zpracování a odvolání souhlasu. Práva uplatníte zprávou přes
+              zpracování a odvolání souhlasu. Souhlas s měřením odvoláte přímo
+              v Nastavení → Notifikace, ostatní práva uplatníte zprávou přes
               Zpětnou vazbu v aplikaci nebo písemně na sídlo spolku. Se
               stížností se lze obrátit na Úřad pro ochranu osobních údajů.
             </p>

--- a/src/app/ochrana-soukromi/page.tsx
+++ b/src/app/ochrana-soukromi/page.tsx
@@ -1,0 +1,179 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+import Image from "next/image";
+import { ThemeSwitcher } from "@/components/theme-switcher";
+import { Button } from "@/components/ui/button";
+import { ArrowRight } from "lucide-react";
+
+export const metadata: Metadata = {
+  title: "Ochrana soukromí",
+  description:
+    "Jak Tappka zpracovává osobní údaje: správce, účely, uchovávání, práva a soubory cookies.",
+};
+
+export default function PrivacyPage() {
+  return (
+    <div className="min-h-screen flex flex-col bg-background text-foreground">
+      <header className="border-b bg-background/95 backdrop-blur supports-[backdrop-filter]:bg-background/60 sticky top-0 z-40">
+        <div className="container max-w-3xl mx-auto flex h-16 items-center justify-between px-4 sm:px-6">
+          <Link href="/" className="flex items-center">
+            <Image
+              src="/pef_logo/CZU_PEF_cerna_RGB.png"
+              alt="ČZU PEF"
+              width={120}
+              height={34}
+              className="object-contain dark:hidden"
+              priority
+            />
+            <Image
+              src="/pef_logo/CZU_PEF_bila_RGB.png"
+              alt="ČZU PEF"
+              width={120}
+              height={34}
+              className="hidden object-contain dark:block"
+              priority
+            />
+          </Link>
+
+          <div className="flex items-center gap-3">
+            <ThemeSwitcher />
+            <Button asChild size="sm" variant="outline">
+              <Link href="/auth/login">
+                Přihlášení
+                <ArrowRight className="size-3.5 ml-1" />
+              </Link>
+            </Button>
+          </div>
+        </div>
+      </header>
+
+      <main className="flex-1 py-10 sm:py-14 px-4 sm:px-6">
+        <article className="container max-w-2xl mx-auto space-y-8 text-base sm:text-lg leading-relaxed text-foreground/90 font-normal">
+          <header className="space-y-2">
+            <h1 className="font-heading text-3xl sm:text-4xl font-bold tracking-tight text-foreground">
+              Ochrana soukromí
+            </h1>
+            <p className="text-sm sm:text-base text-muted-foreground">
+              Jak Tappka nakládá s osobními údaji a co znamená souhlas
+              s měřením používání.
+            </p>
+          </header>
+
+          <hr className="border-border" />
+
+          <section className="space-y-4">
+            <h2 className="font-heading text-xl sm:text-2xl font-bold tracking-tight text-foreground">
+              Správce údajů
+            </h2>
+            <p>
+              Správcem osobních údajů je spolek{" "}
+              <strong>Spirit of TAP, z.s.</strong>, IČO 23152036, se sídlem
+              Blatenská 4018, 430 03 Chomutov, zapsaný ve spolkovém rejstříku
+              vedeném Městským soudem v Praze, spisová značka L 80354.
+            </p>
+          </section>
+
+          <section className="space-y-4">
+            <h2 className="font-heading text-xl sm:text-2xl font-bold tracking-tight text-foreground">
+              Jaké údaje zpracováváme
+            </h2>
+            <ul className="list-disc pl-6 space-y-2 text-base text-foreground/80">
+              <li>
+                <strong>Účet:</strong> jméno, e-mail a zařazení do týmu — bez
+                nich se nelze přihlásit a používat aplikaci.
+              </li>
+              <li>
+                <strong>Obsah, který vytváříte:</strong> rezervace, eseje,
+                výpůjčky a další záznamy podle toho, které části aplikace
+                používáte.
+              </li>
+              <li>
+                <strong>Měření používání (pouze se souhlasem):</strong> jak se
+                používají rezervace a čtení a kdy nastane chyba. Neměříme obsah
+                esejí, zpráv ani dokumentů — pouze to, která část aplikace se
+                otevřela a jaká akce proběhla.
+              </li>
+            </ul>
+          </section>
+
+          <section className="space-y-4">
+            <h2 className="font-heading text-xl sm:text-2xl font-bold tracking-tight text-foreground">
+              Proč a na jakém základě
+            </h2>
+            <ul className="list-disc pl-6 space-y-2 text-base text-foreground/80">
+              <li>
+                <strong>Provoz aplikace</strong> (účet a obsah): plnění účelu
+                spolku — podpora studujících Inovativního podnikání na PEF ČZU.
+              </li>
+              <li>
+                <strong>Měření používání a chyb</strong>: výhradně váš souhlas
+                v dialogu při první návštěvě. Souhlas kdykoli odvoláte
+                odmítnutím v tomto dialogu nebo zprávou přes Zpětnou vazbu
+                v aplikaci. Bez souhlasu se neměří nic.
+              </li>
+            </ul>
+          </section>
+
+          <section className="space-y-4">
+            <h2 className="font-heading text-xl sm:text-2xl font-bold tracking-tight text-foreground">
+              Jak dlouho údaje držíme
+            </h2>
+            <ul className="list-disc pl-6 space-y-2 text-base text-foreground/80">
+              <li>Účet a obsah: po dobu studia a členství ve spolku.</li>
+              <li>Události měření používání: nejdéle 90 dní.</li>
+              <li>Chybové záznamy: nejdéle 30 dní.</li>
+            </ul>
+          </section>
+
+          <section className="space-y-4">
+            <h2 className="font-heading text-xl sm:text-2xl font-bold tracking-tight text-foreground">
+              Komu údaje předáváme
+            </h2>
+            <p>
+              Data neběží přes žádné reklamní sítě. Měření používání zajišťuje
+              zpracovatel <strong>PostHog</strong> s uložením v EU. Bezpečnostní
+              a provozní zázemí aplikace běží u poskytovatele hostingu databáze.
+              Se zpracovateli má spolek uzavřené smlouvy o zpracování osobních
+              údajů.
+            </p>
+          </section>
+
+          <section className="space-y-4">
+            <h2 className="font-heading text-xl sm:text-2xl font-bold tracking-tight text-foreground">
+              Soubory cookies
+            </h2>
+            <p>
+              Měření používá soubory začínající <code>ph_</code> a končící{" "}
+              <code>_posthog</code>: pamatují si souhlas s měřením a
+              rozpoznávají vracející se prohlížeč. Bez souhlasu se neukládají.
+            </p>
+          </section>
+
+          <section className="space-y-4">
+            <h2 className="font-heading text-xl sm:text-2xl font-bold tracking-tight text-foreground">
+              Vaše práva
+            </h2>
+            <p>
+              Máte právo na přístup k údajům, jejich opravu a výmaz, omezení
+              zpracování a odvolání souhlasu. Práva uplatníte zprávou přes
+              Zpětnou vazbu v aplikaci nebo písemně na sídlo spolku. Se
+              stížností se lze obrátit na Úřad pro ochranu osobních údajů.
+            </p>
+          </section>
+
+          <hr className="border-border" />
+
+          <div className="pt-2 flex items-center justify-between text-sm text-muted-foreground">
+            <span>Spirit of TAP, z.s. • IČO 23152036</span>
+            <Link
+              href="/about"
+              className="text-foreground font-medium underline underline-offset-4 hover:text-primary transition-colors"
+            >
+              O Tappce →
+            </Link>
+          </div>
+        </article>
+      </main>
+    </div>
+  );
+}

--- a/src/app/ochrana-soukromi/page.tsx
+++ b/src/app/ochrana-soukromi/page.tsx
@@ -122,7 +122,7 @@ export default function PrivacyPage() {
               vidět, co se stalo: kde se klikalo, jaká chyba nastala a případně
               záznam relace, abychom chybu uměli zopakovat a opravit. Proto —
               a pouze se souhlasem v dialogu při první návštěvě — měříme, jak
-              se používají rezervace a čtení, a zaznamenáváme chyby.
+              se Tappka používá, a zaznamenáváme chyby.
               Bez souhlasu se neměří nic a souhlas lze kdykoli odvolat
               v Nastavení → Notifikace.
             </p>

--- a/src/components/cteni/cteni-view-tracker.test.tsx
+++ b/src/components/cteni/cteni-view-tracker.test.tsx
@@ -1,0 +1,15 @@
+import { render } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+import { trackView } from "@/lib/analytics";
+
+import { CteniViewTracker } from "./cteni-view-tracker";
+
+vi.mock("@/lib/analytics", () => ({ trackView: vi.fn() }));
+
+describe("CteniViewTracker", () => {
+  it("tracks cteni view on mount", () => {
+    render(<CteniViewTracker />);
+    expect(trackView).toHaveBeenCalledWith("cteni");
+  });
+});

--- a/src/components/cteni/cteni-view-tracker.tsx
+++ b/src/components/cteni/cteni-view-tracker.tsx
@@ -1,0 +1,12 @@
+"use client";
+
+import { useEffect } from "react";
+
+import { trackView } from "@/lib/analytics";
+
+export function CteniViewTracker() {
+  useEffect(() => {
+    trackView("cteni");
+  }, []);
+  return null;
+}

--- a/src/components/posthog/consent-banner.test.tsx
+++ b/src/components/posthog/consent-banner.test.tsx
@@ -1,0 +1,43 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it, vi } from "vitest";
+
+import posthog from "posthog-js";
+
+import { ConsentBanner } from "./consent-banner";
+
+vi.mock("posthog-js", () => ({
+  default: {
+    get_explicit_consent_status: vi.fn(),
+    opt_in_capturing: vi.fn(),
+    opt_out_capturing: vi.fn(),
+  },
+}));
+
+const mockedPosthog = vi.mocked(posthog);
+
+describe("ConsentBanner", () => {
+  it("calls opt_in on accept", async () => {
+    mockedPosthog.get_explicit_consent_status.mockReturnValue("pending");
+    const user = userEvent.setup();
+    render(<ConsentBanner />);
+    await user.click(screen.getByRole("button", { name: /přijmout/i }));
+    expect(mockedPosthog.opt_in_capturing).toHaveBeenCalledOnce();
+  });
+
+  it("calls opt_out on decline", async () => {
+    mockedPosthog.get_explicit_consent_status.mockReturnValue("pending");
+    const user = userEvent.setup();
+    render(<ConsentBanner />);
+    await user.click(screen.getByRole("button", { name: /odmítnout/i }));
+    expect(mockedPosthog.opt_out_capturing).toHaveBeenCalledOnce();
+  });
+
+  it("hides when consent already decided", () => {
+    mockedPosthog.get_explicit_consent_status.mockReturnValue("granted");
+    render(<ConsentBanner />);
+    expect(
+      screen.queryByRole("dialog", { name: /souhlas s analytikou/i }),
+    ).not.toBeInTheDocument();
+  });
+});

--- a/src/components/posthog/consent-banner.test.tsx
+++ b/src/components/posthog/consent-banner.test.tsx
@@ -37,7 +37,15 @@ describe("ConsentBanner", () => {
     mockedPosthog.get_explicit_consent_status.mockReturnValue("granted");
     render(<ConsentBanner />);
     expect(
-      screen.queryByRole("dialog", { name: /souhlas s analytikou/i }),
+      screen.queryByRole("dialog", { name: /souhlas s měřením/i }),
     ).not.toBeInTheDocument();
+  });
+
+  it("links to the privacy page", () => {
+    mockedPosthog.get_explicit_consent_status.mockReturnValue("pending");
+    render(<ConsentBanner />);
+    expect(
+      screen.getByRole("link", { name: /jak chráníme soukromí/i }),
+    ).toHaveAttribute("href", "/ochrana-soukromi");
   });
 });

--- a/src/components/posthog/consent-banner.test.tsx
+++ b/src/components/posthog/consent-banner.test.tsx
@@ -35,12 +35,26 @@ describe("ConsentBanner", () => {
 
   it("hides when consent already decided", () => {
     mockedPosthog.get_explicit_consent_status.mockReturnValue("granted");
+    localStorage.setItem("tappka-consent-at", String(Date.now()));
     render(<ConsentBanner />);
     expect(
       screen.queryByRole("dialog", { name: /souhlas s měřením/i }),
     ).not.toBeInTheDocument();
+    localStorage.clear();
   });
 
+  it("treats closing without choice as refusal", async () => {
+    mockedPosthog.get_explicit_consent_status.mockReturnValue("pending");
+    const user = userEvent.setup();
+    render(<ConsentBanner />);
+    await user.click(
+      screen.getByRole("button", { name: /zavřít bez souhlasu/i }),
+    );
+    expect(mockedPosthog.opt_out_capturing).toHaveBeenCalled();
+    expect(
+      screen.queryByRole("dialog", { name: /souhlas s měřením/i }),
+    ).not.toBeInTheDocument();
+  });
   it("links to the privacy page", () => {
     mockedPosthog.get_explicit_consent_status.mockReturnValue("pending");
     render(<ConsentBanner />);

--- a/src/components/posthog/consent-banner.tsx
+++ b/src/components/posthog/consent-banner.tsx
@@ -86,6 +86,12 @@ export function ConsentBanner() {
         </Link>
       </p>
 
+      <p className="mt-2 text-xs text-muted-foreground/80 leading-normal">
+        Plníme tím zákon o elektronických komunikacích (§ 89 odst. 3 ZEK) a
+        nařízení GDPR. Souhlas je dobrovolný a kdykoli ho můžeš změnit nebo
+        odvolat v Nastavení.
+      </p>
+
       <div className="mt-4 flex flex-col-reverse sm:flex-row sm:items-center sm:justify-end gap-2">
         <Button
           type="button"

--- a/src/components/posthog/consent-banner.tsx
+++ b/src/components/posthog/consent-banner.tsx
@@ -2,6 +2,7 @@
 
 import Link from "next/link";
 import { useState, useSyncExternalStore } from "react";
+import { ShieldCheck } from "lucide-react";
 import posthog from "posthog-js";
 
 import { Button } from "@/components/ui/button";
@@ -48,19 +49,29 @@ export function ConsentBanner() {
       aria-label="Souhlas s měřením používání"
       className="fixed inset-x-4 bottom-4 z-50 mx-auto max-w-xl rounded-xl border bg-card p-4 shadow-lg"
     >
-      <p className="font-medium">Řekněte nám, co v Tappce funguje</p>
-      <p className="mt-1 text-sm text-muted-foreground">
-        Se souhlasem měříme, jak se používají rezervace a čtení, a
-        zaznamenáváme chyby, abychom je uměli opravit. Nikdy je nepředáváme
-        škole ke kontrole. Data držíme v EU a nečteme obsah esejí ani zpráv.
-        Bez souhlasu neměříme nic.{" "}
-        <Link
-          href="/ochrana-soukromi"
-          className="underline underline-offset-4 hover:text-foreground"
+      <div className="flex items-start gap-3">
+        <span
+          aria-hidden="true"
+          className="flex size-9 shrink-0 items-center justify-center rounded-lg bg-muted"
         >
-          Jak chráníme soukromí
-        </Link>
-      </p>
+          <ShieldCheck className="size-5 text-primary" />
+        </span>
+        <div>
+          <p className="font-medium">Řekněte nám, co v Tappce funguje</p>
+          <p className="mt-1 text-sm text-muted-foreground">
+            Se souhlasem měříme, jak se používají rezervace a čtení, a
+            zaznamenáváme chyby, abychom je uměli opravit. Nikdy je nepředáváme
+            škole ke kontrole. Data držíme v EU a měření nesbírá obsah esejí
+            ani zpráv. Bez souhlasu neměříme nic.{" "}
+            <Link
+              href="/ochrana-soukromi"
+              className="underline underline-offset-4 hover:text-foreground"
+            >
+              Jak chráníme soukromí
+            </Link>
+          </p>
+        </div>
+      </div>
       <div className="mt-3 flex gap-2">
         <Button type="button" size="sm" variant="outline" onClick={accept}>
           Přijmout

--- a/src/components/posthog/consent-banner.tsx
+++ b/src/components/posthog/consent-banner.tsx
@@ -59,7 +59,7 @@ export function ConsentBanner() {
             id="consent-banner-title"
             className="font-heading text-base font-semibold text-foreground tracking-tight"
           >
-            Řekněte nám, co v Tappce funguje
+            Pomoz nám Tappku vylepšovat
           </h2>
         </div>
         <Button
@@ -75,9 +75,9 @@ export function ConsentBanner() {
       </div>
 
       <p className="mt-3 text-sm text-muted-foreground leading-relaxed">
-        Se souhlasem měříme, jak se používají rezervace a čtení, a
-        zaznamenáváme chyby, abychom je uměli opravit. Nikdy je nepředáváme
-        škole ke kontrole. Data držíme v EU. Bez souhlasu neměříme nic.{" "}
+        S tvým souhlasem měříme, jak Tappku používáš, a když se ti něco rozbije,
+        pomůže nám to chybu rychle najít a opravit. Data držíme v EU a škole
+        je nepředáváme. Bez souhlasu neměříme nic.{" "}
         <Link
           href="/ochrana-soukromi"
           className="font-medium underline underline-offset-4 text-foreground hover:text-primary transition-colors inline-block"

--- a/src/components/posthog/consent-banner.tsx
+++ b/src/components/posthog/consent-banner.tsx
@@ -59,7 +59,7 @@ export function ConsentBanner() {
             id="consent-banner-title"
             className="font-heading text-base font-semibold text-foreground tracking-tight"
           >
-            Pomoz nám Tappku vylepšovat
+            Ať víme, když se něco rozbije
           </h2>
         </div>
         <Button
@@ -75,9 +75,9 @@ export function ConsentBanner() {
       </div>
 
       <p className="mt-3 text-sm text-muted-foreground leading-relaxed">
-        S tvým souhlasem měříme, jak Tappku používáš, a když se ti něco rozbije,
-        pomůže nám to chybu rychle najít a opravit. Data držíme v EU a škole
-        je nepředáváme. Bez souhlasu neměříme nic.{" "}
+        S tvým souhlasem měříme, jak Tappku používáš, abychom rychle opravili,
+        když se něco rozbije. Data držíme v EU, škole je nepředáváme a bez
+        souhlasu neměříme nic.{" "}
         <Link
           href="/ochrana-soukromi"
           className="font-medium underline underline-offset-4 text-foreground hover:text-primary transition-colors inline-block"
@@ -86,10 +86,9 @@ export function ConsentBanner() {
         </Link>
       </p>
 
-      <p className="mt-2 text-xs text-muted-foreground/80 leading-normal">
-        Plníme tím zákon o elektronických komunikacích (§ 89 odst. 3 ZEK) a
-        nařízení GDPR. Souhlas je dobrovolný a kdykoli ho můžeš změnit nebo
-        odvolat v Nastavení.
+      <p className="mt-3.5 pt-2.5 border-t border-border/50 text-[11px] leading-normal text-muted-foreground/70">
+        Zákon o el. komunikacích (§ 89 odst. 3 ZEK) a nařízení GDPR. Volba je
+        dobrovolná a kdykoli ji změníš v Nastavení.
       </p>
 
       <div className="mt-4 flex flex-col-reverse sm:flex-row sm:items-center sm:justify-end gap-2">

--- a/src/components/posthog/consent-banner.tsx
+++ b/src/components/posthog/consent-banner.tsx
@@ -2,7 +2,7 @@
 
 import Link from "next/link";
 import { useState, useSyncExternalStore } from "react";
-import { ShieldCheck, X } from "lucide-react";
+import { Cookie, X } from "lucide-react";
 import posthog from "posthog-js";
 
 import { Button } from "@/components/ui/button";
@@ -43,29 +43,24 @@ export function ConsentBanner() {
   return (
     <div
       role="dialog"
+      aria-labelledby="consent-banner-title"
       aria-label="Souhlas s měřením používání"
-      className="fixed inset-x-4 bottom-4 z-50 mx-auto max-w-xl rounded-xl border bg-card p-4 shadow-lg"
+      className="fixed inset-x-4 bottom-4 z-50 mx-auto max-w-lg rounded-xl border bg-card p-4 sm:p-5 shadow-lg"
     >
-      <div className="flex items-start gap-3">
-        <span
-          aria-hidden="true"
-          className="flex size-9 shrink-0 items-center justify-center rounded-lg bg-muted"
-        >
-          <ShieldCheck className="size-5 text-primary" />
-        </span>
-        <div className="min-w-0 flex-1">
-          <p className="font-medium">Řekněte nám, co v Tappce funguje</p>
-          <p className="mt-1 text-sm text-muted-foreground">
-            Se souhlasem měříme, jak se používají rezervace a čtení, a
-            zaznamenáváme chyby, abychom je uměli opravit. Nikdy je nepředáváme
-            škole ke kontrole. Data držíme v EU. Bez souhlasu neměříme nic.{" "}
-            <Link
-              href="/ochrana-soukromi"
-              className="underline underline-offset-4 hover:text-foreground"
-            >
-              Jak chráníme soukromí
-            </Link>
-          </p>
+      <div className="flex items-start justify-between gap-3">
+        <div className="flex items-center gap-3 min-w-0">
+          <span
+            aria-hidden="true"
+            className="flex size-9 shrink-0 items-center justify-center rounded-lg bg-primary/10 text-primary"
+          >
+            <Cookie className="size-5" />
+          </span>
+          <h2
+            id="consent-banner-title"
+            className="font-heading text-base font-semibold text-foreground tracking-tight"
+          >
+            Řekněte nám, co v Tappce funguje
+          </h2>
         </div>
         <Button
           type="button"
@@ -73,27 +68,42 @@ export function ConsentBanner() {
           size="icon-sm"
           aria-label="Zavřít bez souhlasu"
           onClick={() => choose(false)}
-          className="shrink-0"
+          className="text-muted-foreground hover:text-foreground shrink-0 -mr-1 -mt-1"
         >
-          <X />
+          <X className="size-4" />
         </Button>
       </div>
-      <div className="mt-3 flex gap-2 pl-12">
-        <Button
-          type="button"
-          size="sm"
-          variant="outline"
-          onClick={() => choose(true)}
+
+      <p className="mt-3 text-sm text-muted-foreground leading-relaxed">
+        Se souhlasem měříme, jak se používají rezervace a čtení, a
+        zaznamenáváme chyby, abychom je uměli opravit. Nikdy je nepředáváme
+        škole ke kontrole. Data držíme v EU. Bez souhlasu neměříme nic.{" "}
+        <Link
+          href="/ochrana-soukromi"
+          className="font-medium underline underline-offset-4 text-foreground hover:text-primary transition-colors inline-block"
         >
-          Přijmout
-        </Button>
+          Jak chráníme soukromí →
+        </Link>
+      </p>
+
+      <div className="mt-4 flex flex-col-reverse sm:flex-row sm:items-center sm:justify-end gap-2">
         <Button
           type="button"
           size="sm"
           variant="outline"
+          className="w-full sm:w-auto min-w-24"
           onClick={() => choose(false)}
         >
           Odmítnout
+        </Button>
+        <Button
+          type="button"
+          size="sm"
+          variant="outline"
+          className="w-full sm:w-auto min-w-24"
+          onClick={() => choose(true)}
+        >
+          Přijmout
         </Button>
       </div>
     </div>

--- a/src/components/posthog/consent-banner.tsx
+++ b/src/components/posthog/consent-banner.tsx
@@ -97,7 +97,7 @@ export function ConsentBanner() {
           type="button"
           size="sm"
           variant="outline"
-          className="w-full sm:w-auto min-w-24 dark:border-foreground/25 dark:bg-foreground/10 dark:hover:bg-foreground/20"
+          className="w-full sm:w-auto min-w-24"
           onClick={() => choose(false)}
         >
           Odmítnout
@@ -106,7 +106,7 @@ export function ConsentBanner() {
           type="button"
           size="sm"
           variant="outline"
-          className="w-full sm:w-auto min-w-24 dark:border-foreground/25 dark:bg-foreground/10 dark:hover:bg-foreground/20"
+          className="w-full sm:w-auto min-w-24"
           onClick={() => choose(true)}
         >
           Přijmout

--- a/src/components/posthog/consent-banner.tsx
+++ b/src/components/posthog/consent-banner.tsx
@@ -1,0 +1,60 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import posthog from "posthog-js";
+
+import { Button } from "@/components/ui/button";
+
+export function ConsentBanner() {
+  const [visible, setVisible] = useState(false);
+
+  useEffect(() => {
+    try {
+      if (posthog.get_explicit_consent_status() === "pending") {
+        setVisible(true);
+      }
+    } catch {
+      // PostHog not initialised — stay hidden
+    }
+  }, []);
+
+  if (!visible) return null;
+
+  const accept = () => {
+    try {
+      posthog.opt_in_capturing();
+    } catch {
+      // ignore
+    }
+    setVisible(false);
+  };
+
+  const decline = () => {
+    try {
+      posthog.opt_out_capturing();
+    } catch {
+      // ignore
+    }
+    setVisible(false);
+  };
+
+  return (
+    <div
+      role="dialog"
+      aria-label="Souhlas s analytikou"
+      className="fixed inset-x-4 bottom-4 z-50 mx-auto max-w-xl rounded-xl border bg-card p-4 shadow-lg"
+    >
+      <p className="text-sm">
+        Pomozte nám zlepšit Tappku. Měříme anonymizované používání a chyby.
+      </p>
+      <div className="mt-3 flex gap-2">
+        <Button type="button" size="sm" onClick={accept}>
+          Přijmout
+        </Button>
+        <Button type="button" size="sm" variant="outline" onClick={decline}>
+          Odmítnout
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/src/components/posthog/consent-banner.tsx
+++ b/src/components/posthog/consent-banner.tsx
@@ -1,24 +1,27 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import { useState, useSyncExternalStore } from "react";
 import posthog from "posthog-js";
 
 import { Button } from "@/components/ui/button";
 
+const emptySubscribe = () => () => {};
+
+function getConsentStatus(): string {
+  try {
+    return posthog.get_explicit_consent_status();
+  } catch {
+    // PostHog not initialised — stay hidden
+    return "granted";
+  }
+}
+
 export function ConsentBanner() {
-  const [visible, setVisible] = useState(false);
+  const mounted = useSyncExternalStore(emptySubscribe, () => true, () => false);
+  const [dismissed, setDismissed] = useState(false);
 
-  useEffect(() => {
-    try {
-      if (posthog.get_explicit_consent_status() === "pending") {
-        setVisible(true);
-      }
-    } catch {
-      // PostHog not initialised — stay hidden
-    }
-  }, []);
-
-  if (!visible) return null;
+  if (!mounted || dismissed) return null;
+  if (getConsentStatus() !== "pending") return null;
 
   const accept = () => {
     try {
@@ -26,7 +29,7 @@ export function ConsentBanner() {
     } catch {
       // ignore
     }
-    setVisible(false);
+    setDismissed(true);
   };
 
   const decline = () => {
@@ -35,7 +38,7 @@ export function ConsentBanner() {
     } catch {
       // ignore
     }
-    setVisible(false);
+    setDismissed(true);
   };
 
   return (

--- a/src/components/posthog/consent-banner.tsx
+++ b/src/components/posthog/consent-banner.tsx
@@ -51,7 +51,8 @@ export function ConsentBanner() {
       <p className="font-medium">Řekněte nám, co v Tappce funguje</p>
       <p className="mt-1 text-sm text-muted-foreground">
         Se souhlasem měříme, jak se používají rezervace a čtení, a
-        zaznamenáváme chyby. Data držíme v EU a nečteme obsah esejí ani zpráv.
+        zaznamenáváme chyby, abychom je uměli opravit. Nikdy je nepředáváme
+        škole ke kontrole. Data držíme v EU a nečteme obsah esejí ani zpráv.
         Bez souhlasu neměříme nic.{" "}
         <Link
           href="/ochrana-soukromi"

--- a/src/components/posthog/consent-banner.tsx
+++ b/src/components/posthog/consent-banner.tsx
@@ -76,7 +76,8 @@ export function ConsentBanner() {
 
       <p className="mt-3 text-sm text-muted-foreground leading-relaxed">
         S tvým souhlasem měříme, jak Tappku používáš, abychom rychle opravili,
-        když se něco rozbije. Data držíme v EU, škole je nepředáváme a bez
+        když se něco rozbije, nebo naopak věděli, co používáš nejvíc a zaslouží
+        si naši pozornost. Data držíme v EU, škole je nepředáváme a bez
         souhlasu neměříme nic.{" "}
         <Link
           href="/ochrana-soukromi"

--- a/src/components/posthog/consent-banner.tsx
+++ b/src/components/posthog/consent-banner.tsx
@@ -2,19 +2,20 @@
 
 import Link from "next/link";
 import { useState, useSyncExternalStore } from "react";
-import { ShieldCheck } from "lucide-react";
+import { ShieldCheck, X } from "lucide-react";
 import posthog from "posthog-js";
 
 import { Button } from "@/components/ui/button";
+import { recordConsentChoice, shouldAskConsent } from "@/lib/consent";
 
 const emptySubscribe = () => () => {};
 
-function getConsentStatus(): string {
+function needsChoice(): boolean {
   try {
-    return posthog.get_explicit_consent_status();
+    return shouldAskConsent(posthog.get_explicit_consent_status());
   } catch {
     // PostHog not initialised — stay hidden
-    return "granted";
+    return false;
   }
 }
 
@@ -23,23 +24,19 @@ export function ConsentBanner() {
   const [dismissed, setDismissed] = useState(false);
 
   if (!mounted || dismissed) return null;
-  if (getConsentStatus() !== "pending") return null;
+  if (!needsChoice()) return null;
 
-  const accept = () => {
+  const choose = (granted: boolean) => {
     try {
-      posthog.opt_in_capturing();
+      if (granted) {
+        posthog.opt_in_capturing();
+      } else {
+        posthog.opt_out_capturing();
+      }
     } catch {
       // ignore
     }
-    setDismissed(true);
-  };
-
-  const decline = () => {
-    try {
-      posthog.opt_out_capturing();
-    } catch {
-      // ignore
-    }
+    recordConsentChoice();
     setDismissed(true);
   };
 
@@ -56,7 +53,7 @@ export function ConsentBanner() {
         >
           <ShieldCheck className="size-5 text-primary" />
         </span>
-        <div>
+        <div className="min-w-0 flex-1">
           <p className="font-medium">Řekněte nám, co v Tappce funguje</p>
           <p className="mt-1 text-sm text-muted-foreground">
             Se souhlasem měříme, jak se používají rezervace a čtení, a
@@ -70,12 +67,32 @@ export function ConsentBanner() {
             </Link>
           </p>
         </div>
+        <Button
+          type="button"
+          variant="ghost"
+          size="icon-sm"
+          aria-label="Zavřít bez souhlasu"
+          onClick={() => choose(false)}
+          className="shrink-0"
+        >
+          <X />
+        </Button>
       </div>
-      <div className="mt-3 flex gap-2">
-        <Button type="button" size="sm" variant="outline" onClick={accept}>
+      <div className="mt-3 flex gap-2 pl-12">
+        <Button
+          type="button"
+          size="sm"
+          variant="outline"
+          onClick={() => choose(true)}
+        >
           Přijmout
         </Button>
-        <Button type="button" size="sm" variant="outline" onClick={decline}>
+        <Button
+          type="button"
+          size="sm"
+          variant="outline"
+          onClick={() => choose(false)}
+        >
           Odmítnout
         </Button>
       </div>

--- a/src/components/posthog/consent-banner.tsx
+++ b/src/components/posthog/consent-banner.tsx
@@ -61,8 +61,7 @@ export function ConsentBanner() {
           <p className="mt-1 text-sm text-muted-foreground">
             Se souhlasem měříme, jak se používají rezervace a čtení, a
             zaznamenáváme chyby, abychom je uměli opravit. Nikdy je nepředáváme
-            škole ke kontrole. Data držíme v EU a měření nesbírá obsah esejí
-            ani zpráv. Bez souhlasu neměříme nic.{" "}
+            škole ke kontrole. Data držíme v EU. Bez souhlasu neměříme nic.{" "}
             <Link
               href="/ochrana-soukromi"
               className="underline underline-offset-4 hover:text-foreground"

--- a/src/components/posthog/consent-banner.tsx
+++ b/src/components/posthog/consent-banner.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import Link from "next/link";
 import { useState, useSyncExternalStore } from "react";
 import posthog from "posthog-js";
 
@@ -44,14 +45,23 @@ export function ConsentBanner() {
   return (
     <div
       role="dialog"
-      aria-label="Souhlas s analytikou"
+      aria-label="Souhlas s měřením používání"
       className="fixed inset-x-4 bottom-4 z-50 mx-auto max-w-xl rounded-xl border bg-card p-4 shadow-lg"
     >
-      <p className="text-sm">
-        Pomozte nám zlepšit Tappku. Měříme anonymizované používání a chyby.
+      <p className="font-medium">Řekněte nám, co v Tappce funguje</p>
+      <p className="mt-1 text-sm text-muted-foreground">
+        Se souhlasem měříme, jak se používají rezervace a čtení, a
+        zaznamenáváme chyby. Data držíme v EU a nečteme obsah esejí ani zpráv.
+        Bez souhlasu neměříme nic.{" "}
+        <Link
+          href="/ochrana-soukromi"
+          className="underline underline-offset-4 hover:text-foreground"
+        >
+          Jak chráníme soukromí
+        </Link>
       </p>
       <div className="mt-3 flex gap-2">
-        <Button type="button" size="sm" onClick={accept}>
+        <Button type="button" size="sm" variant="outline" onClick={accept}>
           Přijmout
         </Button>
         <Button type="button" size="sm" variant="outline" onClick={decline}>

--- a/src/components/posthog/consent-banner.tsx
+++ b/src/components/posthog/consent-banner.tsx
@@ -97,7 +97,7 @@ export function ConsentBanner() {
           type="button"
           size="sm"
           variant="outline"
-          className="w-full sm:w-auto min-w-24"
+          className="w-full sm:w-auto min-w-24 dark:border-foreground/25 dark:bg-foreground/10 dark:hover:bg-foreground/20"
           onClick={() => choose(false)}
         >
           Odmítnout
@@ -106,7 +106,7 @@ export function ConsentBanner() {
           type="button"
           size="sm"
           variant="outline"
-          className="w-full sm:w-auto min-w-24"
+          className="w-full sm:w-auto min-w-24 dark:border-foreground/25 dark:bg-foreground/10 dark:hover:bg-foreground/20"
           onClick={() => choose(true)}
         >
           Přijmout

--- a/src/components/posthog/consent-settings.test.tsx
+++ b/src/components/posthog/consent-settings.test.tsx
@@ -1,0 +1,40 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it, vi } from "vitest";
+
+import posthog from "posthog-js";
+
+import { ConsentSettings } from "./consent-settings";
+
+vi.mock("posthog-js", () => ({
+  default: {
+    get_explicit_consent_status: vi.fn(),
+    opt_in_capturing: vi.fn(),
+    opt_out_capturing: vi.fn(),
+  },
+}));
+
+const mockedPosthog = vi.mocked(posthog);
+
+describe("ConsentSettings", () => {
+  it("withdraws consent with one click when granted", async () => {
+    mockedPosthog.get_explicit_consent_status.mockReturnValue("granted");
+    const user = userEvent.setup();
+    render(<ConsentSettings />);
+    await user.click(
+      screen.getByRole("button", { name: /odvolat souhlas/i }),
+    );
+    expect(mockedPosthog.opt_out_capturing).toHaveBeenCalledOnce();
+    expect(
+      screen.getByRole("button", { name: /zapnout měření/i }),
+    ).toBeInTheDocument();
+  });
+
+  it("re-grants consent with one click when denied", async () => {
+    mockedPosthog.get_explicit_consent_status.mockReturnValue("denied");
+    const user = userEvent.setup();
+    render(<ConsentSettings />);
+    await user.click(screen.getByRole("button", { name: /zapnout měření/i }));
+    expect(mockedPosthog.opt_in_capturing).toHaveBeenCalledOnce();
+  });
+});

--- a/src/components/posthog/consent-settings.tsx
+++ b/src/components/posthog/consent-settings.tsx
@@ -51,7 +51,7 @@ export function ConsentSettings() {
         </h2>
         <p className="text-sm text-muted-foreground">
           {granted
-            ? "Měření je zapnuté: vidíme, jak se používají rezervace a čtení, a chyby k opravě. Škole se nic nepředává."
+            ? "Měření je zapnuté: vidíme, jak Tappku používáš, a když se něco rozbije, abychom to mohli opravit. Škole se nic nepředává."
             : "Měření je vypnuté: nic se neměří."}{" "}
           <Link
             href="/ochrana-soukromi"

--- a/src/components/posthog/consent-settings.tsx
+++ b/src/components/posthog/consent-settings.tsx
@@ -1,0 +1,85 @@
+"use client";
+
+import Link from "next/link";
+import { useState, useSyncExternalStore } from "react";
+import posthog from "posthog-js";
+
+import { Button } from "@/components/ui/button";
+import { recordConsentChoice } from "@/lib/consent";
+
+const emptySubscribe = () => () => {};
+
+function currentStatus(): string {
+  try {
+    return posthog.get_explicit_consent_status();
+  } catch {
+    return "pending";
+  }
+}
+
+/**
+ * Self-service consent toggle: withdrawing is one click, re-granting too.
+ * Mounted in Nastavení → Notifikace so consent never requires support.
+ */
+export function ConsentSettings() {
+  const mounted = useSyncExternalStore(emptySubscribe, () => true, () => false);
+  const [status, setStatus] = useState<string | null>(null);
+
+  if (!mounted) return null;
+  const effective = status ?? currentStatus();
+  const granted = effective === "granted";
+
+  const choose = (next: boolean) => {
+    try {
+      if (next) {
+        posthog.opt_in_capturing();
+      } else {
+        posthog.opt_out_capturing();
+      }
+    } catch {
+      // ignore
+    }
+    recordConsentChoice();
+    setStatus(next ? "granted" : "denied");
+  };
+
+  return (
+    <section aria-label="Měření používání" className="space-y-3">
+      <div>
+        <h2 className="font-heading text-lg font-semibold">
+          Měření používání
+        </h2>
+        <p className="text-sm text-muted-foreground">
+          {granted
+            ? "Měření je zapnuté: vidíme, jak se používají rezervace a čtení, a chyby k opravě. Škole se nic nepředává."
+            : "Měření je vypnuté: nic se neměří."}{" "}
+          <Link
+            href="/ochrana-soukromi"
+            className="underline underline-offset-4 hover:text-foreground"
+          >
+            Jak chráníme soukromí
+          </Link>
+        </p>
+      </div>
+      {granted ? (
+        <Button
+          type="button"
+          variant="outline"
+          size="sm"
+          onClick={() => choose(false)}
+        >
+          Odvolat souhlas s měřením
+        </Button>
+      ) : (
+        <Button
+          type="button"
+          variant="outline"
+          size="sm"
+          onClick={() => choose(true)}
+        >
+          Zapnout měření používání
+        </Button>
+      )}
+    </section>
+  );
+}

--- a/src/components/posthog/posthog-identify.test.tsx
+++ b/src/components/posthog/posthog-identify.test.tsx
@@ -1,0 +1,46 @@
+import { render } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+import { PostHogIdentify } from "./posthog-identify";
+
+const identify = vi.fn();
+const group = vi.fn();
+
+vi.mock("posthog-js/react", () => ({
+  usePostHog: () => ({ identify, group }),
+}));
+
+describe("PostHogIdentify", () => {
+  it("identifies with role and groups by team", () => {
+    render(
+      <PostHogIdentify
+        distinctId="user-1"
+        role="student"
+        betaAccess={false}
+        betaCohort="A"
+        teamId="team-1"
+      />,
+    );
+    expect(identify).toHaveBeenCalledWith(
+      "user-1",
+      expect.objectContaining({ role: "student" }),
+    );
+    expect(group).toHaveBeenCalledWith("team", "team-1");
+  });
+
+  it("skips group when no team", () => {
+    identify.mockClear();
+    group.mockClear();
+    render(
+      <PostHogIdentify
+        distinctId="user-2"
+        role="coach"
+        betaAccess
+        betaCohort="B"
+        teamId={null}
+      />,
+    );
+    expect(identify).toHaveBeenCalled();
+    expect(group).not.toHaveBeenCalled();
+  });
+});

--- a/src/components/posthog/posthog-identify.tsx
+++ b/src/components/posthog/posthog-identify.tsx
@@ -5,17 +5,26 @@ import { usePostHog } from "posthog-js/react"
 
 export function PostHogIdentify({
   distinctId,
+  role,
   betaAccess,
   betaCohort,
+  teamId,
 }: {
   distinctId: string
+  role: string
   betaAccess: boolean
   betaCohort: "A" | "B"
+  teamId?: string | null
 }) {
   const posthog = usePostHog()
   useEffect(() => {
     if (!posthog) return
-    posthog.identify(distinctId, { beta_access: betaAccess, beta_cohort: betaCohort })
-  }, [posthog, distinctId, betaAccess, betaCohort])
+    posthog.identify(distinctId, {
+      role,
+      beta_access: betaAccess,
+      beta_cohort: betaCohort,
+    })
+    if (teamId) posthog.group("team", teamId)
+  }, [posthog, distinctId, role, betaAccess, betaCohort, teamId])
   return null
 }

--- a/src/components/reservations/reservations-view-tracker.test.tsx
+++ b/src/components/reservations/reservations-view-tracker.test.tsx
@@ -1,0 +1,15 @@
+import { render } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+import { trackView } from "@/lib/analytics";
+
+import { ReservationsViewTracker } from "./reservations-view-tracker";
+
+vi.mock("@/lib/analytics", () => ({ trackView: vi.fn() }));
+
+describe("ReservationsViewTracker", () => {
+  it("tracks reservations view on mount", () => {
+    render(<ReservationsViewTracker />);
+    expect(trackView).toHaveBeenCalledWith("reservations");
+  });
+});

--- a/src/components/reservations/reservations-view-tracker.tsx
+++ b/src/components/reservations/reservations-view-tracker.tsx
@@ -1,0 +1,12 @@
+"use client";
+
+import { useEffect } from "react";
+
+import { trackView } from "@/lib/analytics";
+
+export function ReservationsViewTracker() {
+  useEffect(() => {
+    trackView("reservations");
+  }, []);
+  return null;
+}

--- a/src/components/ui/button.tsx
+++ b/src/components/ui/button.tsx
@@ -13,7 +13,7 @@ const buttonVariants = cva(
         destructive:
           "bg-destructive text-white hover:bg-destructive/90 focus-visible:ring-destructive/20 dark:focus-visible:ring-destructive/40 dark:bg-destructive/60",
         outline:
-          "border bg-background shadow-xs hover:bg-accent hover:text-accent-foreground dark:bg-input/30 dark:border-input dark:hover:bg-input/50",
+          "border bg-background shadow-xs hover:bg-accent hover:text-accent-foreground dark:bg-foreground/5 dark:border-foreground/20 dark:hover:bg-foreground/10",
         secondary:
           "bg-secondary text-secondary-foreground hover:bg-secondary/80",
         ghost:

--- a/src/instrumentation-client.ts
+++ b/src/instrumentation-client.ts
@@ -19,5 +19,26 @@ if (process.env.NEXT_PUBLIC_POSTHOG_KEY) {
     mask_all_text: false,
     opt_out_capturing_by_default: true,
     opt_out_capturing_persistence_type: "localStorage",
+    before_send: (event) => {
+      // Group chunk-load failures (deploy version skew) into one issue.
+      if (event?.event === "$exception") {
+        const list = (event.properties?.["$exception_list"] ?? []) as Array<{
+          $exception_type?: string;
+          $exception_message?: string;
+        }>;
+        const first = list[0];
+        const message = first?.$exception_message ?? "";
+        if (
+          first?.$exception_type === "ChunkLoadError" ||
+          /chunk|loading chunk|dynamically imported module/i.test(message)
+        ) {
+          event.properties = {
+            ...event.properties,
+            $exception_fingerprint: "chunk-load-error",
+          };
+        }
+      }
+      return event;
+    },
   });
 }

--- a/src/instrumentation-client.ts
+++ b/src/instrumentation-client.ts
@@ -2,9 +2,22 @@ import posthog from "posthog-js";
 
 if (process.env.NEXT_PUBLIC_POSTHOG_KEY) {
   posthog.init(process.env.NEXT_PUBLIC_POSTHOG_KEY, {
-    api_host: process.env.NEXT_PUBLIC_POSTHOG_HOST,
+    api_host: "/ingest",
     defaults: "2026-01-30",
     capture_pageview: false,
     capture_pageleave: true,
+    capture_heatmaps: true,
+    enable_recording_console_log: false,
+    autocapture: {
+      css_selector_ignorelist: [
+        "[data-ph-no-capture]",
+        ".ph-no-capture",
+        "[data-sensitive]",
+      ],
+    },
+    mask_all_element_attributes: false,
+    mask_all_text: false,
+    opt_out_capturing_by_default: true,
+    opt_out_capturing_persistence_type: "localStorage",
   });
 }

--- a/src/instrumentation.ts
+++ b/src/instrumentation.ts
@@ -9,6 +9,9 @@ export const onRequestError: Instrumentation.onRequestError = async (
   request,
   _context
 ) => {
+  // Note: PostHog docs recommend `export { onRequestError } from "@posthog/next"`.
+  // We keep this hand-rolled hook to avoid adding a new dependency: it already
+  // forwards the client distinct_id from the PostHog cookie for identity linking.
   if (process.env.NEXT_RUNTIME === "nodejs") {
     const { getPostHogServer } = await import("./lib/posthog-server");
     const posthog = getPostHogServer();

--- a/src/lib/analytics-server.test.ts
+++ b/src/lib/analytics-server.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { trackServer } from "./analytics-server";
+
+const captureImmediate = vi.fn();
+
+vi.mock("./posthog-server", () => ({
+  getPostHogServer: () => ({ captureImmediate }),
+}));
+
+describe("trackServer", () => {
+  it("forwards event with distinctId and props", async () => {
+    await trackServer("feature_interaction", "user-1", {
+      feature: "reservations",
+      action: "created",
+    });
+    expect(captureImmediate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        distinctId: "user-1",
+        event: "feature_interaction",
+      }),
+    );
+  });
+});

--- a/src/lib/analytics-server.ts
+++ b/src/lib/analytics-server.ts
@@ -1,0 +1,17 @@
+import { getPostHogServer } from "./posthog-server";
+
+type AllowedProp = string | number | boolean;
+
+export async function trackServer(
+  event: string,
+  distinctId: string,
+  properties: Record<string, AllowedProp> = {},
+): Promise<void> {
+  const client = getPostHogServer();
+  if (!client) return;
+  try {
+    await client.captureImmediate({ distinctId, event, properties });
+  } catch {
+    // ignore — analytics must never break the app
+  }
+}

--- a/src/lib/analytics.test.ts
+++ b/src/lib/analytics.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it, vi } from "vitest";
+
+import posthog from "posthog-js";
+
+import { trackFeature } from "./analytics";
+
+describe("trackFeature", () => {
+  it("captures feature_interaction with allowlisted props", () => {
+    const spy = vi
+      .spyOn(posthog, "capture")
+      .mockImplementation(() => undefined);
+    trackFeature("reservations", "created");
+    expect(spy).toHaveBeenCalledWith(
+      "feature_interaction",
+      expect.objectContaining({ feature: "reservations", action: "created" }),
+    );
+    spy.mockRestore();
+  });
+});

--- a/src/lib/analytics.ts
+++ b/src/lib/analytics.ts
@@ -1,0 +1,30 @@
+import posthog from "posthog-js";
+
+// Pilot scope: only GA features. Add others when they leave beta.
+export const FEATURES = ["reservations", "cteni"] as const;
+export type FeatureKey = (typeof FEATURES)[number];
+
+type AllowedProp = string | number | boolean;
+
+export function trackFeature(
+  feature: FeatureKey,
+  action: string,
+  props: Record<string, AllowedProp> = {},
+): void {
+  try {
+    posthog.capture("feature_interaction", { feature, action, ...props });
+  } catch {
+    // ignore — analytics must never break the app
+  }
+}
+
+export function trackView(
+  feature: FeatureKey,
+  props: Record<string, AllowedProp> = {},
+): void {
+  try {
+    posthog.capture("feature_view", { feature, ...props });
+  } catch {
+    // ignore — analytics must never break the app
+  }
+}

--- a/src/lib/consent.test.ts
+++ b/src/lib/consent.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  DECLINE_REASK_MS,
+  GRANT_VALID_MS,
+  shouldAskConsent,
+} from "./consent";
+
+const NOW = 1_800_000_000_000;
+
+function memoryStorage(initial: Record<string, string> = {}) {
+  const map = new Map(Object.entries(initial));
+  return {
+    getItem: (key: string) => map.get(key) ?? null,
+    setItem: (key: string, value: string) => {
+      map.set(key, value);
+    },
+  };
+}
+
+describe("shouldAskConsent", () => {
+  it("asks when status is pending", () => {
+    expect(shouldAskConsent("pending", NOW, memoryStorage())).toBe(true);
+  });
+
+  it("asks when no timestamp exists", () => {
+    const storage = memoryStorage();
+    expect(shouldAskConsent("granted", NOW, storage)).toBe(true);
+    expect(shouldAskConsent("denied", NOW, storage)).toBe(true);
+  });
+
+  it("respects 12-month grant and 6-month decline windows", () => {
+    const grantFresh = memoryStorage({
+      "tappka-consent-at": String(NOW - GRANT_VALID_MS + 1),
+    });
+    expect(shouldAskConsent("granted", NOW, grantFresh)).toBe(false);
+    const grantStale = memoryStorage({
+      "tappka-consent-at": String(NOW - GRANT_VALID_MS - 1),
+    });
+    expect(shouldAskConsent("granted", NOW, grantStale)).toBe(true);
+
+    const declineFresh = memoryStorage({
+      "tappka-consent-at": String(NOW - DECLINE_REASK_MS + 1),
+    });
+    expect(shouldAskConsent("denied", NOW, declineFresh)).toBe(false);
+    const declineStale = memoryStorage({
+      "tappka-consent-at": String(NOW - DECLINE_REASK_MS - 1),
+    });
+    expect(shouldAskConsent("denied", NOW, declineStale)).toBe(true);
+  });
+});

--- a/src/lib/consent.ts
+++ b/src/lib/consent.ts
@@ -1,0 +1,65 @@
+const CONSENT_AT_KEY = "tappka-consent-at";
+
+const DAY_MS = 24 * 60 * 60 * 1000;
+// Per ÚOOÚ guidance: consent valid ~12 months, re-ask at the earliest
+// 6 months after a refusal.
+export const GRANT_VALID_MS = 365 * DAY_MS;
+export const DECLINE_REASK_MS = 6 * 30 * DAY_MS;
+
+interface ConsentStorage {
+  getItem(key: string): string | null;
+  setItem(key: string, value: string): void;
+}
+
+function defaultStorage(): ConsentStorage | null {
+  try {
+    if (typeof localStorage === "undefined") return null;
+    return localStorage;
+  } catch {
+    return null;
+  }
+}
+
+export function readConsentAt(
+  now: number = Date.now(),
+  storage: ConsentStorage | null = defaultStorage(),
+): number | null {
+  if (!storage) return null;
+  try {
+    const raw = storage.getItem(CONSENT_AT_KEY);
+    if (!raw) return null;
+    const at = Number(raw);
+    return Number.isFinite(at) && at <= now ? at : null;
+  } catch {
+    return null;
+  }
+}
+
+export function recordConsentChoice(
+  now: number = Date.now(),
+  storage: ConsentStorage | null = defaultStorage(),
+): void {
+  if (!storage) return;
+  try {
+    storage.setItem(CONSENT_AT_KEY, String(now));
+  } catch {
+    // storage unavailable — consent choice itself is still persisted by PostHog
+  }
+}
+
+/**
+ * Whether the banner should ask. Re-asks when the previous choice expired
+ * (12 months grant / 6 months decline) or when no timestamp exists, since
+ * the operator must be able to prove when consent was given.
+ */
+export function shouldAskConsent(
+  status: string,
+  now: number = Date.now(),
+  storage: ConsentStorage | null = defaultStorage(),
+): boolean {
+  if (status === "pending") return true;
+  const at = readConsentAt(now, storage);
+  if (at == null) return true;
+  if (status === "granted") return now - at > GRANT_VALID_MS;
+  return now - at > DECLINE_REASK_MS;
+}


### PR DESCRIPTION
## Summary

Comprehensive PostHog product + error telemetry implementation on `feat/posthog-improvements`, GDPR compliance groundwork, privacy page, responsive consent banner, and global button dark-mode contrast fix.

### What's Changed

1. **Ingest Proxy & PostHog Client/Server Init**:
   - Reverse proxy `/ingest` in `next.config.ts` to bypass adblockers.
   - Hardened client init with `opt_out_capturing_by_default: true` and localStorage persistence.
   - Enriched identify and group registration (roles, team IDs) via `PostHogIdentify`.
   - Server-side event capture (`trackServer`) using Next.js `after()` across reservation creation, essay submission, and book borrow routes.
   - Page view tracking components for GA features (`ReservationsViewTracker`, `CteniViewTracker`).
   - Hardened error monitoring with chunk error fingerprinting and feature context.

2. **GDPR Consent Banner & Settings**:
   - Banner (`ConsentBanner`) with human, non-generic Czech copy in standard tykání: *„Ať víme, když se něco rozbije...“*
   - Clear distinction between human rationale (fixing bugs + feature prioritization) and a quiet statutory footnote citing § 89 odst. 3 ZEK & GDPR.
   - Equal-weight buttons (`Odmítnout` and `Přijmout`) avoiding deceptive patterns / dark patterns.
   - Responsive layout: clean bottom right-aligned buttons on desktop, stacked full-width touch targets on mobile.
   - Self-service consent management toggle in `Nastavení → Notifikace` (`ConsentSettings`).

3. **Privacy Page**:
   - Dedicated privacy documentation at `/ochrana-soukromi` linked in banner and `/about` footer.
   - Clarifies data controller (Spirit of TAP, z.s., IČO 23152036), EU data storage, separation of study data from analytics, and retention periods (90d events, 30d errors).

4. **Global Dark Mode Button Fix**:
   - Updated `Button` primitive `outline` variant in `src/components/ui/button.tsx`.
   - Fixed virtually invisible dark mode outline buttons across the entire app (e.g. `Rezervovat místnost`, `Hledat knihu`, consent banner) using `dark:bg-foreground/5 dark:border-foreground/20 dark:hover:bg-foreground/10`.

### Verification
- Component & unit tests pass: `pnpm vitest run` (all touched and related suites pass).
- Typecheck: `pnpm typecheck` clean (0 errors).
- ESLint: clean on touched files.