### PR TITLE
feat: PostHog OpenTelemetry logs, GDPR analytics improvements & page titles cleanup

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,6 +39,10 @@
   },
   "dependencies": {
     "@hookform/resolvers": "^5.2.2",
+    "@opentelemetry/api-logs": "^0.222.0",
+    "@opentelemetry/exporter-logs-otlp-http": "^0.222.0",
+    "@opentelemetry/resources": "^2.11.0",
+    "@opentelemetry/sdk-logs": "^0.222.0",
     "@perplexity-ai/perplexity_ai": "0.38.1",
     "@radix-ui/react-accordion": "^1.2.12",
     "@radix-ui/react-alert-dialog": "^1.1.15",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -27,6 +27,18 @@ importers:
       '@hookform/resolvers':
         specifier: ^5.2.2
         version: 5.2.2(react-hook-form@7.71.1(react@19.2.3))
+      '@opentelemetry/api-logs':
+        specifier: ^0.222.0
+        version: 0.222.0
+      '@opentelemetry/exporter-logs-otlp-http':
+        specifier: ^0.222.0
+        version: 0.222.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/resources':
+        specifier: ^2.11.0
+        version: 2.11.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/sdk-logs':
+        specifier: ^0.222.0
+        version: 0.222.0(@opentelemetry/api@1.9.0)
       '@perplexity-ai/perplexity_ai':
         specifier: 0.38.1
         version: 0.38.1
@@ -1241,9 +1253,65 @@ packages:
     resolution: {integrity: sha512-nn5ozdjYQpUCZlWGuxcJY/KpxkWQs4DcbMCmKojjyrYDEAGy4Ce19NN4v5MduafTwJlbKc99UA8YhSVqq9yPZA==}
     engines: {node: '>=12.4.0'}
 
+  '@opentelemetry/api-logs@0.222.0':
+    resolution: {integrity: sha512-9mb1If+IF6u0ZVXkHQ6ogEae5HwA6ajIVUgpSDQyRASxft6BSXHvBvPooRle3yFN/fKnCdSOnuu0OC3PLcF6+g==}
+    engines: {node: '>=8.0.0'}
+
   '@opentelemetry/api@1.9.0':
     resolution: {integrity: sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg==}
     engines: {node: '>=8.0.0'}
+
+  '@opentelemetry/core@2.11.0':
+    resolution: {integrity: sha512-7YP44XH0tV6+Mb54x2YGf84i7yi+31MBZlE8JwvozkxyTvXbSp10X7cI7YE49ChJ3shMJoBmCJF3+1QFBJctGA==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': '>=1.0.0 <1.10.0'
+
+  '@opentelemetry/exporter-logs-otlp-http@0.222.0':
+    resolution: {integrity: sha512-GqwLZohJTf/sttYlOpT1oFTJ9ScYaKnk0sOx4Qe/+KmXYVOa+v94cfnkUkFKDuvTODWhCL50Hz3gvsZD6ngQpg==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+
+  '@opentelemetry/otlp-exporter-base@0.222.0':
+    resolution: {integrity: sha512-YbywG3veEm2Fb6TbdxRkuquWob6eVWXuA8/Ba1tXz9jHfUqpdE3keilOHEtPboC4CvS1bjeeVfNkWGOOrLj+lw==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+
+  '@opentelemetry/otlp-transformer@0.222.0':
+    resolution: {integrity: sha512-/F3BZ89+CJQnZkMh2tCrtcdB+XT2Dxhj4FFE+WPQ//413hmFL0/RfEX6vgOIWGhiSzrkHWTK3+6SiT7K5/g/jQ==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+
+  '@opentelemetry/resources@2.11.0':
+    resolution: {integrity: sha512-Ie7+8q8MDF4FAEQCKVMTx3ReUvxiIAgIiiW3c9JdmP8+HMcDy20puT+AHjexnExgnbvBxjQ9fjkFDWrikJ2jQA==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': '>=1.3.0 <1.10.0'
+
+  '@opentelemetry/sdk-logs@0.222.0':
+    resolution: {integrity: sha512-+19YHODIjaUCArxleaJtuufFZVpz/xvvK+VllQqE+W8hHolxdoRwHfK/s667zezwh1hkx6FFF+oYzetYgqK+Bg==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': '>=1.4.0 <1.10.0'
+
+  '@opentelemetry/sdk-metrics@2.11.0':
+    resolution: {integrity: sha512-7GXXcObyHyDUUSG+L+kJoquty01bzm7ivE7+SSgXXJcHuPzGviptxwARmI2c+bnnxjexGQbJnyNlN8HxBP/Y7A==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': '>=1.9.0 <1.10.0'
+
+  '@opentelemetry/sdk-trace@2.11.0':
+    resolution: {integrity: sha512-fFnTqGm8/G73GQVnxYi7LXa1ZVYEUvgL6XI1LpvV0bPC7WQ/ZGgKxCSl8FnlZBKto9JHHEFTO6s6CUpvvtwFrA==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': '>=1.3.0 <1.10.0'
+
+  '@opentelemetry/semantic-conventions@1.43.0':
+    resolution: {integrity: sha512-eSYWTm620tTk45EKSedaUL8MFYI8hW164hIXsgIHyxu3VobUB3fFCu5t0hQby6OoWRPsG1KkKUG2M5UadiLiVg==}
+    engines: {node: '>=14'}
 
   '@oxc-project/types@0.139.0':
     resolution: {integrity: sha512-r9gHphtCs+1M7J0pw6Sn/hh/Wpa/iQrOOkrNAlVLF/gHq+/CJmHIWKKUUhdWjcD6CIa8idarspCsASiXCXvFUw==}
@@ -6564,8 +6632,68 @@ snapshots:
 
   '@nolyfill/is-core-module@1.0.39': {}
 
-  '@opentelemetry/api@1.9.0':
-    optional: true
+  '@opentelemetry/api-logs@0.222.0':
+    dependencies:
+      '@opentelemetry/api': 1.9.0
+
+  '@opentelemetry/api@1.9.0': {}
+
+  '@opentelemetry/core@2.11.0(@opentelemetry/api@1.9.0)':
+    dependencies:
+      '@opentelemetry/api': 1.9.0
+      '@opentelemetry/semantic-conventions': 1.43.0
+
+  '@opentelemetry/exporter-logs-otlp-http@0.222.0(@opentelemetry/api@1.9.0)':
+    dependencies:
+      '@opentelemetry/api': 1.9.0
+      '@opentelemetry/otlp-exporter-base': 0.222.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/otlp-transformer': 0.222.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/sdk-logs': 0.222.0(@opentelemetry/api@1.9.0)
+
+  '@opentelemetry/otlp-exporter-base@0.222.0(@opentelemetry/api@1.9.0)':
+    dependencies:
+      '@opentelemetry/api': 1.9.0
+      '@opentelemetry/core': 2.11.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/otlp-transformer': 0.222.0(@opentelemetry/api@1.9.0)
+
+  '@opentelemetry/otlp-transformer@0.222.0(@opentelemetry/api@1.9.0)':
+    dependencies:
+      '@opentelemetry/api': 1.9.0
+      '@opentelemetry/api-logs': 0.222.0
+      '@opentelemetry/core': 2.11.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/resources': 2.11.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/sdk-logs': 0.222.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/sdk-metrics': 2.11.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/sdk-trace': 2.11.0(@opentelemetry/api@1.9.0)
+
+  '@opentelemetry/resources@2.11.0(@opentelemetry/api@1.9.0)':
+    dependencies:
+      '@opentelemetry/api': 1.9.0
+      '@opentelemetry/core': 2.11.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/semantic-conventions': 1.43.0
+
+  '@opentelemetry/sdk-logs@0.222.0(@opentelemetry/api@1.9.0)':
+    dependencies:
+      '@opentelemetry/api': 1.9.0
+      '@opentelemetry/api-logs': 0.222.0
+      '@opentelemetry/core': 2.11.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/resources': 2.11.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/semantic-conventions': 1.43.0
+
+  '@opentelemetry/sdk-metrics@2.11.0(@opentelemetry/api@1.9.0)':
+    dependencies:
+      '@opentelemetry/api': 1.9.0
+      '@opentelemetry/core': 2.11.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/resources': 2.11.0(@opentelemetry/api@1.9.0)
+
+  '@opentelemetry/sdk-trace@2.11.0(@opentelemetry/api@1.9.0)':
+    dependencies:
+      '@opentelemetry/api': 1.9.0
+      '@opentelemetry/core': 2.11.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/resources': 2.11.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/semantic-conventions': 1.43.0
+
+  '@opentelemetry/semantic-conventions@1.43.0': {}
 
   '@oxc-project/types@0.139.0': {}
 

--- a/src/app/(main)/birth-giving/[eventId]/page.tsx
+++ b/src/app/(main)/birth-giving/[eventId]/page.tsx
@@ -13,7 +13,7 @@ interface BirthGivingEventPageProps {
 }
 
 export const metadata = {
-  title: "Birth Giving | Tappka",
+  title: "Birth Giving",
   description: "Detail Birth Giving události, týmů a výsledků",
 }
 

--- a/src/app/(main)/birth-giving/historie/nova/page.tsx
+++ b/src/app/(main)/birth-giving/historie/nova/page.tsx
@@ -10,7 +10,7 @@ import { FeatureComingSoon } from "@/components/beta/feature-coming-soon"
 import { canAccessFeature, type BetaCohort } from "@/lib/feature-access"
 
 export const metadata = {
-  title: "Historická Birth Giving událost | Tappka",
+  title: "Historická Birth Giving událost",
   description: "Zapiš proběhlou událost po krocích — změny se ukládají průběžně",
 }
 

--- a/src/app/(main)/birth-giving/nova/page.tsx
+++ b/src/app/(main)/birth-giving/nova/page.tsx
@@ -11,7 +11,7 @@ import { FeatureComingSoon } from "@/components/beta/feature-coming-soon"
 import { canAccessFeature, type BetaCohort } from "@/lib/feature-access"
 
 export const metadata = {
-  title: "Nová Birth Giving událost | Tappka",
+  title: "Nová Birth Giving událost",
   description: "Nastav termín, místo a organizátory nadcházející události",
 }
 

--- a/src/app/(main)/birth-giving/page.tsx
+++ b/src/app/(main)/birth-giving/page.tsx
@@ -9,7 +9,7 @@ import { FeatureComingSoon } from "@/components/beta/feature-coming-soon"
 import { canAccessFeature, type BetaCohort } from "@/lib/feature-access"
 
 export const metadata = {
-  title: "Birth Giving | Tappka",
+  title: "Birth Giving",
   description: "Přehled hackathonů, týmových řešení a odevzdaných výstupů",
 }
 

--- a/src/app/(main)/cteni/eseje/[essayId]/page.tsx
+++ b/src/app/(main)/cteni/eseje/[essayId]/page.tsx
@@ -20,7 +20,7 @@ import { BackButton } from '@/components/essays/back-button';
 import { ProfileAvatar } from '@/components/profile-avatar';
 
 export const metadata = {
-  title: 'Esej | Tappka',
+  title: 'Esej',
 };
 import { formatPoints } from '@/lib/books/points';
 import { BookStatusBadges } from '@/components/books/book-status-badges';

--- a/src/app/(main)/cteni/eseje/ke-kontrole/page.tsx
+++ b/src/app/(main)/cteni/eseje/ke-kontrole/page.tsx
@@ -7,7 +7,7 @@ import { PageHeader } from '@/components/ui/page-header';
 import { PageShell } from '@/components/ui/page-shell';
 
 export const metadata = {
-  title: 'Ke kontrole | Tappka',
+  title: 'Ke kontrole',
   description: 'Nové eseje od studujících',
 };
 

--- a/src/app/(main)/cteni/knihy/[bookId]/page.tsx
+++ b/src/app/(main)/cteni/knihy/[bookId]/page.tsx
@@ -19,7 +19,7 @@ import { PageShell } from '@/components/ui/page-shell';
 import { BookAdminActions } from './admin-actions';
 
 export const metadata = {
-  title: 'Detail knihy | Tappka',
+  title: 'Detail knihy',
 };
 import { BookDescription } from '@/components/books/book-description';
 import { BookEssaysList } from '@/components/books/book-essays-list';

--- a/src/app/(main)/cteni/knihy/[bookId]/pujcit/page.tsx
+++ b/src/app/(main)/cteni/knihy/[bookId]/pujcit/page.tsx
@@ -16,7 +16,7 @@ import { PageBack } from '@/components/ui/page-back';
 import { PageShell } from '@/components/ui/page-shell';
 
 export const metadata = {
-  title: 'Půjčit knihu | Tappka',
+  title: 'Půjčit knihu',
 };
 
 interface PageProps {

--- a/src/app/(main)/cteni/knihy/[bookId]/upravit/page.tsx
+++ b/src/app/(main)/cteni/knihy/[bookId]/upravit/page.tsx
@@ -10,7 +10,7 @@ interface PageProps {
 }
 
 export const metadata = {
-  title: 'Upravit knihu | Tappka',
+  title: 'Upravit knihu',
 };
 
 export default async function BookEditPage({ params }: PageProps) {

--- a/src/app/(main)/cteni/knihy/nova/page.tsx
+++ b/src/app/(main)/cteni/knihy/nova/page.tsx
@@ -4,7 +4,7 @@ import { AddBookFlow } from '@/components/books/add-book/add-book-flow';
 import { parseLibraryLabelCode } from '@/lib/library/label-code';
 
 export const metadata = {
-  title: 'Přidat knihu do BOBa | Tappka',
+  title: 'Přidat knihu do BOBa',
 };
 
 interface NovaKnihaPageProps {

--- a/src/app/(main)/cteni/knihy/rocket-model/page.tsx
+++ b/src/app/(main)/cteni/knihy/rocket-model/page.tsx
@@ -12,7 +12,7 @@ import { structureBookTitle } from '@/lib/books/format-title';
 import { pluralizeCz } from '@/lib/utils/pluralize-cz';
 
 export const metadata = {
-  title: 'Rocket Model | Tappka',
+  title: 'Rocket Model',
   description: 'Klíčové knihy programu — pomáhají Téčkům nastartovat cestu rychleji a bez oklik',
 };
 

--- a/src/app/(main)/cteni/knihy/top-bob/page.tsx
+++ b/src/app/(main)/cteni/knihy/top-bob/page.tsx
@@ -8,7 +8,7 @@ import { PageShell } from '@/components/ui/page-shell';
 import { TopBobBrowser } from '@/components/books/top-bob-browser';
 
 export const metadata = {
-  title: 'TOP BOB | Tappka',
+  title: 'TOP BOB',
   description: 'Zlato celé knihovny — knihy, na kterých se shodli kouči:ky i komunita',
 };
 

--- a/src/app/(main)/cteni/prehled/page.tsx
+++ b/src/app/(main)/cteni/prehled/page.tsx
@@ -11,7 +11,7 @@ import { PageHeader } from '@/components/ui/page-header';
 import { PageShell } from '@/components/ui/page-shell';
 
 export const metadata = {
-  title: 'Moje čtení | Tappka',
+  title: 'Moje čtení',
   description: 'Tvůj pokrok, eseje a srovnání s týmem',
 };
 

--- a/src/app/(main)/cteni/sprava/page.tsx
+++ b/src/app/(main)/cteni/sprava/page.tsx
@@ -10,7 +10,7 @@ import { PageHeader } from '@/components/ui/page-header';
 import { Button } from '@/components/ui/button';
 
 export const metadata = {
-  title: "Správa knihovny | Tappka",
+  title: "Správa knihovny",
   description: "Zařaď knihy do seznamů a spravuj výběr",
 };
 

--- a/src/app/(main)/cteni/zdroje/[id]/page.tsx
+++ b/src/app/(main)/cteni/zdroje/[id]/page.tsx
@@ -13,7 +13,7 @@ import { CONTENT_SOURCE_KIND_LABELS } from '@/lib/content-sources/types';
 import { formatPointsWithLabel } from '@/lib/books/points';
 
 export const metadata = {
-  title: 'Detail zdroje | Tappka',
+  title: 'Detail zdroje',
 };
 
 const ALL_ESSAYS_PAGE_SIZE = 500;

--- a/src/app/(main)/knihovna/stitky/page.tsx
+++ b/src/app/(main)/knihovna/stitky/page.tsx
@@ -13,7 +13,7 @@ interface LibraryLabelsPageProps {
 const PAGE_DESCRIPTION = 'Naskenuj štítek a přiřaď ho ke konkrétnímu výtisku';
 
 export const metadata = {
-  title: 'Přiřazení štítků | Tappka',
+  title: 'Přiřazení štítků',
   description: PAGE_DESCRIPTION,
   robots: { index: false, follow: false },
 };

--- a/src/app/(main)/komunita/page.tsx
+++ b/src/app/(main)/komunita/page.tsx
@@ -5,7 +5,7 @@ import { PageHeader } from '@/components/ui/page-header';
 import { PageShell } from '@/components/ui/page-shell';
 
 export const metadata = {
-  title: 'Komunita | Tappka',
+  title: 'Komunita',
   description: 'Prohlížej si členy:ky komunity a kontaktuj je',
 };
 

--- a/src/app/(main)/komunita/profil/[id]/page.tsx
+++ b/src/app/(main)/komunita/profil/[id]/page.tsx
@@ -21,7 +21,7 @@ import { PageBack } from '@/components/ui/page-back';
 import { PageShell } from '@/components/ui/page-shell';
 
 export const metadata = {
-  title: 'Profil | Tappka',
+  title: 'Profil',
 };
 import { Tabs, TabsContent, TabsList, TabsTrigger, TabsTriggerCount } from '@/components/ui/tabs';
 import { ROLE_LABELS, ROLE_COLORS } from '@/lib/komunita/types';

--- a/src/app/(main)/komunita/tymy/[id]/page.tsx
+++ b/src/app/(main)/komunita/tymy/[id]/page.tsx
@@ -10,7 +10,7 @@ import { PageBack } from '@/components/ui/page-back';
 import { PageShell } from '@/components/ui/page-shell';
 
 export const metadata = {
-  title: 'Tým | Tappka',
+  title: 'Tým',
 };
 import { TeamBookPointsChart } from '@/components/teams/team-book-points-chart';
 import { TeamCustomerMeetingsChart } from '@/components/teams/team-customer-meetings-chart';

--- a/src/app/(main)/koucovani/page.tsx
+++ b/src/app/(main)/koucovani/page.tsx
@@ -8,7 +8,7 @@ import { FeatureComingSoon } from "@/components/beta/feature-coming-soon"
 import { canAccessFeature, type BetaCohort } from "@/lib/feature-access"
 
 export const metadata = {
-  title: "Individuální koučování | Tappka",
+  title: "Individuální koučování",
   description: "Záznamník koučovacích sezení s týmovým:ou koučem:kou",
 }
 

--- a/src/app/(main)/moduly/page.tsx
+++ b/src/app/(main)/moduly/page.tsx
@@ -8,7 +8,7 @@ import { PageShell } from "@/components/ui/page-shell";
 import type { BetaCohort } from "@/lib/feature-access";
 
 export const metadata = {
-  title: "Moduly | Tappka",
+  title: "Moduly",
   description: "Všechny části Tappky na jednom místě",
 };
 

--- a/src/app/(main)/nastroje-techniky/page.tsx
+++ b/src/app/(main)/nastroje-techniky/page.tsx
@@ -8,7 +8,7 @@ import { FeatureComingSoon } from "@/components/beta/feature-coming-soon"
 import { canAccessFeature, type BetaCohort } from "@/lib/feature-access"
 
 export const metadata = {
-  title: "Nástroje a techniky | Tappka",
+  title: "Nástroje a techniky",
   description: "Katalog modelů, technik a nástrojů, které umíš používat pro efektivní práci",
 }
 

--- a/src/app/(main)/osobnostni-testy/page.tsx
+++ b/src/app/(main)/osobnostni-testy/page.tsx
@@ -8,7 +8,7 @@ import { FeatureComingSoon } from "@/components/beta/feature-coming-soon"
 import { canAccessFeature, type BetaCohort } from "@/lib/feature-access"
 
 export const metadata = {
-  title: "Osobnostní testy | Tappka",
+  title: "Osobnostní testy",
   description: "Výsledky osobnostních testů a jejich vývoj v čase",
 }
 

--- a/src/app/(main)/portfolio/page.tsx
+++ b/src/app/(main)/portfolio/page.tsx
@@ -3,7 +3,7 @@ import { PageShell } from '@/components/ui/page-shell';
 import { PortfolioUploader } from '@/components/portfolio/portfolio-uploader';
 
 export const metadata = {
-  title: 'Portfolio | Tappka',
+  title: 'Portfolio',
   description: 'Nahraj své portfolio (.xlsx) a prohlížej si přehled svých aktivit',
 };
 

--- a/src/app/(main)/profil/page.tsx
+++ b/src/app/(main)/profil/page.tsx
@@ -7,7 +7,7 @@ import { PageHeader } from "@/components/ui/page-header";
 import { PageShell } from "@/components/ui/page-shell";
 
 export const metadata = {
-  title: "Profil | Tappka",
+  title: "Profil",
   description: "Tvůj účet, přístupy a nastavení aplikace",
 };
 

--- a/src/app/(main)/reservations/[code]/page.tsx
+++ b/src/app/(main)/reservations/[code]/page.tsx
@@ -18,7 +18,7 @@ interface RoomDetailPageProps {
 export async function generateMetadata({ params }: RoomDetailPageProps) {
   const { code } = await params;
   return {
-    title: `${code.toUpperCase()} | Rezervace | Tappka`,
+    title: `${code.toUpperCase()} | Rezervace`,
   };
 }
 

--- a/src/app/(main)/reservations/[code]/quick/page.tsx
+++ b/src/app/(main)/reservations/[code]/quick/page.tsx
@@ -11,7 +11,7 @@ interface QuickPageProps {
 export async function generateMetadata({ params }: QuickPageProps) {
   const { code } = await params;
   return {
-    title: `${code.toUpperCase()} | Quick Status | Tappka`,
+    title: `${code.toUpperCase()} | Quick Status`,
   };
 }
 

--- a/src/app/(main)/reservations/page.tsx
+++ b/src/app/(main)/reservations/page.tsx
@@ -9,7 +9,7 @@ import { PageShell } from "@/components/ui/page-shell";
 import type { RoomWithStatus, ReservationWithDetails } from "@/lib/reservations/types";
 
 export const metadata = {
-  title: "Rezervace | Tappka",
+  title: "Rezervace",
   description: "Vyber si místnost a zarezervuj si ji",
 };
 

--- a/src/app/(main)/reservations/settings/page.tsx
+++ b/src/app/(main)/reservations/settings/page.tsx
@@ -10,7 +10,7 @@ import { PageHeader } from "@/components/ui/page-header";
 import type { Room, RecurringSchedule, ScheduleBreak } from "@/lib/reservations/types";
 
 export const metadata = {
-  title: "Nastavení rezervací | Tappka",
+  title: "Nastavení rezervací",
   description: "Spravuj Training Sessions a výjimky v rozvrhu",
 };
 

--- a/src/app/(main)/schuzky/[meetingId]/page.tsx
+++ b/src/app/(main)/schuzky/[meetingId]/page.tsx
@@ -14,7 +14,7 @@ interface MeetingDetailPageProps {
 }
 
 export const metadata = {
-  title: "Detail schůzky | Tappka",
+  title: "Detail schůzky",
 }
 
 const CHIP_CLASS: Record<MeetingLoop, string> = {

--- a/src/app/(main)/schuzky/page.tsx
+++ b/src/app/(main)/schuzky/page.tsx
@@ -8,7 +8,7 @@ import { FeatureComingSoon } from "@/components/beta/feature-coming-soon"
 import { canAccessFeature, type BetaCohort } from "@/lib/feature-access"
 
 export const metadata = {
-  title: "Zákaznické schůzky | Tappka",
+  title: "Zákaznické schůzky",
   description: "Záznamník schůzek s lidmi z praxe",
 }
 

--- a/src/app/(main)/settings/notifikace/page.tsx
+++ b/src/app/(main)/settings/notifikace/page.tsx
@@ -7,7 +7,7 @@ import { ConsentSettings } from '@/components/posthog/consent-settings';
 import { PageHeader } from '@/components/ui/page-header';
 
 export const metadata = {
-  title: 'Notifikace | Tappka',
+  title: 'Notifikace',
   description: 'Vyber si, o čem tě budeme informovat e-mailem',
 };
 

--- a/src/app/(main)/tymova-reflexe/[id]/page.tsx
+++ b/src/app/(main)/tymova-reflexe/[id]/page.tsx
@@ -8,7 +8,7 @@ import { FeatureComingSoon } from "@/components/beta/feature-coming-soon"
 import { canAccessFeature, type BetaCohort } from "@/lib/feature-access"
 
 export const metadata = {
-  title: "Týmová reflexe | Tappka",
+  title: "Týmová reflexe",
 }
 
 export default async function ReflexeDetailPage({

--- a/src/app/(main)/tymova-reflexe/nova/page.tsx
+++ b/src/app/(main)/tymova-reflexe/nova/page.tsx
@@ -25,7 +25,7 @@ function getCurrentMonth(): string {
 }
 
 export const metadata = {
-  title: "Nová reflexe | Tappka",
+  title: "Nová reflexe",
 }
 
 export default async function NovaReflexePage({

--- a/src/app/(main)/tymova-reflexe/page.tsx
+++ b/src/app/(main)/tymova-reflexe/page.tsx
@@ -10,7 +10,7 @@ import { FeatureComingSoon } from "@/components/beta/feature-coming-soon"
 import { canAccessFeature, type BetaCohort } from "@/lib/feature-access"
 
 export const metadata = {
-  title: "Týmová reflexe | Tappka",
+  title: "Týmová reflexe",
   description: "Pravidelné ohlédnutí za týmovou spoluprací a rozvojem",
 }
 

--- a/src/app/(main)/tymova-reflexe/rocnikova/[id]/page.tsx
+++ b/src/app/(main)/tymova-reflexe/rocnikova/[id]/page.tsx
@@ -7,7 +7,7 @@ import { FeatureComingSoon } from "@/components/beta/feature-coming-soon"
 import { canAccessFeature, type BetaCohort } from "@/lib/feature-access"
 
 export const metadata = {
-  title: "Ročníková reflexe | Tappka",
+  title: "Ročníková reflexe",
 }
 
 export default async function RocnikovaReflexeDetailPage({

--- a/src/app/(main)/tymova-reflexe/rocnikova/nova/page.tsx
+++ b/src/app/(main)/tymova-reflexe/rocnikova/nova/page.tsx
@@ -21,7 +21,7 @@ function rocnikovaLabel(monthStr: string): string {
 }
 
 export const metadata = {
-  title: "Nová ročníková reflexe | Tappka",
+  title: "Nová ročníková reflexe",
 }
 
 export default async function NovaRocnikovaReflexePage({

--- a/src/app/(main)/tymove-dokumenty/page.tsx
+++ b/src/app/(main)/tymove-dokumenty/page.tsx
@@ -11,7 +11,7 @@ import { FeatureComingSoon } from "@/components/beta/feature-coming-soon"
 import { canAccessFeature, type BetaCohort } from "@/lib/feature-access"
 
 export const metadata = {
-  title: "Týmové dokumenty | Tappka",
+  title: "Týmové dokumenty",
   description: "Pravidla fungování týmu, Team Contract a finanční směrnice",
 }
 

--- a/src/app/(main)/tymovy-denik/[id]/page.tsx
+++ b/src/app/(main)/tymovy-denik/[id]/page.tsx
@@ -12,7 +12,7 @@ interface TeamActivityDetailPageProps {
 }
 
 export const metadata = {
-  title: "Detail akce | Tappka",
+  title: "Detail akce",
 }
 
 export default async function TeamActivityDetailPage({ params }: TeamActivityDetailPageProps) {

--- a/src/app/(main)/tymovy-denik/page.tsx
+++ b/src/app/(main)/tymovy-denik/page.tsx
@@ -8,7 +8,7 @@ import { FeatureComingSoon } from "@/components/beta/feature-coming-soon"
 import { canAccessFeature, type BetaCohort } from "@/lib/feature-access"
 
 export const metadata = {
-  title: "Týmový deník | Tappka",
+  title: "Týmový deník",
   description: "Chronologický záznam týmových akcí mimo pracovní prostředí",
 }
 

--- a/src/app/l/[labelCode]/page.tsx
+++ b/src/app/l/[labelCode]/page.tsx
@@ -10,7 +10,7 @@ interface LibraryLabelPageProps {
 }
 
 export const metadata = {
-  title: 'Knihovna | Tappka',
+  title: 'Knihovna',
   robots: { index: false, follow: false },
 };
 

--- a/src/components/essays/essay-editor-form.tsx
+++ b/src/components/essays/essay-editor-form.tsx
@@ -68,9 +68,12 @@ function SaveStatus({
     prevStatusRef.current = status;
     if (status !== 'saved' || prevStatus === 'saved') return;
 
-    setJustSaved(true);
-    const timer = setTimeout(() => setJustSaved(false), 800);
-    return () => clearTimeout(timer);
+    const showTimer = setTimeout(() => setJustSaved(true), 0);
+    const hideTimer = setTimeout(() => setJustSaved(false), 800);
+    return () => {
+      clearTimeout(showTimer);
+      clearTimeout(hideTimer);
+    };
   }, [status]);
 
   return (

--- a/src/instrumentation-client.ts
+++ b/src/instrumentation-client.ts
@@ -7,7 +7,7 @@ if (process.env.NEXT_PUBLIC_POSTHOG_KEY) {
     capture_pageview: false,
     capture_pageleave: true,
     capture_heatmaps: true,
-    enable_recording_console_log: false,
+    enable_recording_console_log: true,
     autocapture: {
       css_selector_ignorelist: [
         "[data-ph-no-capture]",

--- a/src/instrumentation.ts
+++ b/src/instrumentation.ts
@@ -1,7 +1,38 @@
 import type { Instrumentation } from "next";
+import { logs, SeverityNumber } from "@opentelemetry/api-logs";
+import { OTLPLogExporter } from "@opentelemetry/exporter-logs-otlp-http";
+import { resourceFromAttributes } from "@opentelemetry/resources";
+import { BatchLogRecordProcessor, LoggerProvider } from "@opentelemetry/sdk-logs";
+
+const DEFAULT_POSTHOG_HOST = "https://eu.i.posthog.com";
+const SERVICE_NAME = "tappka";
+
+const posthogHost =
+  process.env.NEXT_PUBLIC_POSTHOG_HOST ?? DEFAULT_POSTHOG_HOST;
+const posthogKey = process.env.NEXT_PUBLIC_POSTHOG_KEY;
+const logsUrl = `${posthogHost.replace(/\/+$/, "")}/i/v1/logs`;
+
+export const loggerProvider = new LoggerProvider({
+  resource: resourceFromAttributes({ "service.name": SERVICE_NAME }),
+  processors: posthogKey
+    ? [
+        new BatchLogRecordProcessor({
+          exporter: new OTLPLogExporter({
+            url: logsUrl,
+            headers: {
+              Authorization: `Bearer ${posthogKey}`,
+              "Content-Type": "application/json",
+            },
+          }),
+        }),
+      ]
+    : [],
+});
 
 export function register() {
-  // No-op — PostHog client init is in instrumentation-client.ts
+  if (process.env.NEXT_RUNTIME === "nodejs") {
+    logs.setGlobalLoggerProvider(loggerProvider);
+  }
 }
 
 export const onRequestError: Instrumentation.onRequestError = async (
@@ -13,9 +44,25 @@ export const onRequestError: Instrumentation.onRequestError = async (
   // We keep this hand-rolled hook to avoid adding a new dependency: it already
   // forwards the client distinct_id from the PostHog cookie for identity linking.
   if (process.env.NEXT_RUNTIME === "nodejs") {
+    const logger = loggerProvider.getLogger(SERVICE_NAME);
+    const errorMessage = err instanceof Error ? err.message : String(err);
+    const errorStack = err instanceof Error ? err.stack : undefined;
+    const errorName = err instanceof Error ? err.name : "Error";
+
+    logger.emit({
+      body: `Request error: ${errorMessage}`,
+      severityNumber: SeverityNumber.ERROR,
+      attributes: {
+        "error.name": errorName,
+        "error.message": errorMessage,
+        ...(errorStack ? { "error.stack": errorStack } : {}),
+        "http.route": request.path,
+        "http.method": request.method,
+      },
+    });
+
     const { getPostHogServer } = await import("./lib/posthog-server");
     const posthog = getPostHogServer();
-    if (!posthog) return;
 
     let distinctId: string | null = null;
 
@@ -38,6 +85,9 @@ export const onRequestError: Instrumentation.onRequestError = async (
       }
     }
 
-    await posthog.captureExceptionImmediate(err, distinctId ?? undefined);
+    await Promise.allSettled([
+      posthog?.captureExceptionImmediate(err, distinctId ?? undefined),
+      loggerProvider.forceFlush(),
+    ]);
   }
 };

--- a/src/lib/server-logger.test.ts
+++ b/src/lib/server-logger.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { loggerProvider } from "@/instrumentation";
+import { serverLogger } from "./server-logger";
+
+describe("serverLogger", () => {
+  it("emits logs without errors across all severity levels", () => {
+    const logger = loggerProvider.getLogger("tappka");
+    const emitSpy = vi.spyOn(logger, "emit");
+
+    serverLogger.info("Info test message", { route: "/test" });
+    serverLogger.warn("Warn test message", { count: 42 });
+    serverLogger.error("Error test message", { failed: true });
+    serverLogger.debug("Debug test message");
+
+    expect(emitSpy).toHaveBeenCalledTimes(4);
+    expect(emitSpy).toHaveBeenNthCalledWith(
+      1,
+      expect.objectContaining({
+        body: "Info test message",
+        attributes: { route: "/test" },
+      })
+    );
+    expect(emitSpy).toHaveBeenNthCalledWith(
+      2,
+      expect.objectContaining({
+        body: "Warn test message",
+        attributes: { count: 42 },
+      })
+    );
+    expect(emitSpy).toHaveBeenNthCalledWith(
+      3,
+      expect.objectContaining({
+        body: "Error test message",
+        attributes: { failed: true },
+      })
+    );
+    expect(emitSpy).toHaveBeenNthCalledWith(
+      4,
+      expect.objectContaining({
+        body: "Debug test message",
+      })
+    );
+
+    emitSpy.mockRestore();
+  });
+
+  it("flushes without throwing", async () => {
+    await expect(serverLogger.flush()).resolves.toBeUndefined();
+  });
+});

--- a/src/lib/server-logger.ts
+++ b/src/lib/server-logger.ts
@@ -1,0 +1,44 @@
+import { SeverityNumber } from "@opentelemetry/api-logs";
+
+import { loggerProvider } from "@/instrumentation";
+
+const SERVICE_NAME = "tappka";
+const logger = loggerProvider.getLogger(SERVICE_NAME);
+
+export interface ServerLogAttributes {
+  [key: string]: string | number | boolean | undefined;
+}
+
+export const serverLogger = {
+  info(body: string, attributes?: ServerLogAttributes) {
+    logger.emit({
+      body,
+      severityNumber: SeverityNumber.INFO,
+      attributes: attributes as Record<string, string | number | boolean>,
+    });
+  },
+  warn(body: string, attributes?: ServerLogAttributes) {
+    logger.emit({
+      body,
+      severityNumber: SeverityNumber.WARN,
+      attributes: attributes as Record<string, string | number | boolean>,
+    });
+  },
+  error(body: string, attributes?: ServerLogAttributes) {
+    logger.emit({
+      body,
+      severityNumber: SeverityNumber.ERROR,
+      attributes: attributes as Record<string, string | number | boolean>,
+    });
+  },
+  debug(body: string, attributes?: ServerLogAttributes) {
+    logger.emit({
+      body,
+      severityNumber: SeverityNumber.DEBUG,
+      attributes: attributes as Record<string, string | number | boolean>,
+    });
+  },
+  async flush() {
+    await loggerProvider.forceFlush();
+  },
+};


### PR DESCRIPTION
## Summary
- **PostHog OpenTelemetry Logs**: Integrated `@opentelemetry/sdk-logs`, `@opentelemetry/exporter-logs-otlp-http`, `@opentelemetry/api-logs`, and `@opentelemetry/resources` with PostHog's `/i/v1/logs` endpoint.
- **Server Logging Utility**: Added `serverLogger` (`info`, `warn`, `error`, `debug`, `flush`) in `src/lib/server-logger.ts` for structured server-side logging.
- **Error Instrumentation**: Configured `onRequestError` in `src/instrumentation.ts` to emit unhandled Next.js server errors with stack trace and route attributes to PostHog Logs.
- **Console Capture**: Enabled `enable_recording_console_log: true` in `src/instrumentation-client.ts` to record browser console output with session replays.
- **Page Titles**: Cleaned up redundant ` | Tappka` title suffix across `src/app/(main)` page metadata.
- **PostHog & GDPR improvements**: Includes consent banner lifecycle, typed analytics wrapper, `/ingest` proxy, and related improvements merged from preview.

## Verification
- `pnpm typecheck` passed
- `pnpm test` passed (192 test files, 1137 tests)
- `pnpm lint` passed (0 errors)