### PR TITLE
docs(pages): serve docs from custom domain docs.tiimi.cz

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -47,6 +47,7 @@ jobs:
       - name: Build documentation
         env:
           GITHUB_PAGES: 'true'
+          VITEPRESS_BASE: '/'
         run: pnpm docs:build
 
       - name: Upload artifact

--- a/docs/public/CNAME
+++ b/docs/public/CNAME
@@ -1,0 +1,1 @@
+docs.tiimi.cz


### PR DESCRIPTION
Custom domain for GitHub Pages docs.

- Add docs/public/CNAME with docs.tiimi.cz (copied to dist root on build)
- Set VITEPRESS_BASE='/' in deploy-docs.yml (custom domains serve from /, not /Tappka/)

Verified: pnpm docs:build passes with root base, CNAME present in dist.

After merge:
1. Add DNS CNAME docs -> spirit-of-tap.github.io in tiimi.cz zone
2. Settings -> Pages -> Custom domain: docs.tiimi.cz, Enforce HTTPS