### PR TITLE
fix(telemetry): deliver server logs to PostHog via after()

### DIFF
--- a/src/lib/server-logger.test.ts
+++ b/src/lib/server-logger.test.ts
@@ -49,6 +49,36 @@ describe("serverLogger", () => {
     await expect(serverLogger.flush()).resolves.toBeUndefined();
   });
 
+  it("registers delivery with after() so exports survive serverless freeze", async () => {
+    vi.resetModules();
+    const callbacks: Array<() => unknown> = [];
+    vi.doMock("next/server", () => ({
+      after: (callback: () => unknown) => {
+        callbacks.push(callback);
+      },
+    }));
+
+    try {
+      const [{ serverLogger: freshLogger }, { loggerProvider: freshProvider }] =
+        await Promise.all([
+          import("./server-logger"),
+          import("@/lib/posthog-logger-provider"),
+        ]);
+      const flushSpy = vi.spyOn(freshProvider, "forceFlush");
+
+      try {
+        freshLogger.info("after flush test");
+        await vi.waitFor(() => expect(callbacks).toHaveLength(1));
+        await callbacks[0]();
+        expect(flushSpy).toHaveBeenCalled();
+      } finally {
+        flushSpy.mockRestore();
+      }
+    } finally {
+      vi.doUnmock("next/server");
+    }
+  });
+
   it("captures migrated console output and redacts sensitive values", () => {
     const logger = loggerProvider.getLogger("tappka");
     const emitSpy = vi.spyOn(logger, "emit");

--- a/src/lib/server-logger.ts
+++ b/src/lib/server-logger.ts
@@ -94,19 +94,26 @@ function withoutUndefined(
 }
 
 function scheduleFlush(): void {
-  // NOTE: intentionally no `after()` from "next/server" here. A static import
-  // of `after` poisons every importer (middleware, edge instrumentation,
-  // client components via auth-helpers) and breaks the Turbopack build, since
-  // `after` is only available in App Router server contexts. The batch
-  // processor handles delivery; callers on critical paths (e.g.
-  // instrumentation onRequestError) await `serverLogger.flush()` explicitly.
-  try {
-    void loggerProvider.forceFlush().catch(() => {
-      // Delivery failures must never break application behavior.
-    });
-  } catch {
-    // Outside a Next.js request, the batch processor handles delivery.
-  }
+  // `after()` keeps the serverless function alive after the response so the
+  // OTLP export can finish. Without it, Vercel freezes the function and the
+  // export is aborted: logs show in Vercel (synchronous console capture) but
+  // never reach PostHog. Dynamic import keeps edge/middleware/client bundles
+  // free of "next/server" (a static import breaks the Turbopack build, since
+  // `after` is only available in App Router server contexts).
+  void (async () => {
+    try {
+      const { after } = await import("next/server");
+      after(() => loggerProvider.forceFlush());
+    } catch {
+      // Outside a Next.js request (or where `after` is unavailable), fall
+      // back to a best-effort flush; the batch processor handles delivery.
+      try {
+        await loggerProvider.forceFlush();
+      } catch {
+        // Delivery failures must never break application behavior.
+      }
+    }
+  })();
 }
 
 function emit(


### PR DESCRIPTION
Fire-and-forget forceFlush() never survived Vercel serverless freeze: the function is suspended when the response returns, aborting the in-flight OTLP export, while synchronous console capture still reached Vercel logs.

Register forceFlush() with after() so the runtime stays alive for delivery. Dynamic import of next/server keeps edge/middleware/client bundles clean (a static import breaks the Turbopack build).