### PR TITLE
perf(auth): use getClaims instead of getUser for id-only checks

### DIFF
--- a/src/app/(main)/beta/page.tsx
+++ b/src/app/(main)/beta/page.tsx
@@ -8,7 +8,8 @@ import { createAdminClient } from "@/lib/supabase/admin"
 
 export default async function BetaPage() {
   const supabase = await createClient()
-  const { data: { user } } = await supabase.auth.getUser()
+  const { data: claimsData } = await supabase.auth.getClaims()
+  const user = claimsData?.claims?.sub ? { id: claimsData.claims.sub } : null
   if (!user) redirect("/auth/login")
 
   const profile = await getCurrentUserProfile(supabase, { user })

--- a/src/app/(main)/birth-giving/[eventId]/page.tsx
+++ b/src/app/(main)/birth-giving/[eventId]/page.tsx
@@ -19,9 +19,8 @@ export const metadata = {
 
 export default async function BirthGivingEventPage({ params }: BirthGivingEventPageProps) {
   const supabase = await createClient()
-  const {
-    data: { user },
-  } = await supabase.auth.getUser()
+  const { data: claimsData } = await supabase.auth.getClaims();
+  const user = claimsData?.claims?.sub ? { id: claimsData.claims.sub } : null;
   if (!user) redirect("/auth/login")
 
   const profile = await getSessionProfile()

--- a/src/app/(main)/birth-giving/historie/nova/page.tsx
+++ b/src/app/(main)/birth-giving/historie/nova/page.tsx
@@ -16,9 +16,8 @@ export const metadata = {
 
 export default async function BirthGivingHistorieNovaPage() {
   const supabase = await createClient()
-  const {
-    data: { user },
-  } = await supabase.auth.getUser()
+  const { data: claimsData } = await supabase.auth.getClaims();
+  const user = claimsData?.claims?.sub ? { id: claimsData.claims.sub } : null;
   if (!user) redirect("/auth/login")
 
   const profile = await getSessionProfile()

--- a/src/app/(main)/birth-giving/nova/page.tsx
+++ b/src/app/(main)/birth-giving/nova/page.tsx
@@ -17,9 +17,8 @@ export const metadata = {
 
 export default async function BirthGivingNovaPage() {
   const supabase = await createClient()
-  const {
-    data: { user },
-  } = await supabase.auth.getUser()
+  const { data: claimsData } = await supabase.auth.getClaims();
+  const user = claimsData?.claims?.sub ? { id: claimsData.claims.sub } : null;
   if (!user) redirect("/auth/login")
 
   const profile = await getSessionProfile()

--- a/src/app/(main)/birth-giving/page.tsx
+++ b/src/app/(main)/birth-giving/page.tsx
@@ -15,9 +15,8 @@ export const metadata = {
 
 export default async function BirthGivingIndexPage() {
   const supabase = await createClient()
-  const {
-    data: { user },
-  } = await supabase.auth.getUser()
+  const { data: claimsData } = await supabase.auth.getClaims();
+  const user = claimsData?.claims?.sub ? { id: claimsData.claims.sub } : null;
   if (!user) redirect("/auth/login")
 
   const profile = await getSessionProfile()

--- a/src/app/(main)/cteni/eseje/[essayId]/page.tsx
+++ b/src/app/(main)/cteni/eseje/[essayId]/page.tsx
@@ -35,7 +35,8 @@ interface PageProps {
 export default async function EssayDetailPage({ params }: PageProps) {
   const { essayId } = await params;
   const supabase = await createClient();
-  const { data: { user } } = await supabase.auth.getUser();
+  const { data: claimsData } = await supabase.auth.getClaims();
+  const user = claimsData?.claims?.sub ? { id: claimsData.claims.sub } : null;
   if (!user) redirect('/auth/login');
 
   const profile = await getCurrentUserProfile(supabase, { user });

--- a/src/app/(main)/cteni/eseje/[essayId]/upravit/page.tsx
+++ b/src/app/(main)/cteni/eseje/[essayId]/upravit/page.tsx
@@ -12,7 +12,8 @@ interface PageProps {
 export default async function EssayEditPage({ params }: PageProps) {
   const { essayId } = await params;
   const supabase = await createClient();
-  const { data: { user } } = await supabase.auth.getUser();
+  const { data: claimsData } = await supabase.auth.getClaims();
+  const user = claimsData?.claims?.sub ? { id: claimsData.claims.sub } : null;
   if (!user) redirect('/auth/login');
 
   const profile = await getCurrentUserProfile(supabase, { user });

--- a/src/app/(main)/cteni/eseje/ke-kontrole/page.tsx
+++ b/src/app/(main)/cteni/eseje/ke-kontrole/page.tsx
@@ -17,9 +17,8 @@ export default async function CoachReviewPage({
   searchParams: Promise<Record<string, string | string[] | undefined>>;
 }) {
   const supabase = await createClient();
-  const {
-    data: { user },
-  } = await supabase.auth.getUser();
+  const { data: claimsData } = await supabase.auth.getClaims();
+  const user = claimsData?.claims?.sub ? { id: claimsData.claims.sub } : null;
   if (!user) redirect('/auth/login');
 
   const profile = await getCurrentUserProfile(supabase, { user });

--- a/src/app/(main)/cteni/hledat/page.tsx
+++ b/src/app/(main)/cteni/hledat/page.tsx
@@ -13,7 +13,8 @@ import { SearchPageClient } from '@/components/search/search-page-client';
 
 export default async function HledatPage() {
   const supabase = await createClient();
-  const { data: { user } } = await supabase.auth.getUser();
+  const { data: claimsData } = await supabase.auth.getClaims();
+  const user = claimsData?.claims?.sub ? { id: claimsData.claims.sub } : null;
   if (!user) redirect('/auth/login');
 
   const profile = await getCurrentUserProfile(supabase, { user });

--- a/src/app/(main)/cteni/knihy/[bookId]/page.tsx
+++ b/src/app/(main)/cteni/knihy/[bookId]/page.tsx
@@ -48,7 +48,8 @@ function MetaItem({ icon: Icon, children }: { icon: React.ElementType; children:
 export default async function BookDetailPage({ params }: PageProps) {
   const { bookId } = await params;
   const supabase = await createClient();
-  const { data: { user } } = await supabase.auth.getUser();
+  const { data: claimsData } = await supabase.auth.getClaims();
+  const user = claimsData?.claims?.sub ? { id: claimsData.claims.sub } : null;
 
   const [book, essays, profile, libraryInfo, copies] = await Promise.all([
     getBookById(supabase, bookId),

--- a/src/app/(main)/cteni/knihy/[bookId]/pujcit/page.tsx
+++ b/src/app/(main)/cteni/knihy/[bookId]/pujcit/page.tsx
@@ -31,7 +31,8 @@ export default async function BorrowBookPage({ params, searchParams }: PageProps
   if (rawLabelCode != null && labelCode == null) notFound();
 
   const supabase = await createClient();
-  const { data: { user } } = await supabase.auth.getUser();
+  const { data: claimsData } = await supabase.auth.getClaims();
+  const user = claimsData?.claims?.sub ? { id: claimsData.claims.sub } : null;
   if (!user) redirect('/auth/login');
 
   const profile = await getCurrentUserProfile(supabase, { user });

--- a/src/app/(main)/cteni/knihy/[bookId]/upravit/page.tsx
+++ b/src/app/(main)/cteni/knihy/[bookId]/upravit/page.tsx
@@ -16,7 +16,8 @@ export const metadata = {
 export default async function BookEditPage({ params }: PageProps) {
   const { bookId } = await params;
   const supabase = await createClient();
-  const { data: { user } } = await supabase.auth.getUser();
+  const { data: claimsData } = await supabase.auth.getClaims();
+  const user = claimsData?.claims?.sub ? { id: claimsData.claims.sub } : null;
   if (!user) redirect('/auth/login');
 
   const [profile, book] = await Promise.all([

--- a/src/app/(main)/cteni/layout.tsx
+++ b/src/app/(main)/cteni/layout.tsx
@@ -7,7 +7,8 @@ import { CteniTabBar } from '@/components/cteni/cteni-tab-bar';
 
 export default async function CteniLayout({ children }: { children: ReactNode }) {
   const supabase = await createClient();
-  const { data: { user } } = await supabase.auth.getUser();
+  const { data: claimsData } = await supabase.auth.getClaims();
+  const user = claimsData?.claims?.sub ? { id: claimsData.claims.sub } : null;
   if (!user) redirect('/auth/login');
 
   const profile = await getCurrentUserProfile(supabase, { user });

--- a/src/app/(main)/cteni/prehled/page.tsx
+++ b/src/app/(main)/cteni/prehled/page.tsx
@@ -17,7 +17,8 @@ export const metadata = {
 
 export default async function PrehledPage() {
   const supabase = await createClient();
-  const { data: { user } } = await supabase.auth.getUser();
+  const { data: claimsData } = await supabase.auth.getClaims();
+  const user = claimsData?.claims?.sub ? { id: claimsData.claims.sub } : null;
   if (!user) redirect('/auth/login');
 
   const profile = await getCurrentUserProfile(supabase, { user });

--- a/src/app/(main)/cteni/sprava/page.tsx
+++ b/src/app/(main)/cteni/sprava/page.tsx
@@ -16,7 +16,8 @@ export const metadata = {
 
 export default async function SpravaKnihovnyPage() {
   const supabase = await createClient();
-  const { data: { user } } = await supabase.auth.getUser();
+  const { data: claimsData } = await supabase.auth.getClaims();
+  const user = claimsData?.claims?.sub ? { id: claimsData.claims.sub } : null;
   if (!user) redirect('/auth/login');
 
   const profile = await getCurrentUserProfile(supabase, { user });

--- a/src/app/(main)/cteni/zdroje/ke-schvaleni/page.tsx
+++ b/src/app/(main)/cteni/zdroje/ke-schvaleni/page.tsx
@@ -8,7 +8,8 @@ import { ContentSourceReviewList } from '@/components/content-sources/content-so
 
 export default async function ZdrojeKeSchvaleniPage() {
   const supabase = await createClient();
-  const { data: { user } } = await supabase.auth.getUser();
+  const { data: claimsData } = await supabase.auth.getClaims();
+  const user = claimsData?.claims?.sub ? { id: claimsData.claims.sub } : null;
   if (!user) redirect('/auth/login');
 
   const profile = await getCurrentUserProfile(supabase, { user });

--- a/src/app/(main)/cteni/zdroje/page.tsx
+++ b/src/app/(main)/cteni/zdroje/page.tsx
@@ -11,7 +11,8 @@ import { Empty, EmptyHeader, EmptyTitle, EmptyDescription, EmptyMedia } from '@/
 
 export default async function ZdrojePage() {
   const supabase = await createClient();
-  const { data: { user } } = await supabase.auth.getUser();
+  const { data: claimsData } = await supabase.auth.getClaims();
+  const user = claimsData?.claims?.sub ? { id: claimsData.claims.sub } : null;
   if (!user) redirect('/auth/login');
 
   const sources = await getContentSources(supabase, { pageSize: 60 });

--- a/src/app/(main)/koucovani/page.tsx
+++ b/src/app/(main)/koucovani/page.tsx
@@ -14,7 +14,8 @@ export const metadata = {
 
 export default async function KoucovaniPage() {
   const supabase = await createClient()
-  const { data: { user } } = await supabase.auth.getUser()
+  const { data: claimsData } = await supabase.auth.getClaims()
+  const user = claimsData?.claims?.sub ? { id: claimsData.claims.sub } : null
   if (!user) redirect("/auth/login")
 
   const profile = await getSessionProfile()

--- a/src/app/(main)/nastroje-techniky/page.tsx
+++ b/src/app/(main)/nastroje-techniky/page.tsx
@@ -14,7 +14,8 @@ export const metadata = {
 
 export default async function NastrojeTechnikyPage() {
   const supabase = await createClient()
-  const { data: { user } } = await supabase.auth.getUser()
+  const { data: claimsData } = await supabase.auth.getClaims()
+  const user = claimsData?.claims?.sub ? { id: claimsData.claims.sub } : null
   if (!user) redirect("/auth/login")
 
   const profile = await getSessionProfile()

--- a/src/app/(main)/osobnostni-testy/page.tsx
+++ b/src/app/(main)/osobnostni-testy/page.tsx
@@ -14,7 +14,8 @@ export const metadata = {
 
 export default async function OsobnostniTestyPage() {
   const supabase = await createClient()
-  const { data: { user } } = await supabase.auth.getUser()
+  const { data: claimsData } = await supabase.auth.getClaims()
+  const user = claimsData?.claims?.sub ? { id: claimsData.claims.sub } : null
   if (!user) redirect("/auth/login")
 
   const profile = await getSessionProfile()

--- a/src/app/(main)/reservations/[code]/page.tsx
+++ b/src/app/(main)/reservations/[code]/page.tsx
@@ -31,7 +31,8 @@ export default async function RoomDetailPage({ params, searchParams }: RoomDetai
   const supabase = await createClient();
 
   // Get current user
-  const { data: { user } } = await supabase.auth.getUser();
+  const { data: claimsData } = await supabase.auth.getClaims();
+  const user = claimsData?.claims?.sub ? { id: claimsData.claims.sub } : null;
   // Fetch the user's profile to get the profile ID (used for ownership checks)
   const currentUserProfile = user ? await getCurrentUserProfile(supabase, { user }) : null;
 

--- a/src/app/(main)/reservations/[code]/quick/page.tsx
+++ b/src/app/(main)/reservations/[code]/quick/page.tsx
@@ -69,7 +69,8 @@ export default async function QuickStatusPage({ params }: QuickPageProps) {
   const nowIso = now.toISOString();
   const twoHoursAhead = new Date(now.getTime() + 2 * 60 * 60 * 1000).toISOString();
 
-  const { data: { user } } = await supabase.auth.getUser();
+  const { data: claimsData } = await supabase.auth.getClaims();
+  const user = claimsData?.claims?.sub ? { id: claimsData.claims.sub } : null;
   const profile = user ? await getCurrentUserProfile(supabase, { user }) : null;
   const currentProfileId = profile?.id ?? null;
 

--- a/src/app/(main)/schuzky/[meetingId]/page.tsx
+++ b/src/app/(main)/schuzky/[meetingId]/page.tsx
@@ -25,7 +25,8 @@ const CHIP_CLASS: Record<MeetingLoop, string> = {
 export default async function MeetingDetailPage({ params }: MeetingDetailPageProps) {
   const { meetingId } = await params
   const supabase = await createClient()
-  const { data: { user } } = await supabase.auth.getUser()
+  const { data: claimsData } = await supabase.auth.getClaims()
+  const user = claimsData?.claims?.sub ? { id: claimsData.claims.sub } : null
   if (!user) redirect("/auth/login")
 
   const profile = await getSessionProfile()

--- a/src/app/(main)/schuzky/page.tsx
+++ b/src/app/(main)/schuzky/page.tsx
@@ -14,7 +14,8 @@ export const metadata = {
 
 export default async function SchuzkyPage() {
   const supabase = await createClient()
-  const { data: { user } } = await supabase.auth.getUser()
+  const { data: claimsData } = await supabase.auth.getClaims()
+  const user = claimsData?.claims?.sub ? { id: claimsData.claims.sub } : null
   if (!user) redirect("/auth/login")
 
   const profile = await getSessionProfile()

--- a/src/app/(main)/settings/notifikace/page.tsx
+++ b/src/app/(main)/settings/notifikace/page.tsx
@@ -13,7 +13,8 @@ export const metadata = {
 
 export default async function NotificationSettingsPage() {
   const supabase = await createClient();
-  const { data: { user } } = await supabase.auth.getUser();
+  const { data: claimsData } = await supabase.auth.getClaims();
+  const user = claimsData?.claims?.sub ? { id: claimsData.claims.sub } : null;
   if (!user) redirect('/auth/login');
 
   const profile = await getCurrentUserProfile(supabase, { user });

--- a/src/app/(main)/tymova-reflexe/[id]/page.tsx
+++ b/src/app/(main)/tymova-reflexe/[id]/page.tsx
@@ -19,7 +19,8 @@ export default async function ReflexeDetailPage({
   const { id } = await params
 
   const supabase = await createClient()
-  const { data: { user } } = await supabase.auth.getUser()
+  const { data: claimsData } = await supabase.auth.getClaims()
+  const user = claimsData?.claims?.sub ? { id: claimsData.claims.sub } : null
   if (!user) redirect("/auth/login")
 
   const profile = await getSessionProfile()

--- a/src/app/(main)/tymova-reflexe/nova/page.tsx
+++ b/src/app/(main)/tymova-reflexe/nova/page.tsx
@@ -37,7 +37,8 @@ export default async function NovaReflexePage({
   const month = monthParam && MONTH_PATTERN.test(monthParam) ? monthParam : getCurrentMonth()
 
   const supabase = await createClient()
-  const { data: { user } } = await supabase.auth.getUser()
+  const { data: claimsData } = await supabase.auth.getClaims()
+  const user = claimsData?.claims?.sub ? { id: claimsData.claims.sub } : null
   if (!user) redirect("/auth/login")
 
   const profile = await getSessionProfile()

--- a/src/app/(main)/tymova-reflexe/page.tsx
+++ b/src/app/(main)/tymova-reflexe/page.tsx
@@ -16,9 +16,8 @@ export const metadata = {
 
 export default async function TymovaReflexePage() {
   const supabase = await createClient()
-  const {
-    data: { user },
-  } = await supabase.auth.getUser()
+  const { data: claimsData } = await supabase.auth.getClaims();
+  const user = claimsData?.claims?.sub ? { id: claimsData.claims.sub } : null;
   if (!user) redirect("/auth/login")
 
   const profile = await getSessionProfile()

--- a/src/app/(main)/tymova-reflexe/rocnikova/[id]/page.tsx
+++ b/src/app/(main)/tymova-reflexe/rocnikova/[id]/page.tsx
@@ -18,9 +18,8 @@ export default async function RocnikovaReflexeDetailPage({
   const { id } = await params
 
   const supabase = await createClient()
-  const {
-    data: { user },
-  } = await supabase.auth.getUser()
+  const { data: claimsData } = await supabase.auth.getClaims();
+  const user = claimsData?.claims?.sub ? { id: claimsData.claims.sub } : null;
   if (!user) redirect("/auth/login")
 
   const profile = await getSessionProfile()

--- a/src/app/(main)/tymova-reflexe/rocnikova/nova/page.tsx
+++ b/src/app/(main)/tymova-reflexe/rocnikova/nova/page.tsx
@@ -40,9 +40,8 @@ export default async function NovaRocnikovaReflexePage({
   }
 
   const supabase = await createClient()
-  const {
-    data: { user },
-  } = await supabase.auth.getUser()
+  const { data: claimsData } = await supabase.auth.getClaims();
+  const user = claimsData?.claims?.sub ? { id: claimsData.claims.sub } : null;
   if (!user) redirect("/auth/login")
 
   const profile = await getSessionProfile()

--- a/src/app/(main)/tymova-reflexe/semestralni/[id]/page.tsx
+++ b/src/app/(main)/tymova-reflexe/semestralni/[id]/page.tsx
@@ -11,9 +11,8 @@ export default async function SemestralniReflexeDetailPage({
   params: Promise<{ id: string }>
 }) {
   const supabase = await createClient()
-  const {
-    data: { user },
-  } = await supabase.auth.getUser()
+  const { data: claimsData } = await supabase.auth.getClaims();
+  const user = claimsData?.claims?.sub ? { id: claimsData.claims.sub } : null;
   if (!user) redirect("/auth/login")
 
   const profile = await getSessionProfile()

--- a/src/app/(main)/tymova-reflexe/semestralni/nova/page.tsx
+++ b/src/app/(main)/tymova-reflexe/semestralni/nova/page.tsx
@@ -11,9 +11,8 @@ export default async function SemestralniNovaPage({
   searchParams: Promise<{ semester?: string; month?: string }>
 }) {
   const supabase = await createClient()
-  const {
-    data: { user },
-  } = await supabase.auth.getUser()
+  const { data: claimsData } = await supabase.auth.getClaims();
+  const user = claimsData?.claims?.sub ? { id: claimsData.claims.sub } : null;
   if (!user) redirect("/auth/login")
 
   const profile = await getSessionProfile()

--- a/src/app/(main)/tymove-dokumenty/page.tsx
+++ b/src/app/(main)/tymove-dokumenty/page.tsx
@@ -17,7 +17,8 @@ export const metadata = {
 
 export default async function TeamDocumentsPage() {
   const supabase = await createClient()
-  const { data: { user } } = await supabase.auth.getUser()
+  const { data: claimsData } = await supabase.auth.getClaims()
+  const user = claimsData?.claims?.sub ? { id: claimsData.claims.sub } : null
   if (!user) redirect("/auth/login")
 
   const profile = await getSessionProfile()

--- a/src/app/(main)/tymovy-denik/[id]/page.tsx
+++ b/src/app/(main)/tymovy-denik/[id]/page.tsx
@@ -18,7 +18,8 @@ export const metadata = {
 export default async function TeamActivityDetailPage({ params }: TeamActivityDetailPageProps) {
   const { id } = await params
   const supabase = await createClient()
-  const { data: { user } } = await supabase.auth.getUser()
+  const { data: claimsData } = await supabase.auth.getClaims()
+  const user = claimsData?.claims?.sub ? { id: claimsData.claims.sub } : null
   if (!user) redirect("/auth/login")
 
   const profile = await getSessionProfile()

--- a/src/app/(main)/tymovy-denik/page.tsx
+++ b/src/app/(main)/tymovy-denik/page.tsx
@@ -14,7 +14,8 @@ export const metadata = {
 
 export default async function TymovyDenikPage() {
   const supabase = await createClient()
-  const { data: { user } } = await supabase.auth.getUser()
+  const { data: claimsData } = await supabase.auth.getClaims()
+  const user = claimsData?.claims?.sub ? { id: claimsData.claims.sub } : null
   if (!user) redirect("/auth/login")
 
   const profile = await getSessionProfile()

--- a/src/app/(main)/zpetna-vazba/page.tsx
+++ b/src/app/(main)/zpetna-vazba/page.tsx
@@ -7,7 +7,8 @@ import { PageShell } from '@/components/ui/page-shell';
 
 export default async function ZpetnaVazbaPage() {
   const supabase = await createClient();
-  const { data: { user } } = await supabase.auth.getUser();
+  const { data: claimsData } = await supabase.auth.getClaims();
+  const user = claimsData?.claims?.sub ? { id: claimsData.claims.sub } : null;
   if (!user) redirect('/auth/login');
 
   const profile = await getCurrentUserProfile(supabase, { user });

--- a/src/app/about/page.tsx
+++ b/src/app/about/page.tsx
@@ -44,9 +44,8 @@ const AUTHORS = [
 
 export default async function AboutPage() {
   const supabase = await createClient();
-  const {
-    data: { user },
-  } = await supabase.auth.getUser();
+  const { data: claimsData } = await supabase.auth.getClaims();
+  const user = claimsData?.claims?.sub ? { id: claimsData.claims.sub } : null;
   const isLoggedIn = !!user;
 
   return (

--- a/src/app/api/admin/beta-cohort/route.ts
+++ b/src/app/api/admin/beta-cohort/route.ts
@@ -14,9 +14,8 @@ const schema = z.object({
 export async function PATCH(request: NextRequest) {
   try {
     const supabase = await createClient()
-    const {
-      data: { user },
-    } = await supabase.auth.getUser()
+    const { data: claimsData } = await supabase.auth.getClaims();
+    const user = claimsData?.claims?.sub ? { id: claimsData.claims.sub } : null;
     if (!user) return NextResponse.json({ error: "Neautorizováno" }, { status: 401 })
 
     const caller = await getCurrentUserProfile(supabase, { user })

--- a/src/app/api/birth-giving/_shared.ts
+++ b/src/app/api/birth-giving/_shared.ts
@@ -27,9 +27,8 @@ export async function requireBirthGivingApiContext(): Promise<
   BirthGivingApiContext | BirthGivingApiGateFailure
 > {
   const supabase = await createClient();
-  const {
-    data: { user },
-  } = await supabase.auth.getUser();
+  const { data: claimsData } = await supabase.auth.getClaims();
+  const user = claimsData?.claims?.sub ? { id: claimsData.claims.sub } : null;
 
   if (!user) {
     return { response: NextResponse.json({ error: "Neautorizováno" }, { status: 401 }) };

--- a/src/app/api/books/[id]/essays-count/route.ts
+++ b/src/app/api/books/[id]/essays-count/route.ts
@@ -11,7 +11,8 @@ export async function GET(_request: NextRequest, { params }: RouteContext) {
   try {
     const { id } = await params;
     const supabase = await createClient();
-    const { data: { user } } = await supabase.auth.getUser();
+    const { data: claimsData } = await supabase.auth.getClaims();
+    const user = claimsData?.claims?.sub ? { id: claimsData.claims.sub } : null;
     if (!user) return NextResponse.json({ error: 'Neautorizováno' }, { status: 401 });
 
     const { count, error } = await supabase

--- a/src/app/api/books/[id]/route.ts
+++ b/src/app/api/books/[id]/route.ts
@@ -16,7 +16,8 @@ export async function GET(_request: NextRequest, { params }: RouteContext) {
   try {
     const { id } = await params;
     const supabase = await createClient();
-    const { data: { user } } = await supabase.auth.getUser();
+    const { data: claimsData } = await supabase.auth.getClaims();
+    const user = claimsData?.claims?.sub ? { id: claimsData.claims.sub } : null;
     if (!user) return NextResponse.json({ error: 'Neautorizováno' }, { status: 401 });
 
     const book = await getBookById(supabase, id);
@@ -33,7 +34,8 @@ export async function PATCH(request: NextRequest, { params }: RouteContext) {
   try {
     const { id } = await params;
     const supabase = await createClient();
-    const { data: { user } } = await supabase.auth.getUser();
+    const { data: claimsData } = await supabase.auth.getClaims();
+    const user = claimsData?.claims?.sub ? { id: claimsData.claims.sub } : null;
     if (!user) return NextResponse.json({ error: 'Neautorizováno' }, { status: 401 });
 
     const profile = await getCurrentUserProfile(supabase, { user });
@@ -269,7 +271,8 @@ export async function DELETE(request: NextRequest, { params }: RouteContext) {
   try {
     const { id } = await params;
     const supabase = await createClient();
-    const { data: { user } } = await supabase.auth.getUser();
+    const { data: claimsData } = await supabase.auth.getClaims();
+    const user = claimsData?.claims?.sub ? { id: claimsData.claims.sub } : null;
     if (!user) return NextResponse.json({ error: 'Neautorizováno' }, { status: 401 });
 
     const profile = await getCurrentUserProfile(supabase, { user });

--- a/src/app/api/books/enrich/route.ts
+++ b/src/app/api/books/enrich/route.ts
@@ -28,7 +28,8 @@ function withinBudget(profileId: string): boolean {
 export async function POST(request: NextRequest) {
   try {
     const supabase = await createClient();
-    const { data: { user } } = await supabase.auth.getUser();
+    const { data: claimsData } = await supabase.auth.getClaims();
+    const user = claimsData?.claims?.sub ? { id: claimsData.claims.sub } : null;
     if (!user) return NextResponse.json({ error: 'Neautorizováno' }, { status: 401 });
 
     const profile = await getCurrentUserProfile(supabase, { user });

--- a/src/app/api/books/external-search/route.ts
+++ b/src/app/api/books/external-search/route.ts
@@ -6,7 +6,8 @@ import { serverLogger } from "@/lib/server-logger";
 export async function GET(request: NextRequest) {
   try {
     const supabase = await createClient();
-    const { data: { user } } = await supabase.auth.getUser();
+    const { data: claimsData } = await supabase.auth.getClaims();
+    const user = claimsData?.claims?.sub ? { id: claimsData.claims.sub } : null;
     if (!user) return NextResponse.json({ error: 'Neautorizováno' }, { status: 401 });
 
     const { searchParams } = new URL(request.url);

--- a/src/app/api/books/route.ts
+++ b/src/app/api/books/route.ts
@@ -19,7 +19,8 @@ const VALID_BOOK_POINTS = [0, 1, 2, 3] as const;
 export async function GET(request: NextRequest) {
   try {
     const supabase = await createClient();
-    const { data: { user } } = await supabase.auth.getUser();
+    const { data: claimsData } = await supabase.auth.getClaims();
+    const user = claimsData?.claims?.sub ? { id: claimsData.claims.sub } : null;
     if (!user) return NextResponse.json({ error: 'Neautorizováno' }, { status: 401 });
 
     const { searchParams } = new URL(request.url);
@@ -52,7 +53,8 @@ export async function GET(request: NextRequest) {
 export async function POST(request: NextRequest) {
   try {
     const supabase = await createClient();
-    const { data: { user } } = await supabase.auth.getUser();
+    const { data: claimsData } = await supabase.auth.getClaims();
+    const user = claimsData?.claims?.sub ? { id: claimsData.claims.sub } : null;
     if (!user) return NextResponse.json({ error: 'Neautorizováno' }, { status: 401 });
 
     const profile = await getCurrentUserProfile(supabase, { user });

--- a/src/app/api/books/search/route.ts
+++ b/src/app/api/books/search/route.ts
@@ -9,7 +9,8 @@ const SEARCH_RESULT_LIMIT = 10;
 export async function GET(request: NextRequest) {
   try {
     const supabase = await createClient();
-    const { data: { user } } = await supabase.auth.getUser();
+    const { data: claimsData } = await supabase.auth.getClaims();
+    const user = claimsData?.claims?.sub ? { id: claimsData.claims.sub } : null;
     if (!user) return NextResponse.json({ error: 'Neautorizováno' }, { status: 401 });
 
     const q = new URL(request.url).searchParams.get('q')?.trim() ?? '';

--- a/src/app/api/content-sources/[id]/route.ts
+++ b/src/app/api/content-sources/[id]/route.ts
@@ -13,7 +13,8 @@ export async function GET(_request: NextRequest, { params }: { params: Promise<{
   try {
     const { id } = await params;
     const supabase = await createClient();
-    const { data: { user } } = await supabase.auth.getUser();
+    const { data: claimsData } = await supabase.auth.getClaims();
+    const user = claimsData?.claims?.sub ? { id: claimsData.claims.sub } : null;
     if (!user) return NextResponse.json({ error: 'Neautorizováno' }, { status: 401 });
 
     const source = await getContentSourceById(supabase, id);
@@ -30,7 +31,8 @@ export async function PATCH(request: NextRequest, { params }: { params: Promise<
   try {
     const { id } = await params;
     const supabase = await createClient();
-    const { data: { user } } = await supabase.auth.getUser();
+    const { data: claimsData } = await supabase.auth.getClaims();
+    const user = claimsData?.claims?.sub ? { id: claimsData.claims.sub } : null;
     if (!user) return NextResponse.json({ error: 'Neautorizováno' }, { status: 401 });
 
     const profile = await getCurrentUserProfile(supabase, { user });

--- a/src/app/api/content-sources/route.ts
+++ b/src/app/api/content-sources/route.ts
@@ -11,7 +11,8 @@ import { serverLogger } from "@/lib/server-logger";
 export async function GET(request: NextRequest) {
   try {
     const supabase = await createClient();
-    const { data: { user } } = await supabase.auth.getUser();
+    const { data: claimsData } = await supabase.auth.getClaims();
+    const user = claimsData?.claims?.sub ? { id: claimsData.claims.sub } : null;
     if (!user) return NextResponse.json({ error: 'Neautorizováno' }, { status: 401 });
 
     const { searchParams } = new URL(request.url);
@@ -42,7 +43,8 @@ export async function GET(request: NextRequest) {
 export async function POST(request: NextRequest) {
   try {
     const supabase = await createClient();
-    const { data: { user } } = await supabase.auth.getUser();
+    const { data: claimsData } = await supabase.auth.getClaims();
+    const user = claimsData?.claims?.sub ? { id: claimsData.claims.sub } : null;
     if (!user) return NextResponse.json({ error: 'Neautorizováno' }, { status: 401 });
 
     const profile = await getCurrentUserProfile(supabase, { user });

--- a/src/app/api/essays/[id]/coach-read/route.ts
+++ b/src/app/api/essays/[id]/coach-read/route.ts
@@ -12,7 +12,8 @@ export async function POST(request: NextRequest, { params }: RouteParams) {
   try {
     const { id } = await params;
     const supabase = await createClient();
-    const { data: { user } } = await supabase.auth.getUser();
+    const { data: claimsData } = await supabase.auth.getClaims();
+    const user = claimsData?.claims?.sub ? { id: claimsData.claims.sub } : null;
     if (!user) return NextResponse.json({ error: 'Neautorizováno' }, { status: 401 });
 
     const profile = await getCurrentUserProfile(supabase, { user });
@@ -60,7 +61,8 @@ export async function DELETE(_request: NextRequest, { params }: RouteParams) {
   try {
     const { id } = await params;
     const supabase = await createClient();
-    const { data: { user } } = await supabase.auth.getUser();
+    const { data: claimsData } = await supabase.auth.getClaims();
+    const user = claimsData?.claims?.sub ? { id: claimsData.claims.sub } : null;
     if (!user) return NextResponse.json({ error: 'Neautorizováno' }, { status: 401 });
 
     const profile = await getCurrentUserProfile(supabase, { user });

--- a/src/app/api/essays/[id]/comments/route.ts
+++ b/src/app/api/essays/[id]/comments/route.ts
@@ -13,7 +13,8 @@ export async function GET(_request: NextRequest, { params }: RouteContext) {
   try {
     const { id } = await params;
     const supabase = await createClient();
-    const { data: { user } } = await supabase.auth.getUser();
+    const { data: claimsData } = await supabase.auth.getClaims();
+    const user = claimsData?.claims?.sub ? { id: claimsData.claims.sub } : null;
     if (!user) return NextResponse.json({ error: 'Neautorizováno' }, { status: 401 });
 
     const comments = await getEssayComments(supabase, id);
@@ -28,7 +29,8 @@ export async function POST(request: NextRequest, { params }: RouteContext) {
   try {
     const { id } = await params;
     const supabase = await createClient();
-    const { data: { user } } = await supabase.auth.getUser();
+    const { data: claimsData } = await supabase.auth.getClaims();
+    const user = claimsData?.claims?.sub ? { id: claimsData.claims.sub } : null;
     if (!user) return NextResponse.json({ error: 'Neautorizováno' }, { status: 401 });
 
     const profile = await getCurrentUserProfile(supabase, { user });
@@ -117,7 +119,8 @@ export async function PATCH(request: NextRequest, { params }: RouteContext) {
     }
 
     const supabase = await createClient();
-    const { data: { user } } = await supabase.auth.getUser();
+    const { data: claimsData } = await supabase.auth.getClaims();
+    const user = claimsData?.claims?.sub ? { id: claimsData.claims.sub } : null;
     if (!user) return NextResponse.json({ error: 'Neautorizováno' }, { status: 401 });
     const profile = await getCurrentUserProfile(supabase, { user });
     if (!profile) return NextResponse.json({ error: 'Profil nenalezen' }, { status: 403 });
@@ -159,7 +162,8 @@ export async function DELETE(request: NextRequest, { params }: RouteContext) {
     }
 
     const supabase = await createClient();
-    const { data: { user } } = await supabase.auth.getUser();
+    const { data: claimsData } = await supabase.auth.getClaims();
+    const user = claimsData?.claims?.sub ? { id: claimsData.claims.sub } : null;
     if (!user) return NextResponse.json({ error: 'Neautorizováno' }, { status: 401 });
     const profile = await getCurrentUserProfile(supabase, { user });
     if (!profile) return NextResponse.json({ error: 'Profil nenalezen' }, { status: 403 });

--- a/src/app/api/essays/[id]/pin/route.ts
+++ b/src/app/api/essays/[id]/pin/route.ts
@@ -12,7 +12,8 @@ export async function POST(_request: NextRequest, { params }: RouteContext) {
   try {
     const { id } = await params;
     const supabase = await createClient();
-    const { data: { user } } = await supabase.auth.getUser();
+    const { data: claimsData } = await supabase.auth.getClaims();
+    const user = claimsData?.claims?.sub ? { id: claimsData.claims.sub } : null;
     if (!user) return NextResponse.json({ error: 'Neautorizováno' }, { status: 401 });
 
     const profile = await getCurrentUserProfile(supabase, { user });

--- a/src/app/api/essays/[id]/revisions/[revisionNo]/route.ts
+++ b/src/app/api/essays/[id]/revisions/[revisionNo]/route.ts
@@ -17,7 +17,8 @@ export async function GET(_request: NextRequest, { params }: RouteContext) {
     }
 
     const supabase = await createClient();
-    const { data: { user } } = await supabase.auth.getUser();
+    const { data: claimsData } = await supabase.auth.getClaims();
+    const user = claimsData?.claims?.sub ? { id: claimsData.claims.sub } : null;
     if (!user) return NextResponse.json({ error: 'Neautorizováno' }, { status: 401 });
 
     const profile = await getCurrentUserProfile(supabase, { user });

--- a/src/app/api/essays/[id]/revisions/route.ts
+++ b/src/app/api/essays/[id]/revisions/route.ts
@@ -13,7 +13,8 @@ export async function GET(_request: NextRequest, { params }: RouteContext) {
   try {
     const { id } = await params;
     const supabase = await createClient();
-    const { data: { user } } = await supabase.auth.getUser();
+    const { data: claimsData } = await supabase.auth.getClaims();
+    const user = claimsData?.claims?.sub ? { id: claimsData.claims.sub } : null;
     if (!user) return NextResponse.json({ error: 'Neautorizováno' }, { status: 401 });
 
     const profile = await getCurrentUserProfile(supabase, { user });

--- a/src/app/api/essays/[id]/route.ts
+++ b/src/app/api/essays/[id]/route.ts
@@ -19,7 +19,8 @@ export async function GET(_request: NextRequest, { params }: RouteContext) {
   try {
     const { id } = await params;
     const supabase = await createClient();
-    const { data: { user } } = await supabase.auth.getUser();
+    const { data: claimsData } = await supabase.auth.getClaims();
+    const user = claimsData?.claims?.sub ? { id: claimsData.claims.sub } : null;
     if (!user) return NextResponse.json({ error: 'Neautorizováno' }, { status: 401 });
 
     const essay = await getEssayById(supabase, id);
@@ -36,7 +37,8 @@ export async function PATCH(request: NextRequest, { params }: RouteContext) {
   try {
     const { id } = await params;
     const supabase = await createClient();
-    const { data: { user } } = await supabase.auth.getUser();
+    const { data: claimsData } = await supabase.auth.getClaims();
+    const user = claimsData?.claims?.sub ? { id: claimsData.claims.sub } : null;
     if (!user) return NextResponse.json({ error: 'Neautorizováno' }, { status: 401 });
 
     const profile = await getCurrentUserProfile(supabase, { user });
@@ -199,7 +201,8 @@ export async function DELETE(_request: NextRequest, { params }: RouteContext) {
   try {
     const { id } = await params;
     const supabase = await createClient();
-    const { data: { user } } = await supabase.auth.getUser();
+    const { data: claimsData } = await supabase.auth.getClaims();
+    const user = claimsData?.claims?.sub ? { id: claimsData.claims.sub } : null;
     if (!user) return NextResponse.json({ error: 'Neautorizováno' }, { status: 401 });
 
     const profile = await getCurrentUserProfile(supabase, { user });

--- a/src/app/api/essays/[id]/view/route.ts
+++ b/src/app/api/essays/[id]/view/route.ts
@@ -10,7 +10,8 @@ export async function POST(_request: NextRequest, { params }: RouteContext) {
   try {
     const { id } = await params;
     const supabase = await createClient();
-    const { data: { user } } = await supabase.auth.getUser();
+    const { data: claimsData } = await supabase.auth.getClaims();
+    const user = claimsData?.claims?.sub ? { id: claimsData.claims.sub } : null;
     if (!user) return NextResponse.json({ error: 'Neautorizováno' }, { status: 401 });
 
     await supabase.rpc('record_essay_view', { p_essay_id: id });

--- a/src/app/api/essays/[id]/vote/route.ts
+++ b/src/app/api/essays/[id]/vote/route.ts
@@ -12,7 +12,8 @@ export async function POST(request: NextRequest, { params }: RouteParams) {
   try {
     const { id } = await params;
     const supabase = await createClient();
-    const { data: { user } } = await supabase.auth.getUser();
+    const { data: claimsData } = await supabase.auth.getClaims();
+    const user = claimsData?.claims?.sub ? { id: claimsData.claims.sub } : null;
     if (!user) return NextResponse.json({ error: 'Neautorizováno' }, { status: 401 });
 
     const profile = await getCurrentUserProfile(supabase, { user });
@@ -57,7 +58,8 @@ export async function DELETE(_request: NextRequest, { params }: RouteParams) {
   try {
     const { id } = await params;
     const supabase = await createClient();
-    const { data: { user } } = await supabase.auth.getUser();
+    const { data: claimsData } = await supabase.auth.getClaims();
+    const user = claimsData?.claims?.sub ? { id: claimsData.claims.sub } : null;
     if (!user) return NextResponse.json({ error: 'Neautorizováno' }, { status: 401 });
 
     const profile = await getCurrentUserProfile(supabase, { user });

--- a/src/app/api/essays/coach-review/route.ts
+++ b/src/app/api/essays/coach-review/route.ts
@@ -14,9 +14,8 @@ import { serverLogger } from "@/lib/server-logger";
 export async function GET(request: NextRequest) {
   try {
     const supabase = await createClient();
-    const {
-      data: { user },
-    } = await supabase.auth.getUser();
+    const { data: claimsData } = await supabase.auth.getClaims();
+    const user = claimsData?.claims?.sub ? { id: claimsData.claims.sub } : null;
     if (!user) return NextResponse.json({ error: 'Neautorizováno' }, { status: 401 });
 
     const profile = await getCurrentUserProfile(supabase, { user });

--- a/src/app/api/essays/route.ts
+++ b/src/app/api/essays/route.ts
@@ -35,7 +35,8 @@ async function annotateWithVoted<T extends { id: string }>(
 export async function GET(request: NextRequest) {
   try {
     const supabase = await createClient();
-    const { data: { user } } = await supabase.auth.getUser();
+    const { data: claimsData } = await supabase.auth.getClaims();
+    const user = claimsData?.claims?.sub ? { id: claimsData.claims.sub } : null;
     if (!user) return NextResponse.json({ error: 'Neautorizováno' }, { status: 401 });
 
     const { searchParams } = new URL(request.url);
@@ -71,7 +72,8 @@ export async function GET(request: NextRequest) {
 export async function POST(request: NextRequest) {
   try {
     const supabase = await createClient();
-    const { data: { user } } = await supabase.auth.getUser();
+    const { data: claimsData } = await supabase.auth.getClaims();
+    const user = claimsData?.claims?.sub ? { id: claimsData.claims.sub } : null;
     if (!user) return NextResponse.json({ error: 'Neautorizováno' }, { status: 401 });
 
     const profile = await getCurrentUserProfile(supabase, { user });

--- a/src/app/api/essays/source-search/route.ts
+++ b/src/app/api/essays/source-search/route.ts
@@ -17,7 +17,8 @@ const RESULT_LIMIT = 10;
 export async function GET(request: NextRequest) {
   try {
     const supabase = await createClient();
-    const { data: { user } } = await supabase.auth.getUser();
+    const { data: claimsData } = await supabase.auth.getClaims();
+    const user = claimsData?.claims?.sub ? { id: claimsData.claims.sub } : null;
     if (!user) return NextResponse.json({ error: 'Neautorizováno' }, { status: 401 });
 
     const q = new URL(request.url).searchParams.get('q')?.trim() ?? '';

--- a/src/app/api/essays/upload-image/route.ts
+++ b/src/app/api/essays/upload-image/route.ts
@@ -24,7 +24,8 @@ const MAX_GIF_BYTES = 5 * 1024 * 1024;
 export async function POST(request: NextRequest) {
   try {
     const supabase = await createClient();
-    const { data: { user } } = await supabase.auth.getUser();
+    const { data: claimsData } = await supabase.auth.getClaims();
+    const user = claimsData?.claims?.sub ? { id: claimsData.claims.sub } : null;
     if (!user) return NextResponse.json({ error: 'Neautorizováno' }, { status: 401 });
 
     const profile = await getCurrentUserProfile(supabase, { user });

--- a/src/app/api/feedback/[id]/route.ts
+++ b/src/app/api/feedback/[id]/route.ts
@@ -14,7 +14,8 @@ export async function PATCH(request: NextRequest, { params }: RouteContext) {
   try {
     const { id } = await params;
     const supabase = await createClient();
-    const { data: { user } } = await supabase.auth.getUser();
+    const { data: claimsData } = await supabase.auth.getClaims();
+    const user = claimsData?.claims?.sub ? { id: claimsData.claims.sub } : null;
     if (!user) return NextResponse.json({ error: 'Neautorizováno' }, { status: 401 });
 
     const profile = await getCurrentUserProfile(supabase, { user });
@@ -55,7 +56,8 @@ export async function DELETE(_request: NextRequest, { params }: RouteContext) {
   try {
     const { id } = await params;
     const supabase = await createClient();
-    const { data: { user } } = await supabase.auth.getUser();
+    const { data: claimsData } = await supabase.auth.getClaims();
+    const user = claimsData?.claims?.sub ? { id: claimsData.claims.sub } : null;
     if (!user) return NextResponse.json({ error: 'Neautorizováno' }, { status: 401 });
 
     const profile = await getCurrentUserProfile(supabase, { user });

--- a/src/app/api/feedback/route.ts
+++ b/src/app/api/feedback/route.ts
@@ -10,7 +10,8 @@ const AUTHOR_SELECT = `*, author:profiles!author_profile_id(id, name, picture, r
 export async function POST(request: NextRequest) {
   try {
     const supabase = await createClient();
-    const { data: { user } } = await supabase.auth.getUser();
+    const { data: claimsData } = await supabase.auth.getClaims();
+    const user = claimsData?.claims?.sub ? { id: claimsData.claims.sub } : null;
     if (!user) return NextResponse.json({ error: 'Neautorizováno' }, { status: 401 });
 
     const profile = await getCurrentUserProfile(supabase, { user });

--- a/src/app/api/highlight-categories/[id]/route.ts
+++ b/src/app/api/highlight-categories/[id]/route.ts
@@ -11,7 +11,8 @@ interface RouteContext {
 
 async function requireCoach() {
   const supabase = await createClient();
-  const { data: { user } } = await supabase.auth.getUser();
+  const { data: claimsData } = await supabase.auth.getClaims();
+  const user = claimsData?.claims?.sub ? { id: claimsData.claims.sub } : null;
   if (!user) return { supabase, error: NextResponse.json({ error: 'Neautorizováno' }, { status: 401 }) };
 
   const profile = await getCurrentUserProfile(supabase, { user });

--- a/src/app/api/highlight-categories/route.ts
+++ b/src/app/api/highlight-categories/route.ts
@@ -8,7 +8,8 @@ import { serverLogger } from "@/lib/server-logger";
 
 async function requireCoach() {
   const supabase = await createClient();
-  const { data: { user } } = await supabase.auth.getUser();
+  const { data: claimsData } = await supabase.auth.getClaims();
+  const user = claimsData?.claims?.sub ? { id: claimsData.claims.sub } : null;
   if (!user) return { supabase, error: NextResponse.json({ error: 'Neautorizováno' }, { status: 401 }) };
 
   const profile = await getCurrentUserProfile(supabase, { user });
@@ -22,7 +23,8 @@ async function requireCoach() {
 export async function GET(_request: NextRequest) {
   try {
     const supabase = await createClient();
-    const { data: { user } } = await supabase.auth.getUser();
+    const { data: claimsData } = await supabase.auth.getClaims();
+    const user = claimsData?.claims?.sub ? { id: claimsData.claims.sub } : null;
     if (!user) return NextResponse.json({ error: 'Neautorizováno' }, { status: 401 });
 
     const categories = await getHighlightCategories(supabase);

--- a/src/app/api/houston-calling/generate/route.ts
+++ b/src/app/api/houston-calling/generate/route.ts
@@ -92,7 +92,8 @@ async function resolveActorProfileId(
   supabase: Awaited<ReturnType<typeof createClient>>,
   adminClient: SupabaseClient<Database>
 ): Promise<string | null> {
-  const { data: { user } } = await supabase.auth.getUser();
+  const { data: claimsData } = await supabase.auth.getClaims();
+  const user = claimsData?.claims?.sub ? { id: claimsData.claims.sub } : null;
   if (user) {
     const profile = await getCurrentUserProfile(supabase, { user });
     if (profile?.id) return profile.id;
@@ -132,7 +133,8 @@ export async function POST(request: NextRequest) {
     } else {
       // If called by user, just verify they are authenticated
       // HC generation is a system task that benefits everyone
-      const { data: { user } } = await supabase.auth.getUser();
+      const { data: claimsData } = await supabase.auth.getClaims();
+      const user = claimsData?.claims?.sub ? { id: claimsData.claims.sub } : null;
       if (!user) {
         return NextResponse.json({ error: "Neautorizováno" }, { status: 401 });
       }

--- a/src/app/api/library/books/[bookId]/borrow/route.ts
+++ b/src/app/api/library/books/[bookId]/borrow/route.ts
@@ -19,7 +19,8 @@ export async function POST(request: NextRequest, { params }: RouteContext) {
   try {
     const { bookId } = await params;
     const supabase = await createClient();
-    const { data: { user } } = await supabase.auth.getUser();
+    const { data: claimsData } = await supabase.auth.getClaims();
+    const user = claimsData?.claims?.sub ? { id: claimsData.claims.sub } : null;
     if (!user) return NextResponse.json({ error: 'Neautorizováno' }, { status: 401 });
 
     const profile = await getCurrentUserProfile(supabase, { user });

--- a/src/app/api/library/books/[bookId]/return/route.ts
+++ b/src/app/api/library/books/[bookId]/return/route.ts
@@ -13,7 +13,8 @@ export async function POST(_request: NextRequest, { params }: RouteContext) {
   try {
     const { bookId } = await params;
     const supabase = await createClient();
-    const { data: { user } } = await supabase.auth.getUser();
+    const { data: claimsData } = await supabase.auth.getClaims();
+    const user = claimsData?.claims?.sub ? { id: claimsData.claims.sub } : null;
     if (!user) return NextResponse.json({ error: 'Neautorizováno' }, { status: 401 });
 
     const profile = await getCurrentUserProfile(supabase, { user });

--- a/src/app/api/library/books/[bookId]/route.ts
+++ b/src/app/api/library/books/[bookId]/route.ts
@@ -12,7 +12,8 @@ export async function GET(_request: NextRequest, { params }: RouteContext) {
   try {
     const { bookId } = await params;
     const supabase = await createClient();
-    const { data: { user } } = await supabase.auth.getUser();
+    const { data: claimsData } = await supabase.auth.getClaims();
+    const user = claimsData?.claims?.sub ? { id: claimsData.claims.sub } : null;
     if (!user) return NextResponse.json({ error: 'Neautorizováno' }, { status: 401 });
 
     const info = await getBookLibraryInfo(supabase, bookId);

--- a/src/app/api/library/books/route.ts
+++ b/src/app/api/library/books/route.ts
@@ -9,7 +9,8 @@ import { serverLogger } from "@/lib/server-logger";
 export async function GET(request: NextRequest) {
   try {
     const supabase = await createClient();
-    const { data: { user } } = await supabase.auth.getUser();
+    const { data: claimsData } = await supabase.auth.getClaims();
+    const user = claimsData?.claims?.sub ? { id: claimsData.claims.sub } : null;
     if (!user) return NextResponse.json({ error: 'Neautorizováno' }, { status: 401 });
 
     const { searchParams } = new URL(request.url);
@@ -48,7 +49,8 @@ export async function GET(request: NextRequest) {
 export async function POST(request: NextRequest) {
   try {
     const supabase = await createClient();
-    const { data: { user } } = await supabase.auth.getUser();
+    const { data: claimsData } = await supabase.auth.getClaims();
+    const user = claimsData?.claims?.sub ? { id: claimsData.claims.sub } : null;
     if (!user) return NextResponse.json({ error: 'Neautorizováno' }, { status: 401 });
 
     const profile = await getCurrentUserProfile(supabase, { user });

--- a/src/app/api/library/catalog-search/route.ts
+++ b/src/app/api/library/catalog-search/route.ts
@@ -11,7 +11,8 @@ const CATALOG_COLUMNS = 'id, title_cs, title_en, author, isbn_13, google_books_c
 export async function GET(request: NextRequest) {
   try {
     const supabase = await createClient();
-    const { data: { user } } = await supabase.auth.getUser();
+    const { data: claimsData } = await supabase.auth.getClaims();
+    const user = claimsData?.claims?.sub ? { id: claimsData.claims.sub } : null;
     if (!user) return NextResponse.json({ error: 'Neautorizováno' }, { status: 401 });
 
     const profile = await getCurrentUserProfile(supabase, { user });

--- a/src/app/api/library/labels/[labelCode]/route.ts
+++ b/src/app/api/library/labels/[labelCode]/route.ts
@@ -19,7 +19,8 @@ interface BookSummary {
 
 async function getAuthorizedContext() {
   const supabase = await createClient();
-  const { data: { user } } = await supabase.auth.getUser();
+  const { data: claimsData } = await supabase.auth.getClaims();
+  const user = claimsData?.claims?.sub ? { id: claimsData.claims.sub } : null;
   if (!user) return { error: NextResponse.json({ error: 'Neautorizováno' }, { status: 401 }) };
 
   const profile = await getCurrentUserProfile(supabase, { user });

--- a/src/app/api/library/loans/my/route.ts
+++ b/src/app/api/library/loans/my/route.ts
@@ -8,7 +8,8 @@ import { serverLogger } from "@/lib/server-logger";
 export async function GET(_request: NextRequest) {
   try {
     const supabase = await createClient();
-    const { data: { user } } = await supabase.auth.getUser();
+    const { data: claimsData } = await supabase.auth.getClaims();
+    const user = claimsData?.claims?.sub ? { id: claimsData.claims.sub } : null;
     if (!user) return NextResponse.json({ error: 'Neautorizováno' }, { status: 401 });
 
     const profile = await getCurrentUserProfile(supabase, { user });

--- a/src/app/api/personality-tests/[id]/open/route.ts
+++ b/src/app/api/personality-tests/[id]/open/route.ts
@@ -8,7 +8,8 @@ export async function GET(request: NextRequest, { params }: { params: Promise<{ 
   try {
     const { id } = await params;
     const supabase = await createClient();
-    const { data: { user } } = await supabase.auth.getUser();
+    const { data: claimsData } = await supabase.auth.getClaims();
+    const user = claimsData?.claims?.sub ? { id: claimsData.claims.sub } : null;
 
     if (!user) {
       return NextResponse.json({ error: "Neautorizováno" }, { status: 401 });

--- a/src/app/api/personality-tests/[id]/route.ts
+++ b/src/app/api/personality-tests/[id]/route.ts
@@ -22,7 +22,8 @@ export async function PATCH(request: NextRequest, { params }: { params: Promise<
   try {
     const { id } = await params;
     const supabase = await createClient();
-    const { data: { user } } = await supabase.auth.getUser();
+    const { data: claimsData } = await supabase.auth.getClaims();
+    const user = claimsData?.claims?.sub ? { id: claimsData.claims.sub } : null;
 
     if (!user) {
       return NextResponse.json({ error: "Neautorizováno" }, { status: 401 });
@@ -112,7 +113,8 @@ export async function DELETE(request: NextRequest, { params }: { params: Promise
   try {
     const { id } = await params;
     const supabase = await createClient();
-    const { data: { user } } = await supabase.auth.getUser();
+    const { data: claimsData } = await supabase.auth.getClaims();
+    const user = claimsData?.claims?.sub ? { id: claimsData.claims.sub } : null;
 
     if (!user) {
       return NextResponse.json({ error: "Neautorizováno" }, { status: 401 });

--- a/src/app/api/personality-tests/route.ts
+++ b/src/app/api/personality-tests/route.ts
@@ -21,7 +21,8 @@ const DATE_RE = /^\d{4}-\d{2}-\d{2}$/;
 export async function POST(request: NextRequest) {
   try {
     const supabase = await createClient();
-    const { data: { user } } = await supabase.auth.getUser();
+    const { data: claimsData } = await supabase.auth.getClaims();
+    const user = claimsData?.claims?.sub ? { id: claimsData.claims.sub } : null;
 
     if (!user) {
       return NextResponse.json({ error: "Neautorizováno" }, { status: 401 });

--- a/src/app/api/portfolio/data/route.ts
+++ b/src/app/api/portfolio/data/route.ts
@@ -40,7 +40,8 @@ function firstEmbed<T>(embed: T | T[] | null | undefined): T | null {
 
 export async function GET() {
   const supabase = await createClient();
-  const { data: { user } } = await supabase.auth.getUser();
+  const { data: claimsData } = await supabase.auth.getClaims();
+  const user = claimsData?.claims?.sub ? { id: claimsData.claims.sub } : null;
   if (!user) return NextResponse.json({ error: 'Neautorizováno' }, { status: 401 });
 
   const profile = await getCurrentUserProfile(supabase, { user });

--- a/src/app/api/portfolio/generate/route.ts
+++ b/src/app/api/portfolio/generate/route.ts
@@ -24,7 +24,8 @@ function firstEmbed<T>(embed: T | T[] | null | undefined): T | null {
 
 export async function POST(request: NextRequest) {
   const supabase = await createClient();
-  const { data: { user } } = await supabase.auth.getUser();
+  const { data: claimsData } = await supabase.auth.getClaims();
+  const user = claimsData?.claims?.sub ? { id: claimsData.claims.sub } : null;
   if (!user) return NextResponse.json({ error: 'Neautorizováno' }, { status: 401 });
 
   const profile = await getCurrentUserProfile(supabase, { user });

--- a/src/app/api/profile/beta-access/route.ts
+++ b/src/app/api/profile/beta-access/route.ts
@@ -6,7 +6,8 @@ import { serverLogger } from "@/lib/server-logger";
 export async function PATCH(request: NextRequest) {
   try {
     const supabase = await createClient()
-    const { data: { user } } = await supabase.auth.getUser()
+    const { data: claimsData } = await supabase.auth.getClaims()
+    const user = claimsData?.claims?.sub ? { id: claimsData.claims.sub } : null
 
     if (!user) {
       return NextResponse.json({ error: "Neautorizováno" }, { status: 401 })

--- a/src/app/api/profile/notification-preferences/route.ts
+++ b/src/app/api/profile/notification-preferences/route.ts
@@ -10,7 +10,8 @@ type ToggleKey = (typeof TOGGLE_KEYS)[number]
 export async function PATCH(request: NextRequest) {
   try {
     const supabase = await createClient()
-    const { data: { user } } = await supabase.auth.getUser()
+    const { data: claimsData } = await supabase.auth.getClaims()
+    const user = claimsData?.claims?.sub ? { id: claimsData.claims.sub } : null
     if (!user) return NextResponse.json({ error: "Neautorizováno" }, { status: 401 })
 
     const profile = await getCurrentUserProfile(supabase, { user })

--- a/src/app/api/recurring-schedules/[id]/route.ts
+++ b/src/app/api/recurring-schedules/[id]/route.ts
@@ -96,7 +96,8 @@ export async function PATCH(request: NextRequest, { params }: RouteParams) {
   try {
     const { id } = await params;
     const supabase = await createClient();
-    const { data: { user } } = await supabase.auth.getUser();
+    const { data: claimsData } = await supabase.auth.getClaims();
+    const user = claimsData?.claims?.sub ? { id: claimsData.claims.sub } : null;
 
     if (!user) {
       return NextResponse.json({ error: "Neautorizováno" }, { status: 401 });
@@ -237,7 +238,8 @@ export async function DELETE(request: NextRequest, { params }: RouteParams) {
   try {
     const { id } = await params;
     const supabase = await createClient();
-    const { data: { user } } = await supabase.auth.getUser();
+    const { data: claimsData } = await supabase.auth.getClaims();
+    const user = claimsData?.claims?.sub ? { id: claimsData.claims.sub } : null;
 
     if (!user) {
       return NextResponse.json({ error: "Neautorizováno" }, { status: 401 });

--- a/src/app/api/recurring-schedules/route.ts
+++ b/src/app/api/recurring-schedules/route.ts
@@ -26,7 +26,8 @@ interface CreateScheduleInput {
 export async function POST(request: NextRequest) {
   try {
     const supabase = await createClient();
-    const { data: { user } } = await supabase.auth.getUser();
+    const { data: claimsData } = await supabase.auth.getClaims();
+    const user = claimsData?.claims?.sub ? { id: claimsData.claims.sub } : null;
 
     if (!user) {
       return NextResponse.json({ error: "Neautorizováno" }, { status: 401 });
@@ -219,7 +220,8 @@ const TRAINING_FALLBACK_NAME = "Tým";
 export async function GET(_request: NextRequest) {
   try {
     const supabase = await createClient();
-    const { data: { user } } = await supabase.auth.getUser();
+    const { data: claimsData } = await supabase.auth.getClaims();
+    const user = claimsData?.claims?.sub ? { id: claimsData.claims.sub } : null;
 
     if (!user) {
       return NextResponse.json({ error: "Neautorizováno" }, { status: 401 });

--- a/src/app/api/reservations/[id]/route.ts
+++ b/src/app/api/reservations/[id]/route.ts
@@ -34,7 +34,8 @@ export async function GET(request: NextRequest, { params }: RouteParams) {
   try {
     const { id } = await params;
     const supabase = await createClient();
-    const { data: { user } } = await supabase.auth.getUser();
+    const { data: claimsData } = await supabase.auth.getClaims();
+    const user = claimsData?.claims?.sub ? { id: claimsData.claims.sub } : null;
 
     if (!user) {
       return NextResponse.json({ error: "Neautorizováno" }, { status: 401 });
@@ -76,7 +77,8 @@ export async function PATCH(request: NextRequest, { params }: RouteParams) {
   try {
     const { id } = await params;
     const supabase = await createClient();
-    const { data: { user } } = await supabase.auth.getUser();
+    const { data: claimsData } = await supabase.auth.getClaims();
+    const user = claimsData?.claims?.sub ? { id: claimsData.claims.sub } : null;
 
     if (!user) {
       return NextResponse.json({ error: "Neautorizováno" }, { status: 401 });
@@ -306,7 +308,8 @@ export async function DELETE(request: NextRequest, { params }: RouteParams) {
   try {
     const { id } = await params;
     const supabase = await createClient();
-    const { data: { user } } = await supabase.auth.getUser();
+    const { data: claimsData } = await supabase.auth.getClaims();
+    const user = claimsData?.claims?.sub ? { id: claimsData.claims.sub } : null;
 
     if (!user) {
       return NextResponse.json({ error: "Neautorizováno" }, { status: 401 });

--- a/src/app/api/reservations/availability/route.ts
+++ b/src/app/api/reservations/availability/route.ts
@@ -15,7 +15,8 @@ import { serverLogger } from "@/lib/server-logger";
 export async function GET(request: NextRequest) {
   try {
     const supabase = await createClient();
-    const { data: { user } } = await supabase.auth.getUser();
+    const { data: claimsData } = await supabase.auth.getClaims();
+    const user = claimsData?.claims?.sub ? { id: claimsData.claims.sub } : null;
 
     if (!user) {
       return NextResponse.json({ error: "Neautorizováno" }, { status: 401 });

--- a/src/app/api/reservations/route.ts
+++ b/src/app/api/reservations/route.ts
@@ -30,7 +30,8 @@ function getPragueHourAndMinute(date: Date): { hour: number; minute: number } {
 export async function GET(request: NextRequest) {
   try {
     const supabase = await createClient();
-    const { data: { user } } = await supabase.auth.getUser();
+    const { data: claimsData } = await supabase.auth.getClaims();
+    const user = claimsData?.claims?.sub ? { id: claimsData.claims.sub } : null;
 
     if (!user) {
       return NextResponse.json({ error: "Neautorizováno" }, { status: 401 });
@@ -96,7 +97,8 @@ export async function GET(request: NextRequest) {
 export async function POST(request: NextRequest) {
   try {
     const supabase = await createClient();
-    const { data: { user } } = await supabase.auth.getUser();
+    const { data: claimsData } = await supabase.auth.getClaims();
+    const user = claimsData?.claims?.sub ? { id: claimsData.claims.sub } : null;
 
     if (!user) {
       return NextResponse.json({ error: "Neautorizováno" }, { status: 401 });

--- a/src/app/api/rooms/[code]/quick-status/route.ts
+++ b/src/app/api/rooms/[code]/quick-status/route.ts
@@ -41,7 +41,8 @@ export async function GET(request: NextRequest, { params }: RouteParams) {
     const supabase = await createClient();
 
     // Check authentication
-    const { data: { user } } = await supabase.auth.getUser();
+    const { data: claimsData } = await supabase.auth.getClaims();
+    const user = claimsData?.claims?.sub ? { id: claimsData.claims.sub } : null;
     if (!user) {
       return NextResponse.json({ error: "Neautorizováno" }, { status: 401 });
     }

--- a/src/app/api/schedule-breaks/[id]/route.ts
+++ b/src/app/api/schedule-breaks/[id]/route.ts
@@ -15,7 +15,8 @@ export async function DELETE(request: NextRequest, { params }: RouteParams) {
   try {
     const { id } = await params;
     const supabase = await createClient();
-    const { data: { user } } = await supabase.auth.getUser();
+    const { data: claimsData } = await supabase.auth.getClaims();
+    const user = claimsData?.claims?.sub ? { id: claimsData.claims.sub } : null;
 
     if (!user) {
       return NextResponse.json({ error: "Neautorizováno" }, { status: 401 });

--- a/src/app/api/schedule-breaks/active/route.ts
+++ b/src/app/api/schedule-breaks/active/route.ts
@@ -13,7 +13,8 @@ import { serverLogger } from "@/lib/server-logger";
 export async function GET(request: NextRequest) {
   try {
     const supabase = await createClient();
-    const { data: { user } } = await supabase.auth.getUser();
+    const { data: claimsData } = await supabase.auth.getClaims();
+    const user = claimsData?.claims?.sub ? { id: claimsData.claims.sub } : null;
 
     if (!user) {
       return NextResponse.json({ error: "Neautorizováno" }, { status: 401 });

--- a/src/app/api/schedule-breaks/route.ts
+++ b/src/app/api/schedule-breaks/route.ts
@@ -18,7 +18,8 @@ interface CreateBreakInput {
 export async function POST(request: NextRequest) {
   try {
     const supabase = await createClient();
-    const { data: { user } } = await supabase.auth.getUser();
+    const { data: claimsData } = await supabase.auth.getClaims();
+    const user = claimsData?.claims?.sub ? { id: claimsData.claims.sub } : null;
 
     if (!user) {
       return NextResponse.json({ error: "Neautorizováno" }, { status: 401 });
@@ -121,7 +122,8 @@ export async function POST(request: NextRequest) {
 export async function GET(_request: NextRequest) {
   try {
     const supabase = await createClient();
-    const { data: { user } } = await supabase.auth.getUser();
+    const { data: claimsData } = await supabase.auth.getClaims();
+    const user = claimsData?.claims?.sub ? { id: claimsData.claims.sub } : null;
 
     if (!user) {
       return NextResponse.json({ error: "Neautorizováno" }, { status: 401 });

--- a/src/app/api/scrollky/route.ts
+++ b/src/app/api/scrollky/route.ts
@@ -9,7 +9,8 @@ import { serverLogger } from "@/lib/server-logger";
 export async function GET(request: NextRequest) {
   try {
     const supabase = await createClient();
-    const { data: { user } } = await supabase.auth.getUser();
+    const { data: claimsData } = await supabase.auth.getClaims();
+    const user = claimsData?.claims?.sub ? { id: claimsData.claims.sub } : null;
     if (!user) {
       return NextResponse.json({ error: 'Neautorizováno' }, { status: 401 });
     }

--- a/src/app/api/storage/confirm-upload/route.ts
+++ b/src/app/api/storage/confirm-upload/route.ts
@@ -22,7 +22,8 @@ interface ConfirmUploadRequest {
 export async function POST(request: NextRequest) {
   try {
     const supabase = await createClient();
-    const { data: { user } } = await supabase.auth.getUser();
+    const { data: claimsData } = await supabase.auth.getClaims();
+    const user = claimsData?.claims?.sub ? { id: claimsData.claims.sub } : null;
 
     if (!user) {
       return NextResponse.json({ error: "Neautorizováno" }, { status: 401 });

--- a/src/app/api/storage/delete/route.ts
+++ b/src/app/api/storage/delete/route.ts
@@ -20,7 +20,8 @@ interface DeleteRequest {
 export async function DELETE(request: NextRequest) {
   try {
     const supabase = await createClient();
-    const { data: { user } } = await supabase.auth.getUser();
+    const { data: claimsData } = await supabase.auth.getClaims();
+    const user = claimsData?.claims?.sub ? { id: claimsData.claims.sub } : null;
 
     if (!user) {
       return NextResponse.json({ error: "Neautorizováno" }, { status: 401 });

--- a/src/app/api/storage/presign-upload/route.ts
+++ b/src/app/api/storage/presign-upload/route.ts
@@ -29,9 +29,8 @@ interface PresignUploadRequest {
 export async function POST(request: NextRequest) {
   try {
     const supabase = await createClient();
-    const {
-      data: { user },
-    } = await supabase.auth.getUser();
+    const { data: claimsData } = await supabase.auth.getClaims();
+    const user = claimsData?.claims?.sub ? { id: claimsData.claims.sub } : null;
 
     if (!user) {
       return NextResponse.json({ error: "Neautorizováno" }, { status: 401 });

--- a/src/app/api/team-documents/[id]/route.ts
+++ b/src/app/api/team-documents/[id]/route.ts
@@ -14,7 +14,8 @@ export async function PATCH(request: NextRequest, { params }: RouteContext) {
   try {
     const { id } = await params
     const supabase = await createClient()
-    const { data: { user } } = await supabase.auth.getUser()
+    const { data: claimsData } = await supabase.auth.getClaims()
+    const user = claimsData?.claims?.sub ? { id: claimsData.claims.sub } : null
     if (!user) return NextResponse.json({ error: "Neautorizováno" }, { status: 401 })
 
     const profile = await getCurrentUserProfile(supabase, { user })
@@ -72,7 +73,8 @@ export async function DELETE(_request: NextRequest, { params }: RouteContext) {
   try {
     const { id } = await params
     const supabase = await createClient()
-    const { data: { user } } = await supabase.auth.getUser()
+    const { data: claimsData } = await supabase.auth.getClaims()
+    const user = claimsData?.claims?.sub ? { id: claimsData.claims.sub } : null
     if (!user) return NextResponse.json({ error: "Neautorizováno" }, { status: 401 })
 
     const profile = await getCurrentUserProfile(supabase, { user })

--- a/src/app/api/team-documents/[id]/versions/route.ts
+++ b/src/app/api/team-documents/[id]/versions/route.ts
@@ -16,7 +16,8 @@ export async function POST(request: NextRequest, { params }: RouteContext) {
   try {
     const { id } = await params
     const supabase = await createClient()
-    const { data: { user } } = await supabase.auth.getUser()
+    const { data: claimsData } = await supabase.auth.getClaims()
+    const user = claimsData?.claims?.sub ? { id: claimsData.claims.sub } : null
     if (!user) return NextResponse.json({ error: "Neautorizováno" }, { status: 401 })
 
     const profile = await getCurrentUserProfile(supabase, { user })

--- a/src/app/api/team-documents/route.ts
+++ b/src/app/api/team-documents/route.ts
@@ -9,7 +9,8 @@ import { serverLogger } from "@/lib/server-logger";
 export async function POST(request: NextRequest) {
   try {
     const supabase = await createClient()
-    const { data: { user } } = await supabase.auth.getUser()
+    const { data: claimsData } = await supabase.auth.getClaims()
+    const user = claimsData?.claims?.sub ? { id: claimsData.claims.sub } : null
     if (!user) return NextResponse.json({ error: "Neautorizováno" }, { status: 401 })
 
     const profile = await getCurrentUserProfile(supabase, { user })

--- a/src/app/api/team-documents/versions/[versionId]/open/route.ts
+++ b/src/app/api/team-documents/versions/[versionId]/open/route.ts
@@ -12,7 +12,8 @@ export async function GET(_request: NextRequest, { params }: RouteContext) {
   try {
     const { versionId } = await params
     const supabase = await createClient()
-    const { data: { user } } = await supabase.auth.getUser()
+    const { data: claimsData } = await supabase.auth.getClaims()
+    const user = claimsData?.claims?.sub ? { id: claimsData.claims.sub } : null
     if (!user) return NextResponse.json({ error: "Neautorizováno" }, { status: 401 })
 
     const { data, error } = await supabase

--- a/src/app/api/tymovy-denik/activities/_shared.ts
+++ b/src/app/api/tymovy-denik/activities/_shared.ts
@@ -79,9 +79,8 @@ interface ParsedTeamActivityRequest {
 
 export async function requireTeamActivityApiContext(): Promise<TeamActivityApiContext | ApiFailure> {
   const supabase = await createClient()
-  const {
-    data: { user },
-  } = await supabase.auth.getUser()
+  const { data: claimsData } = await supabase.auth.getClaims();
+  const user = claimsData?.claims?.sub ? { id: claimsData.claims.sub } : null;
 
   if (!user) {
     return { response: NextResponse.json({ error: "Neautorizováno" }, { status: 401 }) }

--- a/src/app/r/[code]/route.ts
+++ b/src/app/r/[code]/route.ts
@@ -16,7 +16,8 @@ export async function GET(request: NextRequest, { params }: RouteParams) {
   const supabase = await createClient();
 
   // Check if user is logged in
-  const { data: { user } } = await supabase.auth.getUser();
+  const { data: claimsData } = await supabase.auth.getClaims();
+  const user = claimsData?.claims?.sub ? { id: claimsData.claims.sub } : null;
 
   if (user) {
     // Logged in -> redirect to quick status page

--- a/src/components/customer-meetings/customer-meeting-form.test.tsx
+++ b/src/components/customer-meetings/customer-meeting-form.test.tsx
@@ -10,7 +10,10 @@ const update = vi.fn()
 
 vi.mock("@/lib/supabase/client", () => ({
   createClient: () => ({
-    auth: { getUser: async () => ({ data: { user: { id: "u1" } } }) },
+    auth: {
+      getUser: async () => ({ data: { user: { id: "u1" } } }),
+      getClaims: async () => ({ data: { claims: { sub: "u1" } } }),
+    },
     from: () => ({
       insert: (...args: unknown[]) => {
         insert(...args)

--- a/src/components/customer-meetings/customer-meeting-form.tsx
+++ b/src/components/customer-meetings/customer-meeting-form.tsx
@@ -46,7 +46,8 @@ export function CustomerMeetingForm({ profileId, initial, onSuccess, onCancel }:
     setLoading(true)
     try {
       const supabase = createClient()
-      const { data: { user } } = await supabase.auth.getUser()
+      const { data: claimsData } = await supabase.auth.getClaims()
+      const user = claimsData?.claims?.sub ? { id: claimsData.claims.sub } : null
       if (!user) { throw new Error("Nepřihlášen") }
 
       const isEdit = !!initial?.id

--- a/src/components/individual-coaching-sessions/individual-coaching-session-form.test.tsx
+++ b/src/components/individual-coaching-sessions/individual-coaching-session-form.test.tsx
@@ -10,7 +10,10 @@ const update = vi.fn()
 
 vi.mock("@/lib/supabase/client", () => ({
   createClient: () => ({
-    auth: { getUser: async () => ({ data: { user: { id: "u1" } } }) },
+    auth: {
+      getUser: async () => ({ data: { user: { id: "u1" } } }),
+      getClaims: async () => ({ data: { claims: { sub: "u1" } } }),
+    },
     from: () => ({
       insert: (...args: unknown[]) => {
         insert(...args)

--- a/src/components/individual-coaching-sessions/individual-coaching-session-form.tsx
+++ b/src/components/individual-coaching-sessions/individual-coaching-session-form.tsx
@@ -58,7 +58,8 @@ export function IndividualCoachingSessionForm({ profileId, coachProfiles, initia
     setLoading(true)
     try {
       const supabase = createClient()
-      const { data: { user } } = await supabase.auth.getUser()
+      const { data: claimsData } = await supabase.auth.getClaims()
+      const user = claimsData?.claims?.sub ? { id: claimsData.claims.sub } : null
       if (!user) { throw new Error("Nepřihlášen") }
 
       const isEdit = !!initial?.id

--- a/src/lib/hooks/use-email-verification-realtime.ts
+++ b/src/lib/hooks/use-email-verification-realtime.ts
@@ -37,10 +37,8 @@ export function useEmailVerificationRealtime() {
     const setupRealtimeSubscription = async () => {
       try {
         // Get current user to determine channel name
-        const {
-          data: { user },
-          error: userError,
-        } = await supabase.auth.getUser();
+        const { data: claimsData, error: userError } = await supabase.auth.getClaims();
+        const user = claimsData?.claims?.sub ? { id: claimsData.claims.sub } : null;
 
         if (userError || !user) {
           // User not authenticated, skip subscription

--- a/src/lib/hooks/use-profile-link-realtime.ts
+++ b/src/lib/hooks/use-profile-link-realtime.ts
@@ -37,10 +37,8 @@ export function useProfileLinkRealtime() {
     const setupRealtimeSubscription = async () => {
       try {
         // Get current user to determine channel name
-        const {
-          data: { user },
-          error: userError,
-        } = await supabase.auth.getUser();
+        const { data: claimsData, error: userError } = await supabase.auth.getClaims();
+        const user = claimsData?.claims?.sub ? { id: claimsData.claims.sub } : null;
 
         if (userError || !user) {
           // User not authenticated, skip subscription

--- a/tests/unit/team-activity-api-context.test.ts
+++ b/tests/unit/team-activity-api-context.test.ts
@@ -3,7 +3,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest"
 const mocks = vi.hoisted(() => ({
   createClient: vi.fn(),
   getCurrentUserProfile: vi.fn(),
-  getUser: vi.fn(),
+  getClaims: vi.fn(),
 }))
 
 vi.mock("@/lib/supabase/server", () => ({ createClient: mocks.createClient }))
@@ -17,7 +17,7 @@ import {
 } from "@/app/api/tymovy-denik/activities/_shared"
 
 const USER = { id: "user-1" }
-const CLIENT = { auth: { getUser: mocks.getUser } }
+const CLIENT = { auth: { getClaims: mocks.getClaims } }
 
 beforeEach(() => {
   vi.clearAllMocks()
@@ -26,7 +26,7 @@ beforeEach(() => {
 
 describe("requireTeamActivityApiContext", () => {
   it("rejects requests without an authenticated user", async () => {
-    mocks.getUser.mockResolvedValue({ data: { user: null } })
+    mocks.getClaims.mockResolvedValue({ data: { claims: null } })
 
     const result = await requireTeamActivityApiContext()
 
@@ -36,7 +36,7 @@ describe("requireTeamActivityApiContext", () => {
   })
 
   it("rejects profiles without both beta access and a team", async () => {
-    mocks.getUser.mockResolvedValue({ data: { user: USER } })
+    mocks.getClaims.mockResolvedValue({ data: { claims: { sub: "user-1" } } })
     mocks.getCurrentUserProfile.mockResolvedValue({
       id: "profile-1",
       team_id: "team-1",
@@ -50,7 +50,7 @@ describe("requireTeamActivityApiContext", () => {
   })
 
   it("derives team and actor identity from the authenticated profile", async () => {
-    mocks.getUser.mockResolvedValue({ data: { user: USER } })
+    mocks.getClaims.mockResolvedValue({ data: { claims: { sub: "user-1" } } })
     mocks.getCurrentUserProfile.mockResolvedValue({
       id: "profile-1",
       team_id: "team-1",


### PR DESCRIPTION
Replace network auth.getUser() with local JWT getClaims() in 101 pages, API routes, hooks and client forms that only need user id. Keeps getUser() in auth-critical flows (proxy login loop, hasEmailIdentity, onboarding, verify-email-form, login page).

Saves ~1 Auth API RTT per request.